### PR TITLE
close shepherd in a few jsps

### DIFF
--- a/src/main/webapp/individualGallery.jsp
+++ b/src/main/webapp/individualGallery.jsp
@@ -302,4 +302,5 @@ if (!Util.collectionIsEmptyOrNull(indiv.getEncounters())) for (Encounter enc : i
 
 <%
 myShepherd.rollbackDBTransaction();
+myShepherd.closeDBTransaction();
 %>

--- a/src/main/webapp/queue.jsp
+++ b/src/main/webapp/queue.jsp
@@ -240,7 +240,7 @@ System.out.println("WARNING: queue.generateData() has no matchMap(" + ekey + ")"
             } else {
                 all[36] = "???";
             }
-            
+
             rows.add(all);
         }
     }
@@ -262,6 +262,7 @@ User user = AccessControl.getUser(request, myShepherd);
 if (user == null) {
     myShepherd.rollbackDBTransaction();
     response.sendRedirect("login.jsp");
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -283,6 +284,7 @@ if (!"admin".equals(maxRole)) {
     System.out.println("INFO: queue.jsp non-admin, so bailing cuz second trial has ended");
     session.invalidate();
     response.sendRedirect("secondTrialEnd.jsp");
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -291,6 +293,7 @@ if (maxRole == null) {
     //response.sendError(401, "access denied - no valid role");
     myShepherd.rollbackDBTransaction();
     response.sendRedirect("register.jsp");
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -298,6 +301,7 @@ if (maxRole.equals("cat_walk_volunteer")) {
     System.out.println("queue.jsp: sending " + user + " to appUser.jsp");
     myShepherd.rollbackDBTransaction();
     response.sendRedirect("appUser.jsp");
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -323,6 +327,7 @@ if (isAdmin && (request.getParameter("MatchPhoto") != null)) {
     }
 
     myShepherd.rollbackDBTransaction();
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -404,6 +409,7 @@ if (!forceList && (encs.size() > 0)) {
     String redir = "encounters/encounterDecide.jsp?id=" + foundId;
     myShepherd.rollbackDBTransaction();
     response.sendRedirect(redir);
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -691,4 +697,5 @@ function filter(state) {
 
 <%
 myShepherd.rollbackDBTransaction();
+myShepherd.closeDBTransaction();
 %>

--- a/src/main/webapp/utick.jsp
+++ b/src/main/webapp/utick.jsp
@@ -21,6 +21,7 @@ if (user == null) {
     rtn.put("error", "user not logged in");
     out.println(rtn.toString());
     myShepherd.rollbackDBTransaction();
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -55,9 +56,9 @@ myShepherd.commitDBTransaction();
 rtn.put("success", true);
 rtn.put("content", content);
 out.println(rtn);
+myShepherd.closeDBTransaction();
 
 
 
 
 %>
-


### PR DESCRIPTION
A few `myShepherd.closeDBTransaction();`s for less memory leakage. In particular not sure of the effect this has on utick.jsp, since I don't know what that does.