### PR TITLE
WB-918 add new state mergereview, filter by oldest day with things in…

### DIFF
--- a/src/main/java/org/ecocean/Shepherd.java
+++ b/src/main/java/org/ecocean/Shepherd.java
@@ -230,7 +230,7 @@ public class Shepherd {
       e.printStackTrace();
     }
   }
-  
+
   public void storeNewSurveyTrack(SurveyTrack stk) {
     beginDBTransaction();
     try {
@@ -242,7 +242,7 @@ public class Shepherd {
       e.printStackTrace();
     }
   }
-  
+
   public void storeNewPath(Path pth) {
     beginDBTransaction();
     try {
@@ -254,7 +254,7 @@ public class Shepherd {
       e.printStackTrace();
     }
   }
-  
+
   public void storeNewPointLocation(PointLocation plc ) {
     beginDBTransaction();
     try {
@@ -366,7 +366,7 @@ public class Shepherd {
       return false;
     }
   }
-  
+
   public List getAllCollaborations() {
     Collection c;
     try {
@@ -498,7 +498,7 @@ public class Shepherd {
     }
     return tempEnc;
   }
-  
+
   public NoteField getNoteField(String id) {
     try {
       return (NoteField)(pm.getObjectById(pm.newObjectIdInstance(NoteField.class, id), true));
@@ -835,11 +835,11 @@ public class Shepherd {
     return rolesFound;
   }
 
-  
-  
+
+
   public User getUser(String username) {
     User user= null;
-    String filter="SELECT FROM org.ecocean.User WHERE username == \""+username.trim()+"\"";   
+    String filter="SELECT FROM org.ecocean.User WHERE username == \""+username.trim()+"\"";
     Query query=getPM().newQuery(filter);
     Collection c = (Collection) (query.execute());
     Iterator it = c.iterator();
@@ -852,7 +852,7 @@ public class Shepherd {
 
   public Organization getOrganizationByName(String name) {
     Organization org= null;
-    String filter="SELECT FROM org.ecocean.Organization WHERE name == \""+name.trim()+"\"";   
+    String filter="SELECT FROM org.ecocean.Organization WHERE name == \""+name.trim()+"\"";
     Query query=getPM().newQuery(filter);
     Collection c = (Collection) (query.execute());
     Iterator it = c.iterator();
@@ -862,7 +862,7 @@ public class Shepherd {
     query.closeAll();
     return org;
   }
-  
+
   public Organization getOrganization(String uuid) {
     Organization org= null;
     String filter="SELECT FROM org.ecocean.Organization WHERE id == \""+uuid.trim()+"\"";
@@ -903,21 +903,21 @@ public class Shepherd {
       System.out.println("I failed to create a new Taxonomy in Shepherd.storeNewAnnotation().");
       e.printStackTrace();
       return "fail";
-    } 
+    }
     //finally {
       //closeDBTransaction();
     //}
     //if (transactionWasActive) beginDBTransaction();
     return (org.getId());
   }
-  
+
   public List<User> getUsersWithUsername() {
     return getUsersWithUsername("username ascending");
   }
-  
+
   public List<User> getUsersWithUsername(String ordering) {
     List<User> users=null;
-    String filter="SELECT FROM org.ecocean.User WHERE username != null";   
+    String filter="SELECT FROM org.ecocean.User WHERE username != null";
     Query query=getPM().newQuery(filter);
     query.setOrdering(ordering);
     Collection c = (Collection) (query.execute());
@@ -934,7 +934,7 @@ public class Shepherd {
     List<User> users=null;
     String filter="SELECT FROM org.ecocean.User WHERE username != null ";
     // bc of how sql's startsWith method works we need the null check below
-    filter += "&& (fullName == null || !fullName.startsWith('Conserve.IO User '))";   
+    filter += "&& (fullName == null || !fullName.startsWith('Conserve.IO User '))";
     Query query=getPM().newQuery(filter);
     query.setOrdering(ordering);
     Collection c = (Collection) (query.execute());
@@ -942,7 +942,7 @@ public class Shepherd {
     query.closeAll();
     return users;
   }
-  
+
   public User getUserByUUID(String uuid) {
     User user= null;
     try {
@@ -968,9 +968,9 @@ public class Shepherd {
     return getUser(username);
   }
 
-  
-  
-  
+
+
+
   public TissueSample getTissueSample(String sampleID, String encounterNumber) {
     TissueSample tempEnc = null;
     String filter = "this.sampleID == \""+sampleID+"\" && this.correspondingEncounterNumber == \""+encounterNumber+"\"";
@@ -1289,7 +1289,7 @@ public class Shepherd {
     }
     return true;
   }
-  
+
   public boolean isSurveyTrack(String num) {
     try {
       SurveyTrack tempTrack = ((org.ecocean.movement.SurveyTrack) (pm.getObjectById(pm.newObjectIdInstance(SurveyTrack.class, num.trim()), true)));
@@ -1514,7 +1514,7 @@ public class Shepherd {
   public boolean isOccurrence(Occurrence occ) {
     return (occ!=null && isOccurrence(occ.getOccurrenceID()));
   }
-  
+
   public boolean isPath(String name) {
     try {
       Path tempPath = ((org.ecocean.movement.Path) (pm.getObjectById(pm.newObjectIdInstance(Path.class, name.trim()), true)));
@@ -1695,7 +1695,7 @@ public class Shepherd {
   }
 
 
-  
+
   public Iterator<Survey> getAllSurveysNoQuery() {
     try {
       Extent svyClass = pm.getExtent(Survey.class, true);
@@ -1732,7 +1732,7 @@ public class Shepherd {
       return null;
     }
   }
-  
+
   public ArrayList<MediaAsset> getAllMediaAssetsAsArray() {
     try {
       Extent maClass = pm.getExtent(MediaAsset.class, true);
@@ -1926,7 +1926,7 @@ public class Shepherd {
       return null;
     }
   }
-  
+
   public Iterator<Survey> getAllSurveys(Query acceptedSurveys, Map<String, Object> paramMap) {
     Collection c;
     try {
@@ -1964,8 +1964,8 @@ public class Shepherd {
     return al;
 
   }
-  
-  
+
+
   public List<Organization> getAllParentOrganizations() {
     ArrayList<Organization> al = new ArrayList<Organization>();
     try {
@@ -1973,14 +1973,14 @@ public class Shepherd {
       Collection results = (Collection) q.execute();
       al = new ArrayList<Organization>(results);
       q.closeAll();
-    } 
+    }
     catch (javax.jdo.JDOException x) {
       x.printStackTrace();
       return al;
     }
     return al;
   }
-  
+
   public List<Organization> getAllOrganizationsForUser(User user) {
     ArrayList<Organization> al = new ArrayList<Organization>();
     try {
@@ -1988,14 +1988,14 @@ public class Shepherd {
       Collection results = (Collection) q.execute();
       al = new ArrayList<Organization>(results);
       q.closeAll();
-    } 
+    }
     catch (javax.jdo.JDOException x) {
       x.printStackTrace();
       return al;
     }
     return al;
   }
-  
+
   public List<Organization> getAllOrganizations() {
     ArrayList<Organization> al = new ArrayList<Organization>();
     try {
@@ -2004,14 +2004,14 @@ public class Shepherd {
       Collection results = (Collection) q.execute();
       al = new ArrayList<Organization>(results);
       q.closeAll();
-    } 
+    }
     catch (javax.jdo.JDOException x) {
       x.printStackTrace();
       return al;
     }
     return al;
   }
-  
+
 
   public List getPairs(Query query, int pageSize) {
     Collection c;
@@ -2222,7 +2222,7 @@ public class Shepherd {
     query.closeAll();
     return null;
   }
-  
+
   public Occurrence getOccurrenceForSurvey(Survey svy) {
     String svyID = svy.getID();
     String filter="SELECT FROM org.ecocean.Occurrence WHERE correspondingSurveyID == \""+svyID+"\"";
@@ -2231,14 +2231,14 @@ public class Shepherd {
     Iterator obArr = c.iterator();
     q.closeAll();
     if (obArr.hasNext()) {
-      return (Occurrence) obArr.next();      
+      return (Occurrence) obArr.next();
     }
     return null;
   }
-  
-  
 
-  
+
+
+
 
 
 
@@ -2246,7 +2246,7 @@ public class Shepherd {
     String hashedEmailAddress=User.generateEmailHash(email);
     return getUserByHashedEmailAddress(hashedEmailAddress);
   }
-  
+
   public User getUserByHashedEmailAddress(String hashedEmail){
     ArrayList<User> users=new ArrayList<User>();
     String filter="SELECT FROM org.ecocean.User WHERE hashedEmailAddress == \""+hashedEmail+"\"";
@@ -2257,8 +2257,8 @@ public class Shepherd {
     if(users.size()>0){return users.get(0);}
     return null;
   }
-  
-  
+
+
   public List<User> getUsersWithEmailAddresses(){
     ArrayList<User> users=new ArrayList<User>();
     String filter="SELECT FROM org.ecocean.User WHERE emailAddress != null";
@@ -2268,7 +2268,7 @@ public class Shepherd {
     query.closeAll();
     return users;
   }
-  
+
   public User getUserByAffiliation(String affil){
     String filter="SELECT FROM org.ecocean.User WHERE affiliation == \""+affil+"\"";
     Query query=getPM().newQuery(filter);
@@ -2283,8 +2283,8 @@ public class Shepherd {
     query.closeAll();
     return null;
   }
-  
-  
+
+
 
   public User getUserBySocialId(String service, String id) {
         if ((id == null) || (service == null)) return null;
@@ -2368,11 +2368,11 @@ public class Shepherd {
     samples.closeAll();
     return (al);
   }
-  
+
   public ArrayList<TissueSample> getAllTissueSamplesNoQuery() {
     Extent tsClass = pm.getExtent(TissueSample.class, true);
     Query tsQuery = pm.newQuery(tsClass, "");
-    
+
     Collection col = (Collection) (tsQuery.execute());
     ArrayList<TissueSample> samples = new ArrayList<>(col);
     return samples;
@@ -2433,7 +2433,7 @@ public class Shepherd {
     return myArray;
   }
 
-/*  
+/*
   public ArrayList<SinglePhotoVideo> getAllSinglePhotoVideosWithKeyword(Keyword word) {
 	  String keywordQueryString="SELECT FROM org.ecocean.SinglePhotoVideo WHERE keywords.contains(word0) && ( word0.indexname == \""+word.getIndexname()+"\" ) VARIABLES org.ecocean.Keyword word0";
       Query samples = pm.newQuery(keywordQueryString);
@@ -2443,7 +2443,7 @@ public class Shepherd {
 	    return myArray;
 	  }
 */
-  
+
   public ArrayList<MediaAsset> getAllMediAssetsWithKeyword(Keyword word0){
     String keywordQueryString="SELECT FROM org.ecocean.media.MediaAsset WHERE ( this.keywords.contains(word0) && ( word0.indexname == \""+word0.getIndexname()+"\" ) ) VARIABLES org.ecocean.Keyword word0";
     Query samples = pm.newQuery(keywordQueryString);
@@ -2499,7 +2499,7 @@ public class Shepherd {
     // we couldn't find a profile photo with the keyword
     results = getKeywordPhotosForIndividual(indy, new String[]{kwName}, 1);
     if (results!=null && results.size()>0) return (results.get(0));
-    
+
     return null;
   }
 
@@ -2520,7 +2520,7 @@ public class Shepherd {
     return getAllMarkedIndividualsSightedAtLocationID(locationID).size();
   }
 
-  public ArrayList<Encounter> getAllEncountersForSpecies(String genus, String specificEpithet) { 
+  public ArrayList<Encounter> getAllEncountersForSpecies(String genus, String specificEpithet) {
     String keywordQueryString="SELECT FROM org.ecocean.Encounter WHERE genus == '"+genus+"' && specificEpithet == '"+specificEpithet+"'";
       Query samples = pm.newQuery(keywordQueryString);
     Collection c = (Collection) (samples.execute());
@@ -2537,26 +2537,26 @@ public class Shepherd {
       samples.closeAll();
       return myArray;
     }
-  
+
   public ArrayList<Encounter> getEncountersArrayWithMillis(long millis) {
     String milliString = String.valueOf(millis);
-    
+
     // uhhhhhhhh
     String up = milliString.substring(0, milliString.length() - 6) + 999999;
     String down = milliString.substring(0, milliString.length() - 6) + 000000;
-    
-    
+
+
     String keywordQueryString="SELECT FROM org.ecocean.Encounter WHERE dateInMilliseconds >= "+down+" && dateInMilliseconds <= "+up+" ";
     Query encQuery = pm.newQuery(keywordQueryString);
     Collection col = null;
     try {
       encQuery = pm.newQuery(keywordQueryString);
       if (encQuery.execute() != null) {
-        col = (Collection) encQuery.execute();              
+        col = (Collection) encQuery.execute();
       }
     } catch (Exception e) {
       e.printStackTrace();
-      System.out.println("Exception on query : "+keywordQueryString);    
+      System.out.println("Exception on query : "+keywordQueryString);
       return null;
     }
     ArrayList<Encounter> encs = new ArrayList<Encounter>(col);
@@ -2580,11 +2580,11 @@ public class Shepherd {
       encQuery = pm.newQuery(keywordQueryString);
       if (encQuery.execute() != null) {
         col = (Collection) encQuery.execute();
-        colSize = col.size();        
+        colSize = col.size();
       }
     } catch (Exception e) {
       e.printStackTrace();
-      System.out.println("Exception on query : "+keywordQueryString);    
+      System.out.println("Exception on query : "+keywordQueryString);
       return null;
     }
     List<Encounter> encs = new ArrayList<Encounter>(col);
@@ -2592,7 +2592,7 @@ public class Shepherd {
     System.out.println("getEncountersSubmittedDuring used query string "+keywordQueryString+"; returning "+encs.size()+ " (collection size "+colSize+")");
     return encs;
   }
-  
+
   public ArrayList<Encounter> getEncounterArrayWithShortDate(String sd) {
     sd = sd.replace("/", "-");
     sd = sd.replace(".", "-");
@@ -2600,7 +2600,7 @@ public class Shepherd {
     DateFormat fm = new SimpleDateFormat("yyyy-MM-dd");
     Date d = null;
     try {
-      d = (Date)fm.parse(sd);    
+      d = (Date)fm.parse(sd);
     } catch (ParseException pe) {
       pe.printStackTrace();
     }
@@ -2612,15 +2612,15 @@ public class Shepherd {
     System.out.println("Trying to get encounter with date in Millis : "+milliString);
     String keywordQueryString="SELECT FROM org.ecocean.Encounter WHERE dateInMilliseconds >= "+milliString+" && dateInMilliseconds <= "+millisNext+"";
     Collection col = null;
-    Query encQuery = null; 
+    Query encQuery = null;
     try {
       encQuery = pm.newQuery(keywordQueryString);
       if (encQuery.execute() != null) {
-        col = (Collection) encQuery.execute();              
+        col = (Collection) encQuery.execute();
       }
     } catch (Exception e) {
       e.printStackTrace();
-      System.out.println("Exception on query : "+keywordQueryString);    
+      System.out.println("Exception on query : "+keywordQueryString);
       return null;
     }
     ArrayList<Encounter> encs = new ArrayList<Encounter>(col);
@@ -2767,7 +2767,7 @@ public class Shepherd {
     }
     return ((al.size()>0) ? ((MarkedIndividual) al.get(0)) : null);
   }
-  
+
   public Task getTask(String id) {
     Task theTask = null;
     try {
@@ -2824,7 +2824,7 @@ public class Shepherd {
   }
 
 
- 
+
     //note, new indiv is *not* made persistent here!  so do that yourself if you want to. (shouldnt matter if not-new)
     public MarkedIndividual getOrCreateMarkedIndividual(String name, Encounter enc) {
         MarkedIndividual indiv = getMarkedIndividualQuiet(name);
@@ -2853,7 +2853,7 @@ public class Shepherd {
       return occ;
   }
 
-  
+
   public Survey getSurvey(String id) {
     Survey srv = null;
     try {
@@ -2864,7 +2864,7 @@ public class Shepherd {
     }
     return srv;
   }
-  
+
   public SurveyTrack getSurveyTrack(String id) {
     SurveyTrack stk = null;
     try {
@@ -2875,7 +2875,7 @@ public class Shepherd {
     }
     return stk;
   }
-  
+
   public Path getPath(String id) {
     Path pth = null;
     try {
@@ -2886,7 +2886,7 @@ public class Shepherd {
     }
     return pth;
   }
-  
+
   public PointLocation getPointLocation(String id) {
     PointLocation pl = null;
     try {
@@ -3156,7 +3156,7 @@ public class Shepherd {
       return 0;
     }
   }
-  
+
   public int getNumAssetStores() {
     Extent encClass = pm.getExtent(AssetStore.class, true);
     Query acceptedEncounters = pm.newQuery(encClass);
@@ -3527,7 +3527,7 @@ public class Shepherd {
   public List<User> getAllUsers() {
     return getAllUsers("username ascending NULLS LAST");
   }
-  
+
   public List<User> getAllUsers(String ordering) {
     Collection c;
     ArrayList<User> list = new ArrayList<User>();
@@ -3643,7 +3643,7 @@ public class Shepherd {
 
     if((allKeywords!=null)&&(propKeywordNames!=null)) {
       System.out.println("getSortedKeywordList got propKeywordNames: "+propKeywordNames);
-  
+
       for (String propKwName: propKeywordNames) {
         for (Keyword kw: allKeywords) {
           if ((kw.getReadableName()!=null) && kw.getReadableName().equals(propKwName)) {
@@ -3669,7 +3669,7 @@ public class Shepherd {
       acceptedKeywords.setOrdering("readableName descending");
       Collection c = (Collection) (acceptedKeywords.execute());
       if(c!=null) al=new ArrayList<Keyword>(c);
-    } 
+    }
     catch (javax.jdo.JDOException x) {
       x.printStackTrace();
       return null;
@@ -4149,7 +4149,7 @@ public class Shepherd {
     }
     return keeperEnc;
   }
-  
+
   public List<MarkedIndividual> getMarkedIndividualsByNickname(String altID) {
     String filter = "this.nickName.toLowerCase() == \"" + altID.toLowerCase() + "\"";
     Extent encClass = pm.getExtent(MarkedIndividual.class, true);
@@ -4256,7 +4256,7 @@ public class Shepherd {
 	    q.closeAll();
     return al;
   }
-  
+
   public List<String> getAllNativeUsernames() {
     String filter="SELECT FROM org.ecocean.User WHERE username != null ";
     // bc of how sql's startsWith method works we need the null check below
@@ -4395,11 +4395,11 @@ public class Shepherd {
 	    q.closeAll();
     return al;
   }
-  
+
   public Iterator<Survey> getAllSurveys() {
     Extent svyClass = pm.getExtent(Survey.class, true);
     Iterator svsIt = svyClass.iterator();
-    return svsIt;      
+    return svsIt;
   }
 
   public List<Encounter> getEncountersWithHashedEmailAddress(String hashedEmail) {
@@ -4559,7 +4559,7 @@ public class Shepherd {
     return occurrenceIDs;
 
   }
-  
+
   public ArrayList<String> getLinkedLocationIDs(String locationID){
     ArrayList<String> locationIDs=new ArrayList<String>();
 
@@ -4675,8 +4675,8 @@ public class Shepherd {
     Collection c = (Collection) (q.execute());
     ArrayList<String> allUsers = new ArrayList<String>(c);
     q.closeAll();
-    
-    
+
+
     int numAllUsers=allUsers.size();
     //System.out.println("     All users: "+numAllUsers);
     QueryCache qc=QueryCacheFactory.getQueryCache(getContext());
@@ -4688,16 +4688,16 @@ public class Shepherd {
           CachedQuery cq=qc.getQueryByName(("numRecentEncounters_"+thisUser));
           matchingUsers.put(thisUser, (cq.executeCountQuery(this)));
         }
-        
+
         else{
           String userFilter = "SELECT FROM org.ecocean.Encounter WHERE submitterID == \"" + thisUser + "\" && dwcDateAddedLong >= "+startTime;
           //update rankings hourly
           CachedQuery cq=new CachedQuery(("numRecentEncounters_"+thisUser),userFilter,3600000);
           qc.addCachedQuery(cq);
           matchingUsers.put(thisUser, (cq.executeCountQuery(this)));
-          
+
         }
-        
+
       }
     }
 
@@ -4761,7 +4761,7 @@ public class Shepherd {
     }
     return null;
   }
-  
+
   public ArrayList<MediaAsset> getMediaAssetsWithACMId(String acmId){
     String filter = "this.acmId == \""+acmId+"\"";
     Extent annClass = pm.getExtent(MediaAsset.class, true);
@@ -4792,24 +4792,24 @@ public class Shepherd {
 
   public List<String> getAllEncounterNumbers(){
       List<String> encs=null;
-      String filter="SELECT DISTINCT catalogNumber FROM org.ecocean.Encounter";  
+      String filter="SELECT DISTINCT catalogNumber FROM org.ecocean.Encounter";
       Query query=getPM().newQuery(filter);
       Collection c = (Collection) (query.execute());
       encs=new ArrayList<String>(c);
       query.closeAll();
       return encs;
   }
-  
+
   public List<String> getAllUsernamesWithRoles(){
     List<String> usernames=null;
-    String filter="SELECT DISTINCT username FROM org.ecocean.Role";  
+    String filter="SELECT DISTINCT username FROM org.ecocean.Role";
     Query query=getPM().newQuery(filter);
     Collection c = (Collection) (query.execute());
     usernames=new ArrayList<String>(c);
     query.closeAll();
     return usernames;
 }
-  
+
 
   public List<Encounter> getEncountersForSubmitter(User user, Shepherd myShepherd){
       ArrayList<Encounter> users=new ArrayList<Encounter>();
@@ -4832,7 +4832,7 @@ public class Shepherd {
       query.closeAll();
       return users;
   }
-  
+
   public StoredQuery getStoredQuery(String uuid) {
     StoredQuery sq = null;
     try {
@@ -4842,7 +4842,7 @@ public class Shepherd {
     }
     return sq;
   }
-  
+
 
   public List<StoredQuery> getAllStoredQueries() {
     Extent encClass = pm.getExtent(StoredQuery.class, true);
@@ -4851,6 +4851,26 @@ public class Shepherd {
     ArrayList<StoredQuery> listy=new ArrayList<StoredQuery>(c);
     queries.closeAll();
     return listy;
+  }
+
+  public List<Decision> getDecisionsForEncounter(Encounter enc){
+    try {
+      String queryString = "SELECT FROM org.ecocean.Decision WHERE this.encounter.catalogNumber == '"+enc.getCatalogNumber()+"'";
+      Query query = pm.newQuery(queryString);
+      query.setClass(Decision.class);
+      List<Decision> decisions = (List<Decision>) query.execute();
+      if (decisions!=null && decisions.size()>0) return decisions;
+      query.closeAll();
+    }
+    catch (Exception e) {
+      System.out.println("Exception on getDecisionsForEncounter in encounter: " + enc.toString());
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  public void throwAwayDecision(Decision regrettableDecision) {
+    pm.deletePersistent(regrettableDecision);
   }
 
 

--- a/src/main/java/org/ecocean/Shepherd.java
+++ b/src/main/java/org/ecocean/Shepherd.java
@@ -4859,8 +4859,8 @@ public class Shepherd {
       Query query = pm.newQuery(queryString);
       query.setClass(Decision.class);
       List<Decision> decisions = (List<Decision>) query.execute();
-      if (decisions!=null && decisions.size()>0) return decisions;
       query.closeAll();
+      if (decisions!=null && decisions.size()>0) return decisions;
     }
     catch (Exception e) {
       System.out.println("Exception on getDecisionsForEncounter in encounter: " + enc.toString());

--- a/src/main/java/org/ecocean/servlet/DecisionStore.java
+++ b/src/main/java/org/ecocean/servlet/DecisionStore.java
@@ -35,6 +35,7 @@ public class DecisionStore extends HttpServlet {
 
     @Override
     public void doPost(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+        System.out.println("doPost in DecisionStore.java entered");
         String context = ServletUtilities.getContext(request);
         Shepherd myShepherd = new Shepherd(context);
         myShepherd.beginDBTransaction();
@@ -69,6 +70,7 @@ public class DecisionStore extends HttpServlet {
                 Decision dec = new Decision(user, enc, key, val);
                 myShepherd.getPM().makePersistent(dec);
                 ids.put(dec.getId());
+                Decision.updateEncounterStateBasedOnDecision(myShepherd, enc);
             }
             if (ids.length() > 0) {
                 rtn.put("success", true);
@@ -86,6 +88,7 @@ public class DecisionStore extends HttpServlet {
             myShepherd.getPM().makePersistent(dec);
             rtn.put("success", true);
             rtn.put("decisionId", dec.getId());
+            Decision.updateEncounterStateBasedOnDecision(myShepherd, enc);
         }
 
         if (rtn.optBoolean("success", false)) {
@@ -97,4 +100,5 @@ public class DecisionStore extends HttpServlet {
         out.println(rtn);
         out.close();
     }
+
 }

--- a/src/main/resources/bundles/commonConfiguration.properties
+++ b/src/main/resources/bundles/commonConfiguration.properties
@@ -18,24 +18,24 @@
 #
 
 #file system folder in which encounter data will be stored (e.g. photos)
-#imageLocation=encounters 
+#imageLocation=encounters
 
 #base url of the web site
 urlLocation=www.whaleshark.org
 
 #file system folder in which marked individual data will be stored (e.g. data files)
-#markedIndividualDirectoryLocation=individuals 
+#markedIndividualDirectoryLocation=individuals
 
 #kitsci_api_key =
 
 #Google maps & keys
 
-googleMapsKey = 
+googleMapsKey =
 googleSearchKey =
 
 # GPS coordinates for the default center of survey maps
-# MUST be in this format 
-googleMapsCenter={lat: 35.2195, lng: -75.6903} 
+# MUST be in this format
+googleMapsCenter={lat: 35.2195, lng: -75.6903}
 
 #file system folder in which adoption data will be stored (e.g. photos)
 #adoptionLocation=adoptions
@@ -76,7 +76,7 @@ htmlTitle=Wildbook for Whale Sharks
 
 #Modified Groth algorithm parameters for spot pattern recognition
 R=8
-epsilon=0.01 
+epsilon=0.01
 sizelim=0.9
 maxTriangleRotation=30
 C=0.99
@@ -386,3 +386,5 @@ containerName=
 ####  you *must* have a (safe) importDir (absolute path) defined to use the StandardImport functionality
 #importDir=/some/path/here
 
+MIN_DECISIONS_TO_CHANGE_ENC_STATE = 7
+MIN_AGREEMENTS_TO_CHANGE_ENC_STATE = 5

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -64,7 +64,7 @@
                 #only let authenticated users
                 #with the appropriate role
                 #view the web pages in the secure
-                #and admin 
+                #and admin
                 [urls]
 
 		/compare.jsp = authc, roles[subject]
@@ -78,6 +78,7 @@
 
 
                 /appadmin/scanTaskAdmin.jsp = authc, roles[researcher]
+								/appadmin/sandbox.jsp = authc, roles[admin]
 				/appadmin/listImages.jsp = authcBasicWildbook
 
 
@@ -148,7 +149,7 @@
        /surveys/createSurvey.jsp = authc, roles[researcher]
        /surveys/surveySearch.jsp = authc, roles[researcher]
        /surveys/surveySearchResults.jsp = authc, roles[researcher]
-       
+
        /SurveyCreate = authc, roles[researcher]
        /SubmitSurvey = authc, roles[researcher]
        /SurveySetObservation = authc, roles[researcher]
@@ -189,7 +190,7 @@
 		             /EncounterSetBehavior = authc, roles[researcher]
 		      /CJS = authc, roles[researcher]
 		      /software.jsp = authc, roles[researcher]
-      			
+
       			/encounters/searchExport = authc, roles[researcher]
       			/welcome.jsp = authc
       			/EncounterSetSubmitterID = authc, roles[researcher]
@@ -209,20 +210,20 @@
 					/SubmitSpotsAndTransformImage = authc,roles[researcher]
 
 					/ResurrectDeletedEncounter = authc,roles[admin]
-					
+
 				/OccurrenceSearchExportMetadataExcel = authc, roles[researcher]
                  /OccurrenceSearchExportGtm = authc, roles[researcher]
-				 
+
 				 /SUTimeServlet = authc, roles[admin]
-				 
+
 				 #lockdown Keyword handling
 				 /appadmin/kwAdmin.jsp = authc, roles[admin]
 				 /KeywordHandler = authc, roles[admin]
-				
+
 				/ExportWekaPredictorARFF = authc, roles[admin]
-				
+
 				/pictureBook.jsp = authc, roles[researcher]
-				
+
 				/EncounterSetSurveyAndTrack = authc, roles[researcher]
 				/OccurrenceSetSurveyAndTrack = authc, roles[researcher]
 				/EncounterSetGenusSpecies = authc, roles[researcher]
@@ -246,9 +247,9 @@
 				/CRCExportReport = authc, roles[researcher]
 				/DeleteAdoption = authc, roles[adoption]
 			    /IndividualSetSex = authc, roles[researcher]
-				
+
 				/EncounterSetSex = authc, roles[researcher]
-					
+
 				/EncounterSetMaximumDepth = authc, roles[researcher]
 				/EncounterSetMaximumElevation = authc, roles[researcher]
 				/EncounterSetOccurrenceRemarks = authc, roles[researcher]
@@ -280,13 +281,13 @@
 				/sutime/** = authc
 				/EncounterRemoveUser = authc, roles[researcher]
 				/EncounterAddUser = authc, roles[researcher]
-				
+
 				/AnnotationEdit = authc, roles[admin]
-				
+
 				/obrowse.jsp = authc, roles[admin]
-				
+
 				/StandardImport = authc, roles[admin]
-				
+
             </param-value>
         </init-param>
     </filter>
@@ -316,7 +317,7 @@
     <url-pattern>/di/ImgFilter/*</url-pattern>
     <url-pattern>/di/ImgFilter/*</url-pattern>
   </filter-mapping>
-  
+
   <servlet>
     <description>SubmitSurvey</description>
     <servlet-name>SubmitSurvey</servlet-name>
@@ -358,7 +359,7 @@
   <servlet>
     <servlet-name>EncounterCreateSurvey</servlet-name>
     <servlet-class>org.ecocean.servlet.EncounterCreateSurvey</servlet-class>
-  </servlet>	
+  </servlet>
 
   <servlet>
     <servlet-name>WriteOutScanTask</servlet-name>
@@ -374,12 +375,12 @@
     <servlet-name>IndividualSetAlternateID</servlet-name>
     <servlet-class>org.ecocean.servlet.IndividualSetAlternateID</servlet-class>
   </servlet>
-  
+
   <servlet>
     <servlet-name>EncounterSetSurveyAndTrack</servlet-name>
     <servlet-class>org.ecocean.servlet.EncounterSetSurveyAndTrack</servlet-class>
   </servlet>
-  
+
   <servlet>
     <servlet-name>OccurrenceSetSurveyAndTrack</servlet-name>
     <servlet-class>org.ecocean.servlet.OccurrenceSetSurveyAndTrack</servlet-class>
@@ -549,7 +550,7 @@
     <servlet-class>org.ecocean.servlet.EncounterSetAsUnidentifiable</servlet-class>
   </servlet>
 -->
-  
+
 
 
 
@@ -584,7 +585,7 @@
 		<servlet-name>ResumableUpload</servlet-name>
 		<servlet-class>org.ecocean.resumableupload.UploadServlet</servlet-class>
 	</servlet>
-	
+
 	<servlet>
 		<servlet-name>SurveyCreate</servlet-name>
 		<servlet-class>org.ecocean.servlet.SurveyCreate</servlet-class>
@@ -606,7 +607,7 @@
 		<servlet-name>AddOccToTrack</servlet-name>
 		<servlet-class>org.ecocean.servlet.AddOccToTrack</servlet-class>
 	</servlet>
-	
+
 	<servlet-mapping>
  		<servlet-name>ResumableUpload</servlet-name>
 		<url-pattern>/ResumableUpload</url-pattern>
@@ -801,7 +802,7 @@
   </servlet>
 
   <!--
-  
+
         <servlet>
         <servlet-name>ningalooPradel</servlet-name>
         <servlet-class>org.ecocean.servlet.NingalooPradel</servlet-class>
@@ -947,7 +948,7 @@
     <servlet-class>org.ecocean.servlet.SideFeed</servlet-class>
   </servlet>
 -->
-  
+
   <servlet>
     <servlet-name>EncounterRemoveImage</servlet-name>
     <servlet-class>org.ecocean.servlet.EncounterRemoveImage</servlet-class>
@@ -1196,12 +1197,12 @@
     <servlet-name>EncounterSetLivingStatus</servlet-name>
     <servlet-class>org.ecocean.servlet.EncounterSetLivingStatus</servlet-class>
   </servlet>
-  
+
     <servlet>
     <servlet-name>EncounterRemoveUser</servlet-name>
     <servlet-class>org.ecocean.servlet.EncounterRemoveUser</servlet-class>
   </servlet>
-  
+
       <servlet>
     <servlet-name>EncounterAddUser</servlet-name>
     <servlet-class>org.ecocean.servlet.EncounterAddUser</servlet-class>
@@ -1236,8 +1237,8 @@
     	<servlet-class>org.ecocean.servlet.MozRobustByMonths</servlet-class>
   </servlet>
 -->
-  
-  
+
+
   <servlet>
     <servlet-name>ScanWorkItemResultsHandler</servlet-name>
     <servlet-class>org.ecocean.servlet.ScanWorkItemResultsHandler</servlet-class>
@@ -1342,12 +1343,12 @@
       <url-pattern>/SideFeed</url-pattern>
   </servlet-mapping>
   -->
-  
+
     <servlet>
     <servlet-name>ExportWekaPredictorARFF</servlet-name>
     <servlet-class>org.ecocean.ai.servlet.export.ExportWekaPredictorARFF</servlet-class>
   </servlet>
-  
+
     <servlet-mapping>
     <servlet-name>ExportWekaPredictorARFF</servlet-name>
     <url-pattern>/ExportWekaPredictorARFF</url-pattern>
@@ -1396,7 +1397,7 @@
     <servlet-name>OccurrenceClusterMASet</servlet-name>
     <servlet-class>org.ecocean.servlet.OccurrenceClusterMASet</servlet-class>
   </servlet>
-  
+
   <servlet>
     <servlet-name>OccurrenceSetObservation</servlet-name>
     <servlet-class>org.ecocean.servlet.OccurrenceSetObservation</servlet-class>
@@ -1406,12 +1407,12 @@
     <servlet-name>EncounterSetObservation</servlet-name>
     <servlet-class>org.ecocean.servlet.EncounterSetObservation</servlet-class>
   </servlet>
-  
+
   <servlet>
     <servlet-name>SurveySetObservation</servlet-name>
     <servlet-class>org.ecocean.servlet.SurveySetObservation</servlet-class>
   </servlet>
-  
+
     <servlet>
     <servlet-name>OccurrenceSearchExportMetadataExcel</servlet-name>
     <servlet-class>org.ecocean.servlet.export.OccurrenceSearchExportMetadataExcel</servlet-class>
@@ -1420,19 +1421,19 @@
     <servlet-name>OccurrenceSearchExportGtm</servlet-name>
     <servlet-class>org.ecocean.servlet.export.OccurrenceSearchExportGtm</servlet-class>
   </servlet>
-  
+
   <!--SUTime testing-->
         <servlet>
         <servlet-name>SUTimeServlet</servlet-name>
         <servlet-class>org.ecocean.servlet.SUTimeServlet</servlet-class>
   </servlet>
-  
+
       <servlet-mapping>
     <servlet-name>SUTimeServlet</servlet-name>
     <url-pattern>/SUTimeServlet</url-pattern>
   </servlet-mapping>
-  
-  
+
+
     <servlet-mapping>
     <servlet-name>OccurrenceSearchExportGtm</servlet-name>
     <url-pattern>/OccurrenceSearchExportGtm</url-pattern>
@@ -1452,9 +1453,9 @@
 <servlet-mapping>
   <servlet-name>SubmitSurvey</servlet-name>
   <url-pattern>/SubmitSurvey</url-pattern>
-</servlet-mapping>  
-  
-<servlet-mapping> 
+</servlet-mapping>
+
+<servlet-mapping>
   <servlet-name>CRCExportReport</servlet-name>
   <url-pattern>/CRCExportReport</url-pattern>
 </servlet-mapping>
@@ -1533,7 +1534,7 @@
         <servlet-name>TissueSampleSetSexAnalysis</servlet-name>
         <url-pattern>/TissueSampleSetSexAnalysis</url-pattern>
   </servlet-mapping>
-  
+
 
 
       <servlet-mapping>
@@ -1624,12 +1625,12 @@
           <servlet-name>TissueSampleRemoveMicrosatelliteMarkers</servlet-name>
           <url-pattern>/TissueSampleRemoveMicrosatelliteMarkers</url-pattern>
   </servlet-mapping>
-  
+
   <servlet-mapping>
       <servlet-name>EncounterSetSurveyAndTrack</servlet-name>
       <url-pattern>/EncounterSetSurveyAndTrack</url-pattern>
   </servlet-mapping>
-  
+
   <servlet-mapping>
       <servlet-name>OccurrenceSetSurveyAndTrack</servlet-name>
       <url-pattern>/OccurrenceSetSurveyAndTrack</url-pattern>
@@ -1698,7 +1699,7 @@
   </servlet-mapping>
 
   <!--
-  
+
  <servlet-mapping>
        <servlet-name>ningalooRobustByMonths</servlet-name>
        <url-pattern>/ningalooRobustByMonths</url-pattern>
@@ -1824,8 +1825,8 @@
     <url-pattern>/EncounterSetAsUnidentifiable</url-pattern>
   </servlet-mapping>
 -->
-  
-  
+
+
     <servlet-mapping>
       <servlet-name>EncounterSearchExportGeneGISFormat</servlet-name>
       <url-pattern>/EncounterSearchExportGeneGISFormat</url-pattern>
@@ -1885,8 +1886,8 @@
     <url-pattern>/EncounterSetSubmitterPhotographerContactInfo</url-pattern>
   </servlet-mapping>
 -->
-<!--  
-  
+<!--
+
    <servlet-mapping>
       <servlet-name>SinglePhotoVideoRemoveKeyword</servlet-name>
       <url-pattern>/SinglePhotoVideoRemoveKeyword</url-pattern>
@@ -1908,17 +1909,17 @@
     <servlet-name>EncounterRemoveSpots</servlet-name>
     <url-pattern>/EncounterRemoveSpots</url-pattern>
   </servlet-mapping>
-  
+
     <servlet-mapping>
     <servlet-name>EncounterRemoveUser</servlet-name>
     <url-pattern>/EncounterRemoveUser</url-pattern>
   </servlet-mapping>
-  
+
     <servlet-mapping>
     <servlet-name>EncounterAddUser</servlet-name>
     <url-pattern>/EncounterAddUser</url-pattern>
   </servlet-mapping>
-  
+
     <servlet-mapping>
     <servlet-name>RelationshipCreate</servlet-name>
     <url-pattern>/RelationshipCreate</url-pattern>
@@ -1995,7 +1996,7 @@
       <url-pattern>/OccurrenceAddEncounter</url-pattern>
   </servlet-mapping>
 
-  
+
   <!--
 	<servlet-mapping>
 		<servlet-name>EncounterSetPatterningPassport</servlet-name>
@@ -2270,7 +2271,7 @@
     <url-pattern>/ScanResultsServlet</url-pattern>
   </servlet-mapping>
 
- <!-- 
+ <!--
     <servlet-mapping>
       <servlet-name>mitFeed</servlet-name>
       <url-pattern>/MITFeed</url-pattern>
@@ -2341,12 +2342,12 @@
     <servlet-name>OccurrenceSetObservation</servlet-name>
     <url-pattern>/OccurrenceSetObservation</url-pattern>
   </servlet-mapping>
-  
+
   <servlet-mapping>
     <servlet-name>SurveySetObservation</servlet-name>
     <url-pattern>/SurveySetObservation</url-pattern>
   </servlet-mapping>
-  
+
   <servlet-mapping>
     <servlet-name>SurveyCreate</servlet-name>
     <url-pattern>/SurveyCreate</url-pattern>
@@ -2371,12 +2372,12 @@
     <servlet-name>AddOccToTrack</servlet-name>
     <url-pattern>/AddOccToTrack</url-pattern>
   </servlet-mapping>
-  
+
     <servlet>
     <servlet-name>StandardImport</servlet-name>
     <servlet-class>org.ecocean.servlet.importer.StandardImport</servlet-class>
   </servlet>
-  
+
     <servlet-mapping>
       <servlet-name>StandardImport</servlet-name>
       <url-pattern>/StandardImport</url-pattern>

--- a/src/main/webapp/appadmin/sandbox.jsp
+++ b/src/main/webapp/appadmin/sandbox.jsp
@@ -1,0 +1,137 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<%@ page contentType="text/html; charset=utf-8" language="java" import="org.joda.time.LocalDateTime,
+org.joda.time.format.DateTimeFormatter,
+org.joda.time.format.ISODateTimeFormat,java.net.*,
+org.ecocean.grid.*,
+org.ecocean.servlet.ServletUtilities,
+java.io.*,java.util.*,
+java.io.FileInputStream,
+java.io.File,
+java.io.FileNotFoundException,
+org.ecocean.*,
+org.ecocean.servlet.*,
+javax.jdo.*,
+java.lang.StringBuffer,
+java.util.Vector,
+java.util.Iterator,
+org.ecocean.servlet.importer.*,
+org.json.JSONObject,
+java.lang.NumberFormatException"%>
+
+<%
+String context="context0";
+context=ServletUtilities.getContext(request);
+Shepherd myShepherd=new Shepherd(context);
+%>
+
+<jsp:include page="../header.jsp" flush="true"/>
+    <script>
+      let txt = getText("encounter.properties");
+    </script>
+    <%
+    myShepherd.beginDBTransaction();
+    try{
+
+        Encounter targetEncounter = myShepherd.getEncounter("c8d1aae2-a6f8-4c18-a96e-a090c97988e1");
+
+        //reset decisions on encounters
+        System.out.println("got here 1");
+        List<Decision> oldDecisions = myShepherd.getDecisionsForEncounter(targetEncounter);
+        System.out.println("got here 2");
+        if(oldDecisions!=null && oldDecisions.size()>0){
+          System.out.println("oldDecisions.size() is: " + oldDecisions.size());
+          for(Decision currentDecision: oldDecisions){
+            System.out.println("got here 3");
+            myShepherd.throwAwayDecision(currentDecision);
+          }
+          myShepherd.updateDBTransaction();
+        }
+        System.out.println("got here 4");
+        List<Decision> checkDecisions = myShepherd.getDecisionsForEncounter(targetEncounter);
+        System.out.println("got here 5");
+        if(checkDecisions==null || checkDecisions.size()<1){
+          System.out.println("things are going according to plan");
+          String property = "match";
+
+          JSONObject value = new JSONObject();
+          String matchCandidateCatalogNumber1 = "79b5cb31-77a5-497e-9a7a-cee0779b5a13";
+          String matchCandidateCatalogNumber2 = "56950464-9348-493f-a8a7-cbf019af583a";
+          value.put("id", matchCandidateCatalogNumber1);
+          User user1 = myShepherd.getUserByUUID("f37d7426-27e7-4133-a205-dac746824436");
+          User user2 = myShepherd.getUserByUUID("29827461-582e-4bf1-9b3d-453bd4d0cd56");
+          User user3 = myShepherd.getUserByUUID("6c51eb42-8964-4ac1-97b6-2a1c1bad4628");
+          User user4 = myShepherd.getUserByUUID("60edc960-ac45-4710-b28a-679501a0bc48");
+          User user5 = myShepherd.getUserByUUID("6c887eab-3928-47d2-8d47-011e8d589caf");
+          User user6 = myShepherd.getUserByUUID("0b616fdd-ccf9-40e6-bbd9-b93724b12014");
+          User user7 = myShepherd.getUserByUUID("0c205984-0105-469a-8efc-4829cc774914");
+          System.out.println("decision got here 1");
+          Decision dec = new Decision(user1, targetEncounter, property, value);
+          myShepherd.getPM().makePersistent(dec);
+          System.out.println("decision got here 1.5");
+          myShepherd.updateDBTransaction();
+          Decision.updateEncounterStateBasedOnDecision(myShepherd, targetEncounter);
+          System.out.println("decision got here 2");
+          System.out.println("decision got here 3");
+          System.out.println("decision got here 4");
+          dec = new Decision(user2, targetEncounter, property, value);
+          myShepherd.getPM().makePersistent(dec);
+          myShepherd.updateDBTransaction();
+          Decision.updateEncounterStateBasedOnDecision(myShepherd, targetEncounter);
+
+          dec = new Decision(user3, targetEncounter, property, value);
+          myShepherd.getPM().makePersistent(dec);
+          myShepherd.updateDBTransaction();
+          Decision.updateEncounterStateBasedOnDecision(myShepherd, targetEncounter);
+
+          dec = new Decision(user4, targetEncounter, property, value);
+          myShepherd.getPM().makePersistent(dec);
+          myShepherd.updateDBTransaction();
+          Decision.updateEncounterStateBasedOnDecision(myShepherd, targetEncounter);
+
+          value.put("id", matchCandidateCatalogNumber2);
+
+          dec = new Decision(user5, targetEncounter, property, value);
+          myShepherd.getPM().makePersistent(dec);
+          myShepherd.updateDBTransaction();
+          Decision.updateEncounterStateBasedOnDecision(myShepherd, targetEncounter);
+
+          dec = new Decision(user6, targetEncounter, property, value);
+          myShepherd.getPM().makePersistent(dec);
+          myShepherd.updateDBTransaction();
+          Decision.updateEncounterStateBasedOnDecision(myShepherd, targetEncounter);
+
+          dec = new Decision(user7, targetEncounter, property, value);
+          myShepherd.getPM().makePersistent(dec);
+          myShepherd.updateDBTransaction();
+          Decision.updateEncounterStateBasedOnDecision(myShepherd, targetEncounter);
+
+          checkDecisions = myShepherd.getDecisionsForEncounter(targetEncounter);
+          if(checkDecisions!=null){
+            System.out.println("after populating, checkDecisions.size() is: " + checkDecisions.size());
+          }
+        } else{
+          System.out.println("things are NOT going according to plan");
+        }
+
+
+        String newState = "finished";
+        targetEncounter.setState(newState);
+        myShepherd.updateDBTransaction();
+
+        Encounter targetEncounter2 = myShepherd.getEncounter("ed3d828e-baf1-43f1-8130-4b24b0441463");
+        targetEncounter2.setState(newState);
+        myShepherd.updateDBTransaction();
+
+
+        myShepherd.commitDBTransaction();
+      	myShepherd.beginDBTransaction();
+
+
+      }finally{
+        myShepherd.rollbackDBTransaction();
+      	myShepherd.closeDBTransaction();
+      }
+
+    %>
+<jsp:include page="../footer.jsp" flush="true"/>

--- a/src/main/webapp/encounters/encounter.jsp
+++ b/src/main/webapp/encounters/encounter.jsp
@@ -614,7 +614,7 @@ var encounterNumber = '<%=num%>';
       			}
 
 String setState = Util.basicSanitize(request.getParameter("setState"));
-if (isAdmin && (setState != null) && (setState.equals("processing") || setState.equals("finished") || setState.equals("pending"))) {
+if (isAdmin && (setState != null) && (setState.equals("processing") || setState.equals("finished") || setState.equals("pending") ||setState.equals("mergereview")||setState.equals("disputed"))) {
     enc.setState(setState);
     commitTransaction = true;
 }

--- a/src/main/webapp/individualGallery.jsp
+++ b/src/main/webapp/individualGallery.jsp
@@ -302,4 +302,5 @@ if (!Util.collectionIsEmptyOrNull(indiv.getEncounters())) for (Encounter enc : i
 
 <%
 myShepherd.rollbackDBTransaction();
+myShepherd.closeDBTransaction();
 %>

--- a/src/main/webapp/queue.jsp
+++ b/src/main/webapp/queue.jsp
@@ -240,7 +240,7 @@ System.out.println("WARNING: queue.generateData() has no matchMap(" + ekey + ")"
             } else {
                 all[36] = "???";
             }
-            
+
             rows.add(all);
         }
     }
@@ -262,6 +262,7 @@ User user = AccessControl.getUser(request, myShepherd);
 if (user == null) {
     myShepherd.rollbackDBTransaction();
     response.sendRedirect("login.jsp");
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -283,6 +284,7 @@ if (!"admin".equals(maxRole)) {
     System.out.println("INFO: queue.jsp non-admin, so bailing cuz second trial has ended");
     session.invalidate();
     response.sendRedirect("secondTrialEnd.jsp");
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -291,6 +293,7 @@ if (maxRole == null) {
     //response.sendError(401, "access denied - no valid role");
     myShepherd.rollbackDBTransaction();
     response.sendRedirect("register.jsp");
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -298,6 +301,7 @@ if (maxRole.equals("cat_walk_volunteer")) {
     System.out.println("queue.jsp: sending " + user + " to appUser.jsp");
     myShepherd.rollbackDBTransaction();
     response.sendRedirect("appUser.jsp");
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -323,6 +327,7 @@ if (isAdmin && (request.getParameter("MatchPhoto") != null)) {
     }
 
     myShepherd.rollbackDBTransaction();
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -393,8 +398,9 @@ if (!forceList && (encs.size() > 0)) {
         if (eid == null) continue;  //snh
         Long ct = (Long)row[1];
         System.out.println("queue.jsp: ? can give " + eid + " (ct " + ct + ") to " + user);
+        int MIN_DECISIONS_TO_CHANGE_ENC_STATE = (new Integer(CommonConfiguration.getProperty("MIN_DECISIONS_TO_CHANGE_ENC_STATE",context))).intValue();
         for (Encounter enc : encs) {
-            if (eid.equals(enc.getCatalogNumber())) {
+            if (eid.equals(enc.getCatalogNumber()) && ct <= MIN_DECISIONS_TO_CHANGE_ENC_STATE) {
                 foundId = eid;
                 break IDFOUND;
             }
@@ -404,11 +410,12 @@ if (!forceList && (encs.size() > 0)) {
     String redir = "encounters/encounterDecide.jsp?id=" + foundId;
     myShepherd.rollbackDBTransaction();
     response.sendRedirect(redir);
+    myShepherd.closeDBTransaction();
     return;
 }
 
 String[] theads = new String[]{"ID", "Sub Date"};
-if (isAdmin) theads = new String[]{"ID", "State", "Cat", "MatchPhoto", "Sub Date", "Col Date", "Dec Ct", "Flags"};
+if (isAdmin) theads = new String[]{"ID", "State", "Cat", "MatchPhoto", "Sub Date", "Col Date", "Dec Ct", "Level of Agreement", "Flags"};
 %>
 
 <jsp:include page="header.jsp" flush="true" />
@@ -463,6 +470,7 @@ if (isAdmin) theads = new String[]{"ID", "State", "Cat", "MatchPhoto", "Sub Date
 .row-state-rejected,
 .row-state-disputed,
 .row-state-processing,
+.row-state-mergereview,
 .row-state-finished,
 .row-state-practice,
 .row-state-unapproved,
@@ -499,10 +507,12 @@ if (isAdmin) theads = new String[]{"ID", "State", "Cat", "MatchPhoto", "Sub Date
     <button id="filter-button-incoming" onClick="return filter('incoming');">incoming<span class="fct"></span></button>
     <button id="filter-button-pending" onClick="return filter('pending');">pending<span class="fct"></span></button>
     <button id="filter-button-processing" onClick="return filter('processing');">processing<span class="fct"></span></button>
+    <button id="filter-button-mergereview" onClick="return filter('mergereview');">merge review<span class="fct"></span></button>
     <button id="filter-button-finished" onClick="return filter('finished');">finished<span class="fct"></span></button>
     <button id="filter-button-flagged" onClick="return filter('flagged');">flagged<span class="fct"></span></button>
     <button id="filter-button-disputed" onClick="return filter('disputed');">disputed<span class="fct"></span></button>
     <button id="filter-button-rejected" onClick="return filter('rejected');">rejected<span class="fct"></span></button>
+    <br>
     <span id="filter-info"></span>
 </div>
 <% } %>
@@ -528,6 +538,12 @@ if (isAdmin) theads = new String[]{"ID", "State", "Cat", "MatchPhoto", "Sub Date
     for (Encounter enc : encs) {
         out.println("<tr class=\"enc-row row-state-" + enc.getState() + "\">");
         String ename = enc.getEventID();
+
+        // TODO IF THAT STUFF DIDN'T END UP JUST BEING TEST DATA, comment this back in and run once on production....This will only need to be run once to update all of the already-existing encounters and the decisions that have been made based on them. Feel free to remove these lines if this has already happened and I forgot to delete. Should speed things up just a little bit... -Mark F.
+        // System.out.println("got here 1. Encounter " + enc.getCatalogNumber()+"'s state is: " + enc.getState());
+        // Decision.updateEncounterStateBasedOnDecision(myShepherd, enc);
+        // System.out.println("got here 2 Encounter " + enc.getCatalogNumber()+"'s state is now: " + enc.getState());
+
         if (ename == null) ename = enc.getCatalogNumber().substring(0,8);
         out.println("<td class=\"col-id\">");
         if (isAdmin) {
@@ -606,6 +622,7 @@ if (isAdmin) theads = new String[]{"ID", "State", "Cat", "MatchPhoto", "Sub Date
             }
 
             out.println("<td class=\"col-dct-" + dct + "\">" + dct + "</td>");
+            out.println("<td class=\"col-lvl-ag-" + Decision.getNumberOfAgreementsForMostAgreedUponMatch(decs) + "\">" + Decision.getNumberOfAgreementsForMostAgreedUponMatch(decs) + "</td>");
             out.println("<td " + ((fct == 0) ? "" : " title=\"" + String.join(" | ", fmap.keySet()) + "\"") + " class=\"col-flag" + ((fct > 0) ? " is-flagged" : "") + " col-fct-" + fct + "\">" + fct + "</td>");
         }
 
@@ -666,13 +683,19 @@ function setActiveTab(state) {
     $('#filter-tabs .tab-active').removeClass('tab-active');
     $('#filter-button-' + state).addClass('tab-active');
     var ct = $('.enc-row:visible').length;
-    $('#filter-info').html('<b>' + ct + '</b> <i>' + state + '</i> submission' + (ct == 1 ? '' : 's'));
+    $('#filter-info').html('<b>' + ct + '</b> <i>' + state + '</i> submission' + (ct == 1 ? '' : 's') + ' in current day');
 }
 
 function filter(state) {
     currentActiveState = state;
     $('.enc-row').hide();
-    $('.row-state-' + state).show();
+    let oldestDateThatNeedsAttention = getOldestDateThatNeedsAttentionInState(state);
+    if(oldestDateThatNeedsAttention && state!=="finished"){ //finished should not filter by date; it should capture _all_ encounters that are in the finished state
+      $('.col-date:contains('+oldestDateThatNeedsAttention+')').parents('.row-state-' + state).show();
+    }else{
+      //if, for some reason, the oldest date fetch fails, at least show them the encounters in the state they want  -Mark F.
+      $('.row-state-' + state).show();
+    }
 
     if (state == 'flagged') {  //special case to find also *any* with flags
         $('.is-flagged').each(function(i, el) {
@@ -690,6 +713,22 @@ function filter(state) {
     setActiveTab(state);
 }
 
+function getOldestDateThatNeedsAttentionInState(state){ //weird to use jQuery here and in the filter method to accomplish something similar, but I wanted clear division of task in this method -Mark F.
+  let allDatesInState = $('.row-state-' + state).children('.col-date').map(function(){
+    return $(this).text();
+  }).get();
+  let allDatesSorted = allDatesInState.sort(function(a,b) {
+    a = a.split('-').join(''); //a little hacky. Depends on the text date display format. But easy to change using .reverse() and changing the split character, say, to "/", as needed. Also, be mindful of month/date order if we ever add support for other languages here -Mark F.
+    b = b.split('-').join('');
+    return a > b ? 1 : a < b ? -1 : 0;
+  });
+  if(allDatesSorted && allDatesSorted.length>0){
+    return allDatesSorted[0];
+  }else{
+    return null;
+  }
+}
+
 </script>
 
 
@@ -697,4 +736,5 @@ function filter(state) {
 
 <%
 myShepherd.rollbackDBTransaction();
+myShepherd.closeDBTransaction();
 %>

--- a/src/main/webapp/utick.jsp
+++ b/src/main/webapp/utick.jsp
@@ -21,6 +21,7 @@ if (user == null) {
     rtn.put("error", "user not logged in");
     out.println(rtn.toString());
     myShepherd.rollbackDBTransaction();
+    myShepherd.closeDBTransaction();
     return;
 }
 
@@ -55,9 +56,9 @@ myShepherd.commitDBTransaction();
 rtn.put("success", true);
 rtn.put("content", content);
 out.println(rtn);
+myShepherd.closeDBTransaction();
 
 
 
 
 %>
-


### PR DESCRIPTION
… all enconter states except finished, filter per site locationID if present in both match candidate and focal encounter. WB-914 create Decision.updateEncounterState and submethods, automatically call updateEncounterState in Decision store upon a new Decision creation. Set min number of decisions needed and min number of merge decisions for a candidate match in commonConfig and use its logic in updateEncounterState to set state to mergereview or disputed as needed, and enforce the logic for showing volunteers the encounters based on these threshold numbers. WB-1370 add disputed state to queue. WB-909 add column in the queue for encounter level of agreement called Level of Agreement. WB-917 make queue show encounters in various states on an oldest-day-requiring-attention basis.