### PR TITLE
Wb 1668

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -718,7 +718,6 @@ System.out.println("[1] getMatchingSet params=" + params);
         else if(enc.getSpecificEpithet().equals("sp.")) {
           filter = "SELECT FROM org.ecocean.Annotation WHERE matchAgainst "
             + this.getMatchingSetFilterFromParameters(params)
-            + this.getMatchingSetFilterIAClassClause(filterIAClass, this.getIAClass())
             + this.getMatchingSetFilterViewpointClause(myShepherd)
             + this.getPartClause(myShepherd)
             + " && acmId != null && enc.catalogNumber != '" + enc.getCatalogNumber()
@@ -729,7 +728,6 @@ System.out.println("[1] getMatchingSet params=" + params);
         else {
           filter = "SELECT FROM org.ecocean.Annotation WHERE matchAgainst "
             + this.getMatchingSetFilterFromParameters(params)
-            + this.getMatchingSetFilterIAClassClause(filterIAClass, this.getIAClass())
             + this.getMatchingSetFilterViewpointClause(myShepherd)
             + this.getPartClause(myShepherd)
             + " && acmId != null && enc.catalogNumber != '" + enc.getCatalogNumber()
@@ -807,12 +805,6 @@ System.out.println("[1] getMatchingSet params=" + params);
         String clause = "&& (viewpoint == null || viewpoint == '" + String.join("' || viewpoint == '", Arrays.asList(viewpoints)) + "')";
         System.out.println("VIEWPOINT CLAUSE: "+clause);
         return clause;
-    }
-
-    private String getMatchingSetFilterIAClassClause(boolean filterIAClass, String iaClass) {
-        if (!filterIAClass) return "";
-        String iaClassClause = " && iaClass.equals('"+iaClass+"') ";
-        return iaClassClause;
     }
 
     private String getPartClause(Shepherd myShepherd) {


### PR DESCRIPTION
Trying to solve incomplete iaClass based matching sets and matchAgainst not being set correctly on ACW+IOT and any other species with multiple classes.

- Disables iaClass clause in getMatchingSet
- Adds check for any ID config contents in IA.json for a given iaClass before setting matchAgains=true
- This unfortunately requires a shepherd to be created or injected in every validForIdentification call, I tried to avoid it  

Would love to hear if anyone has an idea on how to do this better that will work in every WB.