### PR TITLE
WB-1800 add defaultReceiveEmails to commonConfig that defaults to tru…

### DIFF
--- a/src/main/java/org/ecocean/CommonConfiguration.java
+++ b/src/main/java/org/ecocean/CommonConfiguration.java
@@ -397,6 +397,14 @@ public class CommonConfiguration {
     }
   }
 
+  public static Boolean getDefaultReceiveEmails(String context) {
+    if (Util.stringExists(getProperty("defaultReceiveEmails", context))) {
+      return Boolean.parseBoolean(getProperty("defaultReceiveEmails", context).trim());
+    } else {
+      return true;
+    }
+  }
+
   public static String getNewSubmissionEmail(String context) {
     return getProperty("newSubmissionEmail",context).trim();
   }

--- a/src/main/java/org/ecocean/User.java
+++ b/src/main/java/org/ecocean/User.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.io.Serializable;
 import org.ecocean.SinglePhotoVideo;
+import org.ecocean.CommonConfiguration;
 import org.ecocean.servlet.ServletUtilities;
 import org.joda.time.DateTime;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -74,7 +75,7 @@ public class User implements Serializable {
 
   private boolean acceptedUserAgreement=false;
 
-  private boolean receiveEmails=true;
+  private Boolean receiveEmails=true;
 
   // turning this off means the user is greedy and mean: they never share data and nobody ever shares with them
   private Boolean sharing=true;
@@ -109,7 +110,7 @@ public class User implements Serializable {
     public User(String email,String uuid){
       this.uuid=uuid;
       setEmailAddress(email);
-      setReceiveEmails(true);
+      setReceiveEmails(CommonConfiguration.getDefaultReceiveEmails("context0"));
       String salt=ServletUtilities.getSalt().toHex();
       String pass=Util.generateUUID();
       String hashedPassword=ServletUtilities.hashAndSaltPassword(pass, salt);
@@ -339,8 +340,8 @@ public class User implements Serializable {
     public void setLastLogin(long lastie){this.lastLogin=lastie;}
 
 
-    public boolean getReceiveEmails(){return receiveEmails;}
-    public void setReceiveEmails(boolean receive){this.receiveEmails=receive;}
+    public Boolean getReceiveEmails(){return receiveEmails;}
+    public void setReceiveEmails(Boolean receive){this.receiveEmails=receive;}
 
 
 

--- a/src/main/resources/bundles/commonConfiguration.properties
+++ b/src/main/resources/bundles/commonConfiguration.properties
@@ -513,3 +513,4 @@ animalPlural=African carnivores
 animalSingularCapitalized=African Carnivore
 animalPluralCapitalized=African Carnivores
 shepherdDataDir=wildbook_data_dir
+defaultReceiveEmails=false


### PR DESCRIPTION
…e if nothing is in commonConfig. Make it so that user creation everywhere the two-argument user constructor is used (encounterForm, standardImport) uses defaultReceiveEmails to set receiveEmails property.