### PR TITLE
Ng patch fixes

### DIFF
--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -2082,7 +2082,7 @@ public void doNotSetLocalHaplotypeReflection(String myHaplo) {
 }
 
 public long getTimeOfBirth(){return timeOfBirth;}
-public long getTimeofDeath(){return timeOfDeath;}
+public long getTimeOfDeath(){return timeOfDeath;}
 
 public void setTimeOfBirth(long newTime){timeOfBirth=newTime;}
 public void setTimeOfDeath(long newTime){timeOfDeath=newTime;}
@@ -2820,24 +2820,24 @@ public Float getMinDistanceBetweenTwoMarkedIndividuals(MarkedIndividual otherInd
                     }
                   break;
               case "sex":
-                  String sex = jsonIn.optString("sex", null);
+                  String sex = jsonIn.optString("value", null);
                   this.setSex(sex);
                   break;
               case "comments":
-                  String comments = jsonIn.optString("comments", null);
+                  String comments = jsonIn.optString("value", null);
                   this.addComments(comments);
                   break;
               case "timeOfBirth":
                   try {
-                    this.setTimeOfBirth(Long.parseLong(jsonIn.optString("timeOfBirth")));
+                    this.setTimeOfBirth(Long.parseLong(jsonIn.optString("value")));
                   } catch (NumberFormatException nfe) {
                     nfe.printStackTrace();
                     throw new ApiValueException("value must be convertable to a Long { id, value }", "timeOfBirth");
                   }
                   break;
               case "timeOfDeath":
-                  try {
-                    this.setTimeOfBirth(Long.parseLong(jsonIn.optString("timeOfDeath")));
+                try {
+                    this.setTimeOfDeath(Long.parseLong(jsonIn.optString("value")));
                   } catch (NumberFormatException nfe) {
                     nfe.printStackTrace();
                     throw new ApiValueException("value must be convertable to a Long { id, value }", "timeOfDeath");

--- a/src/main/java/org/ecocean/Occurrence.java
+++ b/src/main/java/org/ecocean/Occurrence.java
@@ -1259,6 +1259,9 @@ public class Occurrence extends org.ecocean.api.ApiCustomFields implements java.
     public boolean hasLatLon() {
       return (decimalLongitude!=null && decimalLatitude!=null);
     }
+    public boolean hasLatOrLon() {
+      return (decimalLongitude!=null || decimalLatitude!=null);
+    }
     public void setDecimalLongitude(Double decimalLongitude) {
         if ((decimalLongitude != null) && !Util.isValidDecimalLongitude(decimalLongitude)) throw new ApiValueException("invalid longitude value", "decimalLongitude");
       this.decimalLongitude = decimalLongitude;
@@ -1678,7 +1681,7 @@ public class Occurrence extends org.ecocean.api.ApiCustomFields implements java.
 
         obj.put("customFields", this.getCustomFieldJSONObject());
 
-        if (hasLatLon()) {
+        if (hasLatOrLon()) {
             obj.put("decimalLatitude", getDecimalLatitude());
             obj.put("decimalLongitude", getDecimalLongitude());
         } else {


### PR DESCRIPTION
A few simple changes that fix/improve patching individuals and sightings/occurrences from Houston.

Individuals: we'd previously been looking for the e.g. `decimalLongitude` key's value on a PATCH call, when the key is actually `value`, and `decimalLongitude` appears as a value itself, under the `path` key. Honestly, just looking at the diff is going to make more sense than my explanation here, haha.

Sightings: all I did was change the read logic so that we'll return just lat or just lon if only one of those is set. It is admittedly weird when there's only one set, but the frontend should be able to see that scenario so they can fix it.

NOTE: we shouldn't merge this until we figure out what's the deal with the default sex value in MarkedIndividual.java. If we leave it as "null", we have to change individual tests on houston to _not_ expect sex with every returned object (one-line change in tests/modules/individuals/resources/utils.py::read_individual`), else we break a bunch of tests. If we leave it as "unknown" we're gravy. I'm not certain why that commit is on this branch, I'm guessing it's bc @colinwkingen rolled back the commit in question after I branched off of next-gen.