### PR TITLE
ident job requeue fix

### DIFF
--- a/src/main/java/org/ecocean/ia/IA.java
+++ b/src/main/java/org/ecocean/ia/IA.java
@@ -375,6 +375,7 @@ System.out.println("INFO: IA.intakeAnnotations() finished as " + topTask);
         Map<String,List<Annotation>> iaClassToAnns = new HashMap<String, List<Annotation>>();
         for (Annotation ann: anns) {
             String iaClass = ann.getIAClass();
+            if (iaClass == null) continue;
             List<Annotation> iaClassList = iaClassToAnns.getOrDefault(iaClass, new ArrayList<Annotation>());
             iaClassList.add(ann);
             iaClassToAnns.put(iaClass, iaClassList);

--- a/src/main/java/org/ecocean/servlet/IAGateway.java
+++ b/src/main/java/org/ecocean/servlet/IAGateway.java
@@ -426,13 +426,11 @@ System.out.println("anns -> " + anns);
             Task subTask = subTasks.get(i);
             try {
                 taskRes = _sendIdentificationTask(ann, context, baseUrl, queryConfigDict, null, limitTargetSize, subTask, myShepherd,fastlane);
-            } catch (Exception ex) {
+            } catch (Exception ex) {  // unsure if maybe _some_ exceptions should be treated differently here?
                 System.out.println("subTask failure on " + subTask + ": " + ex.toString());
                 taskRes.put("success", false);
                 taskRes.put("error", ex.toString());
 System.out.println(">>>>>>> parentTask: " + parentTask);
-System.out.println(">>>>>>> parentTask params: " + parentTask.getParameters());
-System.out.println(">>>>>>> jin: " + jin);
                 JSONObject jobj = new JSONObject();
                 jobj.put("identify", new JSONObject());
                 jobj.getJSONObject("identify").put("annotationIds", new JSONArray());


### PR DESCRIPTION
when a child (annotation) sub-task fails to run as identification, it is requeued as its own job, so it can be tried again.