### PR TITLE
Allow public encounters to be added to projects and more broadly viewed

### DIFF
--- a/src/main/java/org/ecocean/servlet/ProjectUpdate.java
+++ b/src/main/java/org/ecocean/servlet/ProjectUpdate.java
@@ -261,9 +261,10 @@ public class ProjectUpdate extends HttpServlet {
 
     private boolean isUserAuthorizedToAddEncounters(Project project, Shepherd myShepherd, HttpServletRequest request) {
         User currentUser = myShepherd.getUser(request);
+        if(currentUser==null) return false;
         if (isUserAuthorizedToUpdateProject(project, myShepherd, request)) return true;
         for (User user : project.getUsers()) {
-            if (user!=null&&user.equals(currentUser)) {
+            if (user!=null&&user.getUsername().equals(currentUser.getUsername())) {
                 return true;
             }
         }

--- a/src/main/java/org/ecocean/servlet/ServletUtilities.java
+++ b/src/main/java/org/ecocean/servlet/ServletUtilities.java
@@ -399,6 +399,9 @@ public class ServletUtilities {
         //user-specific checks
         else if ((enc.getSubmitterID() != null) && (request.getRemoteUser() != null)) {
           
+          //allow access to public encounters
+          if(enc.getSubmitterID().equals("public")) return true;
+          
           //if the current user owns the Encounter, they obviously have permission
           if(enc.getSubmitterID().equals(request.getRemoteUser())) {isOwner = true;}
           //if the current user is the orgAdmin for the other user, they can ave permission


### PR DESCRIPTION
Allow public encounters to be added to projects

PR fixes #329 

**Changes**
- allow broader access to public encounters for all logged in users
- specifically allow public encounters to be added to projects
- better check project access via username (not comparing user objects)
