### PR TITLE
Picturebook image fix

### DIFF
--- a/src/main/webapp/pictureBook.jsp
+++ b/src/main/webapp/pictureBook.jsp
@@ -159,7 +159,7 @@ org.datanucleus.api.rest.orgjson.JSONObject" %>
 		width: 100%;
 		max-height: 50%;
 		position: relative;
-		display: inline-block;
+		display: inline;
 		overflow: hidden;
 		max-height: 50%;
 		top: 0


### PR DESCRIPTION
The 'pictureBook-images' div element in pictureBook.jsp had CSS display style 'inline-block', this was changed to 'inline' to fix the issue.

PR fixes #273

**Changes**
- CSS display style changed from 'inline-block' to 'inline' for 'pictureBook-images' div element.