### PR TITLE
Org admin broader collab

### DIFF
--- a/src/main/java/org/ecocean/security/Collaboration.java
+++ b/src/main/java/org/ecocean/security/Collaboration.java
@@ -174,10 +174,35 @@ public class Collaboration implements java.io.Serializable {
 		//myShepherd.setAction("Collaboration.class1");
 		Query query = myShepherd.getPM().newQuery(queryString);
     //ArrayList got = myShepherd.getAllOccurrences(query);
-		List returnMe=myShepherd.getAllOccurrences(query);
+		//List returnMe=myShepherd.getAllOccurrences(query);
+		Collection c = (Collection) (query.execute());
+		ArrayList<Collaboration> returnMe = new ArrayList<Collaboration>(c);
 		query.closeAll();
+		
+		//orgAdmin check
+		//for the current user, check if they're an orgAdmin and therefore get default collaborations with all members
+		//in which we assume that an orgAdmin only belongs to one org
+		//and has a default, edit-level collaboration with all users in org
+		if(myShepherd.doesUserHaveRole(username, "orgAdmin", myShepherd.getContext())) {
+		  if(myShepherd.getUser(username)!=null) {
+		    List<Organization> orgs=myShepherd.getAllOrganizationsForUser(myShepherd.getUser(username));
+		    //while we assume they are in only one org, there must be exceptions, so be prepared for multi-org orgadmins here
+		    for(Organization org:orgs) {
+		      List<User> users=org.getMembers();
+		      for(User user:users) {
+		        if(user.getUsername()!=null && !user.getUsername().equals(username)) {
+		          //so this is someone else than the orgAdmin and therefore someone we should have a default
+		          //edit-level collaboration with
+		          Collaboration tempCollab = new Collaboration(username,user.getUsername());
+		          tempCollab.setState(STATE_EDIT_PRIV);
+		          tempCollab.setEditInitiator(username);
+		          returnMe.add(tempCollab);		        }
+		      }
+		    }
+		  }
+		  
+		}
     return returnMe;
-
 	}
 
 
@@ -199,6 +224,31 @@ public class Collaboration implements java.io.Serializable {
 		query.closeAll();
 		myShepherd.rollbackDBTransaction();
 		myShepherd.closeDBTransaction();
+		
+    //orgAdmin check
+    //for the current user, check if they're an orgAdmin and therefore get default collaborations with all members
+    //in which we assume that an orgAdmin only belongs to one org
+    //and has a default, edit-level collaboration with all users in org
+    if(myShepherd.doesUserHaveRole(username, "orgAdmin", myShepherd.getContext())) {
+      if(myShepherd.getUser(username)!=null) {
+        List<Organization> orgs=myShepherd.getAllOrganizationsForUser(myShepherd.getUser(username));
+        //while we assume they are in only one org, there must be exceptions, so be prepared for multi-org orgadmins here
+        for(Organization org:orgs) {
+          List<User> users=org.getMembers();
+          for(User user:users) {
+            if(user.getUsername()!=null && !user.getUsername().equals(username)) {
+              //so this is someone else than the orgAdmin and therefore someone we should have a default
+              //edit-level collaboration with
+              Collaboration tempCollab = new Collaboration(username,user.getUsername());
+              tempCollab.setState(STATE_EDIT_PRIV);
+              tempCollab.setEditInitiator(username);
+              returnMe.add(tempCollab);           }
+          }
+        }
+      }
+      
+    }
+		
     return returnMe;
 	}
 
@@ -237,6 +287,30 @@ public class Collaboration implements java.io.Serializable {
 		  myShepherd.rollbackDBTransaction();
 		  myShepherd.closeDBTransaction();
 		}
+		
+    //orgAdmin check
+    //for username1, check if they're an orgAdmin and therefore get default collaborations with all members
+    //in which we assume that an orgAdmin only belongs to one org
+    //and has a default, edit-level collaboration with all users in org
+    if(myShepherd.doesUserHaveRole(username1, "orgAdmin", myShepherd.getContext())) {
+      if(myShepherd.getUser(username1)!=null) {
+        List<Organization> orgs=myShepherd.getAllOrganizationsForUser(myShepherd.getUser(username1));
+        //while we assume they are in only one org, there must be exceptions, so be prepared for multi-org orgadmins here
+        for(Organization org:orgs) {
+          List<User> users=org.getMembers();
+          for(User user:users) {
+            if(user.getUsername()!=null && !user.getUsername().equals(username1)) {
+              //so this is someone else than the orgAdmin and therefore someone we should have a default
+              //edit-level collaboration with
+              Collaboration tempCollab = new Collaboration(username1,user.getUsername());
+              tempCollab.setState(STATE_EDIT_PRIV);
+              tempCollab.setEditInitiator(username1);
+              results.add(tempCollab);           }
+          }
+        }
+      }
+      
+    }
 
 		if (results == null || results.size()<1) return null;
 		return ((Collaboration) results.get(0));

--- a/src/main/java/org/ecocean/security/Collaboration.java
+++ b/src/main/java/org/ecocean/security/Collaboration.java
@@ -179,29 +179,8 @@ public class Collaboration implements java.io.Serializable {
 		ArrayList<Collaboration> returnMe = new ArrayList<Collaboration>(c);
 		query.closeAll();
 		
-		//orgAdmin check
-		//for the current user, check if they're an orgAdmin and therefore get default collaborations with all members
-		//in which we assume that an orgAdmin only belongs to one org
-		//and has a default, edit-level collaboration with all users in org
-		if(myShepherd.doesUserHaveRole(username, "orgAdmin", myShepherd.getContext())) {
-		  if(myShepherd.getUser(username)!=null) {
-		    List<Organization> orgs=myShepherd.getAllOrganizationsForUser(myShepherd.getUser(username));
-		    //while we assume they are in only one org, there must be exceptions, so be prepared for multi-org orgadmins here
-		    for(Organization org:orgs) {
-		      List<User> users=org.getMembers();
-		      for(User user:users) {
-		        if(user.getUsername()!=null && !user.getUsername().equals(username)) {
-		          //so this is someone else than the orgAdmin and therefore someone we should have a default
-		          //edit-level collaboration with
-		          Collaboration tempCollab = new Collaboration(username,user.getUsername());
-		          tempCollab.setState(STATE_EDIT_PRIV);
-		          tempCollab.setEditInitiator(username);
-		          returnMe.add(tempCollab);		        }
-		      }
-		    }
-		  }
-		  
-		}
+		returnMe=(ArrayList<Collaboration>)addAssumedOrgAdminCollaborations(returnMe, myShepherd, username);
+		
     return returnMe;
 	}
 
@@ -225,29 +204,7 @@ public class Collaboration implements java.io.Serializable {
 		myShepherd.rollbackDBTransaction();
 		myShepherd.closeDBTransaction();
 		
-    //orgAdmin check
-    //for the current user, check if they're an orgAdmin and therefore get default collaborations with all members
-    //in which we assume that an orgAdmin only belongs to one org
-    //and has a default, edit-level collaboration with all users in org
-    if(myShepherd.doesUserHaveRole(username, "orgAdmin", myShepherd.getContext())) {
-      if(myShepherd.getUser(username)!=null) {
-        List<Organization> orgs=myShepherd.getAllOrganizationsForUser(myShepherd.getUser(username));
-        //while we assume they are in only one org, there must be exceptions, so be prepared for multi-org orgadmins here
-        for(Organization org:orgs) {
-          List<User> users=org.getMembers();
-          for(User user:users) {
-            if(user.getUsername()!=null && !user.getUsername().equals(username)) {
-              //so this is someone else than the orgAdmin and therefore someone we should have a default
-              //edit-level collaboration with
-              Collaboration tempCollab = new Collaboration(username,user.getUsername());
-              tempCollab.setState(STATE_EDIT_PRIV);
-              tempCollab.setEditInitiator(username);
-              returnMe.add(tempCollab);           }
-          }
-        }
-      }
-      
-    }
+   returnMe=addAssumedOrgAdminCollaborations(returnMe, myShepherd, username);
 		
     return returnMe;
 	}
@@ -288,29 +245,7 @@ public class Collaboration implements java.io.Serializable {
 		  myShepherd.closeDBTransaction();
 		}
 		
-    //orgAdmin check
-    //for username1, check if they're an orgAdmin and therefore get default collaborations with all members
-    //in which we assume that an orgAdmin only belongs to one org
-    //and has a default, edit-level collaboration with all users in org
-    if(myShepherd.doesUserHaveRole(username1, "orgAdmin", myShepherd.getContext())) {
-      if(myShepherd.getUser(username1)!=null) {
-        List<Organization> orgs=myShepherd.getAllOrganizationsForUser(myShepherd.getUser(username1));
-        //while we assume they are in only one org, there must be exceptions, so be prepared for multi-org orgadmins here
-        for(Organization org:orgs) {
-          List<User> users=org.getMembers();
-          for(User user:users) {
-            if(user.getUsername()!=null && !user.getUsername().equals(username1)) {
-              //so this is someone else than the orgAdmin and therefore someone we should have a default
-              //edit-level collaboration with
-              Collaboration tempCollab = new Collaboration(username1,user.getUsername());
-              tempCollab.setState(STATE_EDIT_PRIV);
-              tempCollab.setEditInitiator(username1);
-              results.add(tempCollab);           }
-          }
-        }
-      }
-      
-    }
+    results=(ArrayList<Collaboration>)addAssumedOrgAdminCollaborations(results, myShepherd, username1);
 
 		if (results == null || results.size()<1) return null;
 		return ((Collaboration) results.get(0));
@@ -573,6 +508,34 @@ System.out.println("username->"+username);
 	}
 */
 
-
+private static List<Collaboration> addAssumedOrgAdminCollaborations(List<Collaboration> returnMe, Shepherd myShepherd, String username){
+  
+  //orgAdmin check
+  //for the current user, check if they're an orgAdmin and therefore get default collaborations with all members
+  //in which we assume that an orgAdmin only belongs to one org
+  //and has a default, edit-level collaboration with all users in org
+  if(returnMe !=null && myShepherd.doesUserHaveRole(username, "orgAdmin", myShepherd.getContext())) {
+    if(myShepherd.getUser(username)!=null) {
+      List<Organization> orgs=myShepherd.getAllOrganizationsForUser(myShepherd.getUser(username));
+      //while we assume they are in only one org, there must be exceptions, so be prepared for multi-org orgadmins here
+      for(Organization org:orgs) {
+        List<User> users=org.getMembers();
+        for(User user:users) {
+          if(user.getUsername()!=null && !user.getUsername().equals(username)) {
+            //so this is someone else than the orgAdmin and therefore someone we should have a default
+            //edit-level collaboration with
+            Collaboration tempCollab = new Collaboration(username,user.getUsername());
+            tempCollab.setState(STATE_EDIT_PRIV);
+            tempCollab.setEditInitiator(username);
+            returnMe.add(tempCollab);           }
+        }
+      }
+    }
+    
+  }
+  return returnMe;
+  
+}
+	
 
 }


### PR DESCRIPTION
Allows users with the orgAdmin role to dynamically receive an edit-level Collaboration with anyone in their organization. The collaboration is one-way, and only the orgAdmin should dynamically receive it to get full access permissions. users without orgAdmin role do not get a collaboration with their orgAdmin dynamically.
