### PR TITLE
Names Cache: call onces and prevent rare lockup on restart

### DIFF
--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -2622,7 +2622,11 @@ public Float getMinDistanceBetweenTwoMarkedIndividuals(MarkedIndividual otherInd
         NAMES_KEY_CACHE = new HashMap<Integer,String>();
         Query query = myShepherd.getPM().newQuery("SELECT FROM org.ecocean.MarkedIndividual");
         Collection c = (Collection) (query.execute());
+        int numIndividuals = c.size();
+        int currentIndy=0;
         for (Object m : c) {
+            currentIndy++;
+            myShepherd.setAction("MarkedIndividual.initNamesCache_"+currentIndy+"_"+numIndividuals);
             MarkedIndividual ind = (MarkedIndividual) m;
             if (ind.names == null) continue;
             NAMES_CACHE.put(ind.names.getId(), ind.getId() + ";" + String.join(";", ind.names.getAllValues()).toLowerCase());

--- a/src/main/java/org/ecocean/StartupWildbook.java
+++ b/src/main/java/org/ecocean/StartupWildbook.java
@@ -50,11 +50,6 @@ public class StartupWildbook implements ServletContextListener {
     ensureTomcatUserExists(myShepherd);
     ensureAssetStoreExists(request, myShepherd);
     ensureProfilePhotoKeywordExists(myShepherd);
-    
-    //moved initNamesCache here
-    System.out.println("XXXXXXXXXX INIT NAMES CACHE sTART");
-    boolean cached=org.ecocean.MarkedIndividual.initNamesCache(myShepherd);
-    System.out.println("XXXXXXXXXX INIT NAMES CACHE END: "+cached);
 
   }
 
@@ -155,9 +150,26 @@ public class StartupWildbook implements ServletContextListener {
 
         try {
             startWildbookScheduledTaskThread(context);
-        } catch (Exception e) {
-            e.printStackTrace();
         } 
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+        
+        //initialize the MarkedIndividual names cache
+        //moved initNamesCache here
+        Shepherd myShepherd=new Shepherd(context);
+        myShepherd.setAction("MarkedIndividual.initNamesCache");
+        myShepherd.beginDBTransaction();
+        try {
+          System.out.println("XXXXXXXXXX INIT NAMES CACHE sTART");
+          boolean cached=org.ecocean.MarkedIndividual.initNamesCache(myShepherd);
+          System.out.println("XXXXXXXXXX INIT NAMES CACHE END: "+cached);
+        }
+        catch (Exception f) {
+          f.printStackTrace();
+        }
+        finally {myShepherd.rollbackAndClose();}
+        
     }
 
 

--- a/src/main/java/org/ecocean/StartupWildbook.java
+++ b/src/main/java/org/ecocean/StartupWildbook.java
@@ -50,6 +50,11 @@ public class StartupWildbook implements ServletContextListener {
     ensureTomcatUserExists(myShepherd);
     ensureAssetStoreExists(request, myShepherd);
     ensureProfilePhotoKeywordExists(myShepherd);
+    
+    //moved initNamesCache here
+    System.out.println("XXXXXXXXXX INIT NAMES CACHE sTART");
+    boolean cached=org.ecocean.MarkedIndividual.initNamesCache(myShepherd);
+    System.out.println("XXXXXXXXXX INIT NAMES CACHE END: "+cached);
 
   }
 

--- a/src/main/webapp/header.jsp
+++ b/src/main/webapp/header.jsp
@@ -45,7 +45,6 @@ Shepherd myShepherd = new Shepherd(context);
 myShepherd.setAction("header.jsp");
 String urlLoc = "//" + CommonConfiguration.getURLLocation(request);
 
-if (org.ecocean.MarkedIndividual.initNamesCache(myShepherd)) System.out.println("INFO: MarkedIndividual.NAMES_CACHE initialized");
 
 String pageTitle = (String)request.getAttribute("pageTitle");  //allows custom override from calling jsp (must set BEFORE include:header)
 if (pageTitle == null) {


### PR DESCRIPTION
This PR moves the names cache initialization (e.g., looking up individuals by name) to a better location where it will only be initialized once. This prevents the rare issue of Wildbook lockup when there is heavy traffic on Tomcat restart.

