### PR TITLE
#365 Individuals page link interactions

### DIFF
--- a/src/main/webapp/individualSearchResults.jsp
+++ b/src/main/webapp/individualSearchResults.jsp
@@ -322,7 +322,7 @@
 			}
 		$('#results-table').append(th + '</tr></thead>');
 		for (var i = 0 ; i < howMany ; i++) {
-			var r = '<tr onClick="return rowClick(this);" class="clickable pageableTable-visible">';
+			var r = '<tr onClick="return rowClick(this);" onAuxClick="return rowClick(this);" class="clickable pageableTable-visible">';
 			for (var c = 0 ; c < colDefn.length ; c++) {
 				r += '<td class="ptcol-' + colDefn[c].key + '"></td>';
 			}
@@ -353,7 +353,8 @@
 
 	function rowClick(el) {
 		console.log(el);
-		var w = window.open('individuals.jsp?number=' + el.getAttribute('data-id'), '_blank');
+		var target = (event.metaKey && event.button == 0) || (event.button == 1) ? '_blank' : '_self';
+		var w = window.open('individuals.jsp?number=' + el.getAttribute('data-id'), target);
 		w.focus();
 		return false;
 	}
@@ -421,8 +422,14 @@
   		$('#results-table tbody tr')[i].title = title;
 			//$('#results-table tbody tr')[i].title = 'Encounter ' + searchResults[results[i]].id;
 			$('#results-table tbody tr')[i].setAttribute('data-id', searchResults[results[i]].individualID);
+			var individualLink = "individuals.jsp?number=" + searchResults[results[i]].individualID;
 			for (var c = 0 ; c < colDefn.length ; c++) {
-				$('#results-table tbody tr')[i].children[c].innerHTML = '<div>' + sTable.values[results[i]][c] + '</div>';
+				if (c == 1) {
+					$('#results-table tbody tr')[i].children[c].innerHTML = '<a href="'+individualLink+'">' + sTable.values[results[i]][c] + '</a>';
+				}
+				else {
+					$('#results-table tbody tr')[i].children[c].innerHTML = '<div>' + sTable.values[results[i]][c] + '</div>';
+				}
 			}
 		}
 		if (results.length < howMany) {

--- a/src/main/webapp/individuals.jsp
+++ b/src/main/webapp/individuals.jsp
@@ -2598,6 +2598,16 @@ if (sharky.getNames() != null) {
 
    </script>
 
+   <script type="text/javascript">
+		function encountTableAuxClick(el) {
+			goToEncounterURL(el.getAttribute("class"));
+			return false;
+		}
+		function cooccurTableAuxClick(el) {
+			goToWhaleURL(el.getAttribute("class"));
+    		return false;
+		}
+   </script>
 
 </div>
 

--- a/src/main/webapp/javascript/bubbleDiagram/encounter-calls.js
+++ b/src/main/webapp/javascript/bubbleDiagram/encounter-calls.js
@@ -84,10 +84,12 @@ var getData = function(individualID, displayName) {
 	//}
 	
 	makeTable(items, "#coHead", "#coBody", null,["occurringWith", "occurrenceNumber","sex","location"]);
-	$('#cooccurrenceTable tr').click(function() {
-            selectedWhale = ($(this).attr("class"));
-            goToWhaleURL(selectedWhale);
-	});
+	$('#cooccurrenceTable tr').attr("onClick", "return cooccurTableAuxClick(this);")
+							  .attr("onAuxClick", "return cooccurTableAuxClick(this);")
+							  .each(function() {
+								indivUrl = "individuals.jsp?number=" + ($(this).attr("class"));
+								$(this).find("td").first().wrapInner("<a href=\""+indivUrl+"\"></a>");
+							  });
 	
 	getEncounterTableData(occurrenceObjectArray, individualID);
     });
@@ -227,11 +229,11 @@ var makeTable = function(items, tableHeadLocation, tableBodyLocation, sortOn, ke
 			return d[0].italics() + "-" + d[1];
 		    }
 		    if(d.length > 2) {
-			return "<a target='_blank' href='individuals.jsp?number=" + d[0] + "'>" + d[5] + "</a><br><span>" + dict['nickname'] + " : " + d[1]+ "</span><br><span>" + dict['alternateID'] + ": " + d[2] + "</span><br><span>" + dict['sex'] + ": " + d[3] + "</span><br><span>" + dict['haplotype'] +": " + d[4] + "</span>";
+			return "<a href='individuals.jsp?number=" + d[0] + "'>" + d[5] + "</a><br><span>" + dict['nickname'] + " : " + d[1]+ "</span><br><span>" + dict['alternateID'] + ": " + d[2] + "</span><br><span>" + dict['sex'] + ": " + d[3] + "</span><br><span>" + dict['haplotype'] +": " + d[4] + "</span>";
 		    }
 		}
 		if(d == "GOS") {
-		    return "<a target='_blank' href='socialUnit.jsp?name=" + d + "'>" + d + "</a>"
+		    return "<a href='socialUnit.jsp?name=" + d + "'>" + d + "</a>"
 		}
 		return d; 
 	    });
@@ -407,14 +409,14 @@ var makeRelTable = function(items, tableHeadLocation, tableBodyLocation, sortOn)
 				    	return "<button type='button' name='button' value='" + d[1] + "' class='btn btn-sm btn-block deleteRelationshipBtn' id='remove" + d[1] + "'>Remove</button><div class='confirmDelete' value='" + d[1] + "'><p>Are you sure you want to delete this relationship?</p><button class='btn btn-sm btn-block yesDelete' type='button' name='button' value='" +d[1]+ "'>Yes</button><button class='btn btn-sm btn-block cancelDelete' type='button' name='button' value='" + d[1] + "'>No</button></div>";
 					}
 					if(d.length > 2) {
-						return "<a target='_blank' href='individuals.jsp?number=" + d[0] + "'>" + d[5] + "</a><br><span>" + dict['nickname'] + " : " + d[1]+ "</span><br><span>" + dict['alternateID'] + ": " + d[2] + "</span><br><span>" + dict['sex'] + ": " + d[3] + "</span><br><span>" + dict['haplotype'] +": " + d[4] + "</span>";
+						return "<a href='individuals.jsp?number=" + d[0] + "'>" + d[5] + "</a><br><span>" + dict['nickname'] + " : " + d[1]+ "</span><br><span>" + dict['alternateID'] + ": " + d[2] + "</span><br><span>" + dict['sex'] + ": " + d[3] + "</span><br><span>" + dict['haplotype'] +": " + d[4] + "</span>";
 			    	}
 					return d[0].italics() + "-" + d[1];
 			    	//}
 			    
 				}
 				if(d == "socialUnit") {
-			    	return "<a target='_blank' href='socialUnit.jsp?name=" + d + "'>" + d + "</a>"
+			    	return "<a href='socialUnit.jsp?name=" + d + "'>" + d + "</a>"
 				}
 			
 				//couldn't find it so dump it as text
@@ -543,19 +545,23 @@ var getEncounterTableData = function(occurrenceObjectArray, individualID) {
             encounterData.push(encounter);
 	}
 	makeTable(encounterData, "#encountHead", "#encountBody", "date", null);
-	$('#encountTable tr').click(function() {
-            selectedWhale = ($(this).attr("class"));
-            goToEncounterURL(selectedWhale);
-	});
+	$('#encountTable tr').attr("onClick", "return encountTableAuxClick(this);")
+						 .attr("onAuxClick", "return encountTableAuxClick(this);")
+						 .each(function() {
+							encountUrl = "encounters/encounter.jsp?number=" + ($(this).attr("class"));
+							$(this).find("td").first().wrapInner("<a href=\""+encountUrl+"\"></a>");
+						 });
     });
 }
 
 var goToEncounterURL = function(selectedWhale) {
-    window.open(wildbookGlobals.baseUrl + "/encounters/encounter.jsp?number=" + selectedWhale);
+	var target = (event.metaKey && event.button == 0) || (event.button == 1) ? '_blank' : '_self';
+    window.open(wildbookGlobals.baseUrl + "/encounters/encounter.jsp?number=" + selectedWhale, target);
 }
 
 var goToWhaleURL = function(selectedWhale) {
-    window.open(wildbookGlobals.baseUrl + "/individuals.jsp?number=" + selectedWhale);
+	var target = (event.metaKey && event.button == 0) || (event.button == 1) ? '_blank' : '_self';
+    window.open(wildbookGlobals.baseUrl + "/individuals.jsp?number=" + selectedWhale, target);
 }
 
 var getRelationshipData = function(relationshipID) {


### PR DESCRIPTION
Event button and meta key used to differentiate between various clicks and open the links accordingly on the Individuals page. AuxClick event handling added for middle-click on browsers such as Chrome. Content within one of the columns (which is expected to have unique values) wrapped within an anchor 'a' element for users to right-click and open links on a new tab. Some of the existing anchor 'a' elements on the page had target = '_blank' attribute, this has been excluded for the links to show standard link behaviour as expected.

PR fixes #365 

**Changes**
Functions added: encountTableAuxClick and cooccurTableAuxClick on individuals.jsp 
Functions edited: getData, getEncounterTableData, goToEncounterURL, goToWhaleURL, makeTable, makeRelTable on encounter-calls.js and doTable, rowClick on individualSearchResults.jsp

Callout:

1. While applying fix for the issue on the Individuals page, the issue was also seen on the Individual Search Results page. Fix has also been applied for the Individual Search Results page as part of this PR since users navigate to the Individuals page through this page.

2. The links in the Individuals page and Individuals Search results page are clickable table row 'tr' elements, not anchor 'a' elements. On right-click, the default browser menu does not show the 'Open link in new tab' option for table row elements. This was called out in #292. As a workaround, in this PR, content within one of the columns (which is expected to have unique values) has been wrapped within an anchor 'a' element for tables in Individuals page and Individuals Search results page. Users could now right-click on the links within these columns, which show the expected standard link behaviour, to open links in a new tab.

3. Event has been added as an attribute to HTML through attr method within encounter-calls.js in this PR, instead of binding the event through click method. This is because, when binding through click method, the link added by wrapping with the anchor 'a' element gets opened twice upon middle-click or cmd + click on some browsers. This does not happen when the event is added to the HTML through attr method instead.

4. Another existing issue was seen, in the Co-occurrences table on Individuals page, while applying fix for this issue. Individual id is not getting appended properly to the Co-occurrences table links, hence clicking on the table rows does not navigate to proper URLs. Details provided on #365 comments.
