### PR TITLE
Added use case where a second part on an image forces a cloned Encounter

### DIFF
--- a/src/main/webapp/encounters/manualAnnotation.jsp
+++ b/src/main/webapp/encounters/manualAnnotation.jsp
@@ -300,6 +300,15 @@ try{
 		}
 		
 	}
+	else if(annots.size()==1 && !annots.get(0).isTrivial() && iaClass!=null &&  iaClass.indexOf("+")>-1){
+		//exception case - if there is only one annotation and it is a part
+		if(annots.size()==1){
+			Annotation annot1 = annots.get(0);
+			if(annot1.getIAClass()!=null && annot1.getIAClass().indexOf("+")!=-1){
+				cloneEncounter=true;
+			}
+		}
+	}
 
 
 

--- a/src/main/webapp/encounters/manualAnnotation.jsp
+++ b/src/main/webapp/encounters/manualAnnotation.jsp
@@ -291,12 +291,11 @@ try{
 		cloneEncounter=true;
 		
 		//exception case - if there is only one annotation and it is a part
-		if(annots.size()==1){
-			Annotation annot1 = annots.get(0);
-			if(annot1.getIAClass()!=null && annot1.getIAClass().indexOf("+")!=-1){
-				cloneEncounter=false;
-			}
+		Annotation annot1 = annots.get(0);
+		if(annot1.getIAClass()!=null && annot1.getIAClass().indexOf("+")!=-1){
+			cloneEncounter=false;
 		}
+
 		
 	}
 	else if(annots.size()==1 && !annots.get(0).isTrivial() && iaClass!=null &&  iaClass.indexOf("+")>-1){

--- a/src/main/webapp/encounters/manualAnnotation.jsp
+++ b/src/main/webapp/encounters/manualAnnotation.jsp
@@ -282,9 +282,8 @@ try{
 
 	//we would expect at least a trivial annotation, so if annots>=2, we know we need to clone
 	//also don't clone if this is a part
-	if(annots.size()>1 && iaClass!=null && iaClass.indexOf("+")==-1){
+	if(annots.size()>1 && iaClass!=null){
 		cloneEncounter=true;
-		
 	}
 	//also don't clone if this is a part
 	//if the one annot isn't trivial, then we have to clone the encounter as well
@@ -302,12 +301,12 @@ try{
 	}
 	else if(annots.size()==1 && !annots.get(0).isTrivial() && iaClass!=null &&  iaClass.indexOf("+")>-1){
 		//exception case - if there is only one annotation and it is a part
-		if(annots.size()==1){
+
 			Annotation annot1 = annots.get(0);
 			if(annot1.getIAClass()!=null && annot1.getIAClass().indexOf("+")!=-1){
 				cloneEncounter=true;
 			}
-		}
+
 	}
 
 


### PR DESCRIPTION
Additional logic to ensure that if you draw a part on top of an image that already has another part then the new part is forced onto a separate encounter. This primarily addresses the use case of many finned species in which we only allow drawing fin parts, such that every additional part is the fin of another individual.
