### PR TITLE
Dependabot Reactivation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/" # Location of pom.xml
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"  #actions are all over the build, need to clean up before can get specific
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
weekly dependabot run for github actions and maven dependencies. no automated acceptance

**Changes**
- devops update
