### PR TITLE
Bulk import validation - species

### DIFF
--- a/src/main/java/org/ecocean/importutils/RowFeedback.java
+++ b/src/main/java/org/ecocean/importutils/RowFeedback.java
@@ -66,12 +66,14 @@ public class RowFeedback {
             CellFeedback cellFeedback = this.cells[colNum];
             System.out.println("Setting ERROR value on OLD CellFeedback for col "+colNum+" val "+String.valueOf(value)+" row "+row.getRowNum());
             // I think we can assume a BLANK or NULL cell doesn't need to get overwritten with an error. 
-            if (!cellFeedback.isBlank()) {
-              this.cells[colNum].setSuccess(false);
-              //TODO replace this universal NOT FOUND for an overwrite with something specific.
-              this.cells[colNum].setValueString(value+" NOT FOUND");
-            }
-          } else {
+            //if (!cellFeedback.isBlank()) {
+            this.cells[colNum].setSuccess(false);
+            this.cells[colNum].setIsBlank(false);
+            //TODO replace this universal NOT FOUND for an overwrite with something specific.
+            this.cells[colNum].setValueString(value+" NOT FOUND");
+            //}
+          } 
+          else {
             System.out.println("Setting ERROR value on NEW CellFeedback for col "+colNum+" val "+String.valueOf(value)+" row "+row.getRowNum());
             this.cells[colNum] = new CellFeedback(value, false, false);
           }

--- a/src/main/java/org/ecocean/importutils/RowFeedback.java
+++ b/src/main/java/org/ecocean/importutils/RowFeedback.java
@@ -58,8 +58,12 @@ public class RowFeedback {
         } 
       }
     }
-
+    
     public void logParseError(int colNum, Object value, Row row) {
+    	logParseError(colNum, value, row, null);
+    }
+
+    public void logParseError(int colNum, Object value, Row row, String exactMessageToDisplay) {
       try {
         if (!committing) {
           if (colNum<this.cells.length&&this.cells[colNum]!=null) {
@@ -70,7 +74,12 @@ public class RowFeedback {
             this.cells[colNum].setSuccess(false);
             this.cells[colNum].setIsBlank(false);
             //TODO replace this universal NOT FOUND for an overwrite with something specific.
-            this.cells[colNum].setValueString(value+" NOT FOUND");
+            if(exactMessageToDisplay!=null) {
+            	this.cells[colNum].setValueString(exactMessageToDisplay);
+            }
+            else {
+            	this.cells[colNum].setValueString(value+" NOT FOUND");
+            }
             //}
           } 
           else {

--- a/src/main/java/org/ecocean/importutils/TabularFeedback.java
+++ b/src/main/java/org/ecocean/importutils/TabularFeedback.java
@@ -100,10 +100,14 @@ public class TabularFeedback {
     }
 
     public void logParseError(int colNum, Object value, Row row) {
-      if (!committing) {
-        this.currentRow.logParseError(colNum, value, row);
-      }
+    	logParseError(colNum, value, row, null);
     }
+    
+    public void logParseError(int colNum, Object value, Row row, String exactMessageToDisplay) {
+        if (!committing) {
+          this.currentRow.logParseError(colNum, value, row, exactMessageToDisplay);
+        }
+      }
 
     public void logParseNoValue(int colNum) {
       if (!committing) {

--- a/src/main/java/org/ecocean/servlet/importer/StandardImport.java
+++ b/src/main/java/org/ecocean/servlet/importer/StandardImport.java
@@ -551,7 +551,7 @@ public class StandardImport extends HttpServlet {
     }
 
     out.println("<div class=\"col-sm-12 col-md-6 col-lg-6 col-xl-6\">"); // half page bootstrap column
-    out.println("<h2>Import Overview: </h2>");
+    out.println("<h2>Import Overview</h2>");
     out.println("<ul>");
     out.println("<li>Excel File Name: "+filename+"</li>");
     out.println("<li>Excel File Successfully Found = "+dataFound+"</li>");
@@ -560,8 +560,17 @@ public class StandardImport extends HttpServlet {
     out.println("<li>Excel Columns = "+cols+"</li>");
     //out.println("<li>Last col num = "+lastColNum+"</li>");
     out.println("<li><em>Trial Run: "+!committing+"</em></li>");
-
     out.println("</ul>");
+    
+    out.println("<h3 style='color: red;'>Errors</h3>");
+    out.println("<p>Number of errors: <span id='errorCount'></span></p>");
+    out.println("<script>");
+    out.println("     const err_elements = document.querySelectorAll('.cellFeedback.error');");
+    out.println("     const errorCount = err_elements.length;");
+    out.println("     document.getElementById('errorCount').textContent=errorCount");
+    out.println("</script>");
+    
+    
 
     String uName = request.getUserPrincipal().getName();
     if (committing&&uName!=null) out.println("<p><a href=\"../encounters/searchResults.jsp?username="+uName+"\">Search encounters owned by current user \""+uName+"\"</a></p>");

--- a/src/main/java/org/ecocean/servlet/importer/StandardImport.java
+++ b/src/main/java/org/ecocean/servlet/importer/StandardImport.java
@@ -564,32 +564,38 @@ public class StandardImport extends HttpServlet {
     out.println("<li><em>Trial Run: "+!committing+"</em></li>");
     out.println("</ul>");
     
-    out.println("<h3 style='color: red;'>Errors</h3>");
+    out.println("<h3 id='errorHeader' style='color: red;'>Errors</h3>");
     out.println("<p>Number of errors: <span id='errorCount'></span></p>");
     out.println("<p>Error columns: <span id='errorElements'></span></p>");
     out.println("<script>");
     out.println("	  var errorElementNames = [];");
     out.println("     const err_elements = document.querySelectorAll('.cellFeedback.error');");
     out.println("     const errorCount = err_elements.length;");
-    out.println("     for (var i = 0; i < err_elements.length; i ++ ){");
-    out.println("       console.log('count: '+i)");
-    out.println("     	var errorElement = err_elements[i];");
-    out.println("       console.log('errorElement: '+errorElement.textContent);");
-    out.println("       var table = errorElement.closest('table');");
-    out.println("       var headerRow = table.querySelector('tbody tr.headerRow');");
-    out.println("       var th = headerRow.children[errorElement.cellIndex].querySelector('th div span.tableFeedbackColumnHeader').innerHTML;");
-    out.println("       if(!errorElementNames.includes(th))errorElementNames.push(th); ");
-    out.println("     }");
     out.println("     document.getElementById('errorCount').textContent=errorCount");
-    out.println("     var errorList = document.getElementById('errorElements')");
+    out.println("     if(errorCount>0){");
+    out.println("        var errorTitle = document.getElementById('errorHeader');  ");
+    out.println("        var errorMessage = document.createElement('p');  ");
+    out.println("        errorMessage.style.color='red';  ");
+    out.println("        errorMessage.innerText='Errors are preventing submission of this bulk import.';  ");
+    out.println("        errorTitle.insertAdjacentElement('afterend', errorMessage);   ");
+
     
-    out.println("     const ul = document.createElement('ul');");
-    out.println("     errorElementNames.toString().split(',').forEach((item) => {");
+    out.println("     	for (var i = 0; i < err_elements.length; i ++ ){");
+    out.println("     		var errorElement = err_elements[i];");
+    out.println("     	  var table = errorElement.closest('table');");
+    out.println("     	  var headerRow = table.querySelector('tbody tr.headerRow');");
+    out.println("     	  var th = headerRow.children[errorElement.cellIndex].querySelector('th div span.tableFeedbackColumnHeader').innerHTML;");
+    out.println("     	  if(!errorElementNames.includes(th))errorElementNames.push(th); ");
+    out.println("     	}");
+    out.println("     	var errorList = document.getElementById('errorElements')");    
+    out.println("     	const ul = document.createElement('ul');");
+    out.println("     	errorElementNames.toString().split(',').forEach((item) => {");
     out.println("          const li = document.createElement('li');");
     out.println("     	   li.textContent = item;");
     out.println("          ul.appendChild(li);");
-    out.println("     });");
-    out.println("     errorList.appendChild(ul);");
+    out.println("     	});");
+    out.println("     	errorList.appendChild(ul);");
+    out.println("     }");
     out.println("</script>");
     
     

--- a/src/main/java/org/ecocean/servlet/importer/StandardImport.java
+++ b/src/main/java/org/ecocean/servlet/importer/StandardImport.java
@@ -910,11 +910,11 @@ public class StandardImport extends HttpServlet {
     //start check for missing or unconfigured genus+species
     if (!hasGenus) {
         //mark genus empty
-    	feedback.logParseError(getColIndexFromColName("Encounter.genus", colIndexMap),"GENUS", row);
+    	feedback.logParseError(getColIndexFromColName("Encounter.genus", colIndexMap),"GENUS", row, "MISSING GENUS");
     }
     if (!hasSpecificEpithet) {
         //mark specific epithet
-        feedback.logParseError(getColIndexFromColName("Encounter.specificEpithet", colIndexMap),"SPECIFIC EPITHET", row);
+        feedback.logParseError(getColIndexFromColName("Encounter.specificEpithet", colIndexMap),"SPECIFIC EPITHET", row, "MISSING SPECIFIC EPITHET");
     }
     //now validate that a present genus and species value are supported
     if(hasGenus && hasSpecificEpithet) {
@@ -922,8 +922,8 @@ public class StandardImport extends HttpServlet {
     	List<String> configuredSpecies = CommonConfiguration.getIndexedPropertyValues("genusSpecies", myShepherd.getContext());
     	if(configuredSpecies!=null && configuredSpecies.size()>0 && configuredSpecies.toString().indexOf(enc.getTaxonomyString())<0) {
     		//if bad values
-    		feedback.logParseError(getColIndexFromColName("Encounter.genus", colIndexMap), genus, row);
-    		feedback.logParseError(getColIndexFromColName("Encounter.specificEpithet", colIndexMap), specificEpithet, row);
+    		feedback.logParseError(getColIndexFromColName("Encounter.genus", colIndexMap), genus, row,"UNCONFIGURED VALUE: "+genus);
+    		feedback.logParseError(getColIndexFromColName("Encounter.specificEpithet", colIndexMap), specificEpithet, row, "UNCONFIGURED VALUE: "+specificEpithet);
     	}
     	
     }

--- a/src/main/java/org/ecocean/servlet/importer/StandardImport.java
+++ b/src/main/java/org/ecocean/servlet/importer/StandardImport.java
@@ -44,6 +44,8 @@ import org.joda.time.DateTimeZone;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+
+
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
@@ -564,10 +566,30 @@ public class StandardImport extends HttpServlet {
     
     out.println("<h3 style='color: red;'>Errors</h3>");
     out.println("<p>Number of errors: <span id='errorCount'></span></p>");
+    out.println("<p>Error columns: <span id='errorElements'></span></p>");
     out.println("<script>");
+    out.println("	  var errorElementNames = [];");
     out.println("     const err_elements = document.querySelectorAll('.cellFeedback.error');");
     out.println("     const errorCount = err_elements.length;");
+    out.println("     for (var i = 0; i < err_elements.length; i ++ ){");
+    out.println("       console.log('count: '+i)");
+    out.println("     	var errorElement = err_elements[i];");
+    out.println("       console.log('errorElement: '+errorElement.textContent);");
+    out.println("       var table = errorElement.closest('table');");
+    out.println("       var headerRow = table.querySelector('tbody tr.headerRow');");
+    out.println("       var th = headerRow.children[errorElement.cellIndex].querySelector('th div span.tableFeedbackColumnHeader').innerHTML;");
+    out.println("       if(!errorElementNames.includes(th))errorElementNames.push(th); ");
+    out.println("     }");
     out.println("     document.getElementById('errorCount').textContent=errorCount");
+    out.println("     var errorList = document.getElementById('errorElements')");
+    
+    out.println("     const ul = document.createElement('ul');");
+    out.println("     errorElementNames.toString().split(',').forEach((item) => {");
+    out.println("          const li = document.createElement('li');");
+    out.println("     	   li.textContent = item;");
+    out.println("          ul.appendChild(li);");
+    out.println("     });");
+    out.println("     errorList.appendChild(ul);");
     out.println("</script>");
     
     
@@ -931,8 +953,8 @@ public class StandardImport extends HttpServlet {
     	List<String> configuredSpecies = CommonConfiguration.getIndexedPropertyValues("genusSpecies", myShepherd.getContext());
     	if(configuredSpecies!=null && configuredSpecies.size()>0 && configuredSpecies.toString().indexOf(enc.getTaxonomyString())<0) {
     		//if bad values
-    		feedback.logParseError(getColIndexFromColName("Encounter.genus", colIndexMap), genus, row,"UNCONFIGURED VALUE: "+genus);
-    		feedback.logParseError(getColIndexFromColName("Encounter.specificEpithet", colIndexMap), specificEpithet, row, "UNCONFIGURED VALUE: "+specificEpithet);
+    		feedback.logParseError(getColIndexFromColName("Encounter.genus", colIndexMap), genus, row,"UNSUPPORTED VALUE: "+genus);
+    		feedback.logParseError(getColIndexFromColName("Encounter.specificEpithet", colIndexMap), specificEpithet, row, "UNSUPPORTED VALUE: "+specificEpithet);
     	}
     	
     }

--- a/src/main/webapp/import/uploadFooter.jsp
+++ b/src/main/webapp/import/uploadFooter.jsp
@@ -52,8 +52,17 @@ if (!committing) {
 %>
 	<p>If you are adding many images and encounters (more than a couple hundred if each) this may take a while. You will be redirected to a status page as the process completes.</p>
 	<p><a onclick="sendAndRedirect('<%=uploadAction %>','<%=uuid %>')"><button id="commitButton" onclick="confirmCommit()">Commit these results.</button></a></p>
+	<script>
+		console.log("Commit count: "+errorCount);
+		if(errorCount>0){
+			var commitButton = document.getElementById('commitButton');
+			commitButton.setAttribute("disabled", "disabled");
+		}
+	</script>
 <%
 }
 %>
+
+
 
 </div></div><!-- container maincontent -->


### PR DESCRIPTION
This PR addresses missing or unsupported species columns (Encounter.genus and Encounter.specificEpithet) in bulk import spreadsheets. However, it lays the foundation for reporting errors in other fields as well and blocking submission where data is missing.

Specifically:

- Adds method RowFeed.logParseError(int colNum, Object value, Row row, String exactMessageToDisplay) for more informative error messages via parameter exactMessageToDisplay
- Adds an Errors section to the Import Overview preview
- Provides a count of total errors in the spreadsheet, which can include missing images and incorrect species currently
- Throws an error if Encounter.genus and/or Encounter.specificEpithet are blank or empty strings
- Throws an error if Encounter.genus and Encounter.specificEpithet form a taxonomy not defined in commonConfiguration.properties
- Lists columns with errors in the Errors summary to help focus the user
- Blocks the "Commit these results." button if errors are >0, allowing for future behavior to also add more errors to the list of blocking errors.


![image](https://github.com/WildMeOrg/Wildbook/assets/154927/9102cb2f-cb7f-4be7-9a2b-2c81d242b918)
