### PR TITLE
Remove unneeded wbia call

### DIFF
--- a/src/main/java/org/ecocean/ia/Task.java
+++ b/src/main/java/org/ecocean/ia/Task.java
@@ -424,6 +424,8 @@ public class Task implements java.io.Serializable {
         return roots;
     }
     
+    public String getStatusNoWBIA(){return status;}
+    
     public String getStatus(Shepherd myShepherd){
       //if status is not null, just send it
       if(status!=null) return status;

--- a/src/main/java/org/ecocean/ia/Task.java
+++ b/src/main/java/org/ecocean/ia/Task.java
@@ -424,7 +424,19 @@ public class Task implements java.io.Serializable {
         return roots;
     }
     
-    public String getStatusNoWBIA(){return status;}
+    public boolean areSelfAndOrAllChildrenComplete() {
+    	boolean complete=false;
+    	if(!hasChildren()&&completionDateInMilliseconds!=null) {complete=true;}
+    	else if(hasChildren()) {
+    		List<Task> children=getChildren();
+    		complete=true;
+    		for(Task t:children) {
+    			if(!t.areSelfAndOrAllChildrenComplete())complete=false;
+    		}
+    	}
+    	return complete;
+    }
+    
     
     public String getStatus(Shepherd myShepherd){
       //if status is not null, just send it

--- a/src/main/java/org/ecocean/identity/IdentityServiceLog.java
+++ b/src/main/java/org/ecocean/identity/IdentityServiceLog.java
@@ -274,6 +274,10 @@ public class IdentityServiceLog implements java.io.Serializable {
 */
 
     public JSONObject toJSONObject() {
+    	return toJSONObject(false);
+    }
+    
+    public JSONObject toJSONObject(boolean completed) {
         JSONObject j = new JSONObject();
         j.put("serviceName", this.getServiceName());
         j.put("serviceJobId", this.getServiceJobID());
@@ -281,8 +285,13 @@ public class IdentityServiceLog implements java.io.Serializable {
         j.put("timestamp", this.getTimestamp());
         if (this.getObjectIDs() != null) j.put("objectIds", new JSONArray(this.getObjectIDs()));
         j.put("status", this.getStatusJson());
-        String queueStatus = WbiaQueueUtil.getStatusWBIAJob(this.getTaskID(), false);
-        if(queueStatus!=null)j.put("queueStatus", queueStatus);
+        if(!completed) {
+        	String queueStatus = WbiaQueueUtil.getStatusWBIAJob(this.getTaskID(), false);
+        	if(queueStatus!=null)j.put("queueStatus", queueStatus);
+        }
+        else {
+        	j.put("queueStatus", "completed");
+        }
         return j;
     }
 

--- a/src/main/java/org/ecocean/identity/IdentityServiceLog.java
+++ b/src/main/java/org/ecocean/identity/IdentityServiceLog.java
@@ -290,7 +290,7 @@ public class IdentityServiceLog implements java.io.Serializable {
         	if(queueStatus!=null)j.put("queueStatus", queueStatus);
         }
         else {
-        	j.put("queueStatus", "completed");
+        	j.put("queueStatus", "complete");
         }
         return j;
     }

--- a/src/main/webapp/iaLogs.jsp
+++ b/src/main/webapp/iaLogs.jsp
@@ -35,7 +35,6 @@ myShepherd.setAction("iaLogs.jsp");
 
 
 myShepherd.beginDBTransaction();
-long startTime=System.currentTimeMillis();
 
 //if the Task is completed, we can skip some checks
 if(request.getParameter("taskId")!=null){

--- a/src/main/webapp/iaLogs.jsp
+++ b/src/main/webapp/iaLogs.jsp
@@ -39,8 +39,8 @@ long startTime=System.currentTimeMillis();
 
 //if the Task is completed, we can skip some checks
 if(request.getParameter("taskId")!=null){
-	Task t=myShepherd.getTask(request.getParameter("taskID"));
-	if(t!=null && t.getStatusNoWBIA()!=null && t.getStatusNoWBIA().equals("completed")){
+	Task t=myShepherd.getTask(request.getParameter("taskId"));
+	if(t!=null && t.getCompletionDateInMilliseconds()!=null){
 		taskCompleted=true;
 	}
 }
@@ -53,11 +53,7 @@ try{
 	} else {
 		
 		logs = IdentityServiceLog.loadByTaskID(taskId, "IBEISIA", myShepherd);
-		long queryTime=System.currentTimeMillis();
 		Collections.reverse(logs);  //so it has newest first like mostRecent above
-		long reverseTime=System.currentTimeMillis();
-		System.out.println("Query time: "+(queryTime-startTime));
-		System.out.println("Reverse time: "+(reverseTime-queryTime));
 	}
 	
 	if (logs == null) {
@@ -80,15 +76,12 @@ try{
 			all.put(projectData);
 		}
 	}
-	System.out.println("projectTime: "+(System.currentTimeMillis()-startTime));
 	
 	for (IdentityServiceLog l : logs) {
 		all.put(l.toJSONObject(taskCompleted));
 	}
 	
-	System.out.println("islPutTime: "+(System.currentTimeMillis()-startTime));
-	
-	
+
 	out.println(all.toString());
 
 }

--- a/src/main/webapp/iaResults.jsp
+++ b/src/main/webapp/iaResults.jsp
@@ -78,37 +78,40 @@ if (Util.stringExists(projectIdPrefix)) {
 //do queue stuff
 String queueStatementID="";
 boolean fastlane=false;
+boolean taskCompleted=false;
 if(request.getParameter("taskId")!=null){
 	Task t=myShepherd.getTask(request.getParameter("taskId"));
 	if(t!=null && t.getParameters()!=null && t.getParameters().optBoolean("fastlane", false)){
 		fastlane=true;
 	}
+	if(t.getStatusNoWBIA()!=null && t.getStatusNoWBIA().equals("completed"))taskCompleted=true;
 
 }
 int wbiaIDQueueSize = 0;
-if(fastlane){wbiaIDQueueSize =  WbiaQueueUtil.getSizeDetectionJobQueue(false);}
-else{wbiaIDQueueSize = WbiaQueueUtil.getSizeIDJobQueue(false);}
-if(wbiaIDQueueSize==0){
-	queueStatementID = "The machine learning queue is working.";
-}
-else if(Prometheus.getValue("wildbook_wbia_turnaroundtime_id")!=null){
-	String val=Prometheus.getValue("wildbook_wbia_turnaroundtime_id");
-	String queueType="bulk import";
-	if(fastlane){
-		val=Prometheus.getValue("wildbook_wbia_turnaroundtime_detection");
-		queueType="small batch";
+if(!taskCompleted){
+	if(fastlane){wbiaIDQueueSize =  WbiaQueueUtil.getSizeDetectionJobQueue(false);}
+	else{wbiaIDQueueSize = WbiaQueueUtil.getSizeIDJobQueue(false);}
+	if(wbiaIDQueueSize==0){
+		queueStatementID = "The machine learning queue is working.";
 	}
-	try{
-		if(wbiaIDQueueSize>1){
-			Double d = Double.parseDouble(val);
-			d=d/60.0;
-			queueStatementID = "There are currently "+wbiaIDQueueSize+" ID jobs in the "+queueType+" queue. Time per job is averaging "+(int)Math.round(d)+" minutes based on recent matches. Your time may be much faster or slower.";
+	else if(Prometheus.getValue("wildbook_wbia_turnaroundtime_id")!=null){
+		String val=Prometheus.getValue("wildbook_wbia_turnaroundtime_id");
+		String queueType="bulk import";
+		if(fastlane){
+			val=Prometheus.getValue("wildbook_wbia_turnaroundtime_detection");
+			queueType="small batch";
 		}
+		try{
+			if(wbiaIDQueueSize>1){
+				Double d = Double.parseDouble(val);
+				d=d/60.0;
+				queueStatementID = "There are currently "+wbiaIDQueueSize+" ID jobs in the "+queueType+" queue. Time per job is averaging "+(int)Math.round(d)+" minutes based on recent matches. Your time may be much faster or slower.";
+			}
+		}
+		catch(Exception de){de.printStackTrace();}
 	}
-	catch(Exception de){de.printStackTrace();}
 }
-
-//do queue stuff
+//end do queue stuff
 
 
 

--- a/src/main/webapp/iaResults.jsp
+++ b/src/main/webapp/iaResults.jsp
@@ -84,7 +84,7 @@ if(request.getParameter("taskId")!=null){
 	if(t!=null && t.getParameters()!=null && t.getParameters().optBoolean("fastlane", false)){
 		fastlane=true;
 	}
-	if(t.getStatusNoWBIA()!=null && t.getStatusNoWBIA().equals("completed"))taskCompleted=true;
+	if(t!=null && t.areSelfAndOrAllChildrenComplete())taskCompleted=true;
 
 }
 int wbiaIDQueueSize = 0;


### PR DESCRIPTION
This change improves iaResults.jsp page display speed while reducing unnecessary traffic to and burden on WBIA. Wildbook knows when a matching Task is complete but was still sending multiple completion status queries to WBIA per page load for completed tasks, causing significant and unnecessary page load slow downs. This change now checks for Task object completion (either its own completion time is set or all completion times are set for all sub-Task node children) in the database before querying WBIA about Task status. For incomplete tasks, queries are still sent.
