### PR TITLE
Genetics Export: Filter Loci to Only Those Found in the Result Set

### DIFF
--- a/src/main/java/org/ecocean/servlet/TissueSampleSetHaplotype.java
+++ b/src/main/java/org/ecocean/servlet/TissueSampleSetHaplotype.java
@@ -74,8 +74,8 @@ public class TissueSampleSetHaplotype extends HttpServlet {
         enc.addComments("<p><em>" + request.getRemoteUser() + " on " + (new java.util.Date()).toString() + "</em><br />" + "Added or updated mitochondrial DNA analysis (haplotype) "+request.getParameter("analysisID")+" for tissue sample "+request.getParameter("sampleID")+".<br />"+mtDNA.getHTMLString());
         
         //check if this affects the MarkedIndividual.localHaplotypeReflection
-        if(enc.getIndividualID()!=null){
-            MarkedIndividual indie=myShepherd.getMarkedIndividual(enc.getIndividualID());
+        if(enc.getIndividual()!=null){
+            MarkedIndividual indie=myShepherd.getMarkedIndividual(enc.getIndividual().getIndividualID());
             indie.doNotSetLocalHaplotypeReflection(mtDNA.getHaplotype());
         }
 

--- a/src/main/java/org/ecocean/servlet/export/KinalyzerExport.java
+++ b/src/main/java/org/ecocean/servlet/export/KinalyzerExport.java
@@ -97,10 +97,22 @@ public class KinalyzerExport extends HttpServlet{
         //iterate through the loci
         List<String> loci=myShepherd.getAllLoci();
         int numLoci=loci.size();
+        ArrayList<String> allowedLoci=new ArrayList<String>();
+        
+        //filter to only loci of query individuals
+        for(int i=0;i<numSearch2Individuals;i++){
+            MarkedIndividual indie=(MarkedIndividual)query2Individuals.get(i);
+            for(int r=0;r<numLoci;r++){
+            	if(indie.hasLocus(loci.get(r))) {
+            		if(!allowedLoci.contains(loci.get(r))) {allowedLoci.add(loci.get(r));}
+            	}
+            }
+        }
+        int numAllowedLoci=allowedLoci.size();
         
         //let's add loci to the header row
-        for(int r=0;r<numLoci;r++){
-            String locus=loci.get(r);
+        for(int r=0;r<numAllowedLoci;r++){
+            String locus=allowedLoci.get(r);
             headerRow+=", "+locus+" Allele1";
             headerRow+=", "+locus+" Allele2";
         }
@@ -130,8 +142,8 @@ public class KinalyzerExport extends HttpServlet{
           lociString+=sexString+",";
           
 
-          for(int r=0;r<numLoci;r++){
-            String locus=loci.get(r);
+          for(int r=0;r<numAllowedLoci;r++){
+            String locus=allowedLoci.get(r);
             ArrayList<Integer> values=indie.getAlleleValuesForLocus(locus);
             if(indie.getAlleleValuesForLocus(locus).size()==2){
               lociString+=(values.get(0)+",");


### PR DESCRIPTION
This PR:

- Filters the genetics export to only the loci found on matching individuals
- Fixes a bug that prevented propagation of Haplotype to the MarkedIndividual in some cases
