### PR TITLE
Makes an empty MediaAsset column a non-blocking validation.

### DIFF
--- a/src/main/java/org/ecocean/servlet/importer/StandardImport.java
+++ b/src/main/java/org/ecocean/servlet/importer/StandardImport.java
@@ -1587,8 +1587,8 @@ public class StandardImport extends HttpServlet {
     String fullPath = null;
     try {
 
-      if (localPath==null||"null".equals(localPath)) {
-        feedback.logParseError(assetColIndex(i, allColsMap), localPath, row);
+      if (localPath==null||"null".equals(localPath)||"".equals(localPath.trim())) {
+        feedback.logParseNoValue(assetColIndex(i, allColsMap));
         return null;
       }
 


### PR DESCRIPTION
Validation tweak on previous validation changes for this release: this ensure that an empty Encounter.mediaAssetX column does not create a blocking error. Still blocks if there is a value (filename) and it cannot be found.
