### PR TITLE
Match results page links fixed

### DIFF
--- a/src/main/webapp/iaResults.jsp
+++ b/src/main/webapp/iaResults.jsp
@@ -1254,16 +1254,21 @@ function displayAnnotDetails(taskId, num, illustrationUrl, acmIdPassed) {
 					thisResultLine.prop('title', 'From Encounter: '+encId);
 
 					// make whole encounter line clickable
-					thisResultLine.click(function(event) {
-						let tar = $(event.target);
-						if (tar.is(thisResultLine)||tar.is(thisResultLine.find('.annot-info-num')[0])||tar.is(thisResultLine.find('.annot-info')[0])) {
-							window.location.href = 'encounters/encounter.jsp?number='+encId;
-						}
+					let click = false
+					thisResultLine.click(function(ev) {
+						  click = true;
+						  rowClick(ev, thisResultLine, encId);
+					});
+					//For browsers such as Chrome where 'click' does not work for scroll wheel click
+					thisResultLine.mousedown(function(ev) { 
+						  if (!click && ev.button == 1) {
+							  rowClick(ev, thisResultLine, encId); 
+						  }
 					});
 
 					//console.log("Main asset encId = "+encId);
-                    h += ' for <a  class="enc-link" target="_new" href="encounters/encounter.jsp?number=' + encId + '" title="open encounter ' + encId + '">Encounter: '+encDisplay+'</a>';
-                    //thisResultLine.append('<a class="enc-link" target="_new" href="encounters/encounter.jsp?number=' + encId + '" title="encounter ' + encId + '">Encounter LINE APPEND</a>');
+                    h += ' for <a  class="enc-link" href="encounters/encounter.jsp?number=' + encId + '" title="open encounter ' + encId + '">Encounter: '+encDisplay+'</a>';
+                    //thisResultLine.append('<a class="enc-link" href="encounters/encounter.jsp?number=' + encId + '" title="encounter ' + encId + '">Encounter LINE APPEND</a>');
 
 					if (!indivId) {
 						thisResultLine.append('<span class="indiv-link-target" id="encnum'+encId+'"></span>');
@@ -1272,22 +1277,22 @@ function displayAnnotDetails(taskId, num, illustrationUrl, acmIdPassed) {
 
 				if (isProjectSelected()) {
 					console.log("trying to show project-based id for asset...(UUID: "+projectUUID+" )");
-					h += ' in <a class="project-link" target="_new" href="/projects/project.jsp?id=<%=researchProjectUUID%>" title="Open Project '+researchProjectName+'">Project: ' + researchProjectName.substring(0,15) + '</a>';
+					h += ' in <a class="project-link" href="/projects/project.jsp?id=<%=researchProjectUUID%>" title="Open Project '+researchProjectName+'">Project: ' + researchProjectName.substring(0,15) + '</a>';
 
 					if (incrementalProjectId) {
-						thisResultLine.append('<a class="indiv-link" target="_new" href="/projects/project.jsp?id='+projectUUID+'" title="Project Id: '+incrementalProjectId+'">' + incrementalProjectId.substring(0,15) + '</a>');
+						thisResultLine.append('<a class="indiv-link" href="/projects/project.jsp?id='+projectUUID+'" title="Project Id: '+incrementalProjectId+'">' + incrementalProjectId.substring(0,15) + '</a>');
 					}
 				}
 
 				if (taxonomy && taxonomy!='Eubalaena glacialis' && indivId && (incrementalProjectId!=displayName)) {
-                    h += '<a class="indiv-link" title="open individual page" target="_new" href="individuals.jsp?number=' + indivId + '"  title="'+displayName+'">' + displayName + '</a>';
-                    thisResultLine.append('<a class="indiv-link" target="_new" href="individuals.jsp?number=' + indivId + '" title="'+displayName+'">' + displayName.substring(0,15) + '</a>');
+                    h += '<a class="indiv-link" title="open individual page" href="individuals.jsp?number=' + indivId + '"  title="'+displayName+'">' + displayName + '</a>';
+                    thisResultLine.append('<a class="indiv-link" href="individuals.jsp?number=' + indivId + '" title="'+displayName+'">' + displayName.substring(0,15) + '</a>');
                     
                     //add social unit name
                     console.log("socialunit name: "+socialUnitName);
                     if(socialUnitName){
                     	
-                    	thisResultLine.append('<a class="indiv-link" target="_new" href="socialUnit.jsp?name=' + socialUnitName + '" title="'+socialUnitName+'">' + socialUnitName.substring(0,10) + '</a>');
+                    	thisResultLine.append('<a class="indiv-link" href="socialUnit.jsp?name=' + socialUnitName + '" title="'+socialUnitName+'">' + socialUnitName.substring(0,10) + '</a>');
                     }
                 }
                 if (taxonomy && taxonomy=='Eubalaena glacialis') {
@@ -1370,13 +1375,13 @@ console.info('qdata[%s] = %o', taskId, qdata);
                 var indivId = ft.individualId;
                 var displayName = ft.displayName;
                 if (encId) {
-                	imgInfo += ' <a xstyle="margin-top: -6px;" class="enc-link" target="_new" href="encounters/encounter.jsp?number=' + encId + '" title="open encounter ' + encId + '">Enc ' + encId.substring(0,6) + '</a>';
+                	imgInfo += ' <a xstyle="margin-top: -6px;" class="enc-link" href="encounters/encounter.jsp?number=' + encId + '" title="open encounter ' + encId + '">Enc ' + encId.substring(0,6) + '</a>';
                 	console.log("another encId = "+encId);
                 }
-                if (indivId) imgInfo += ' <a class="indiv-link" title="open individual page" target="_new" href="individuals.jsp?number=' + indivId + '">' + displayName + '</a>';
+                if (indivId) imgInfo += ' <a class="indiv-link" title="open individual page" href="individuals.jsp?number=' + indivId + '">' + displayName + '</a>';
                 //add social unit name
                 if(socialUnitName){
-                	thisResultLine.append('<a class="indiv-link" target="_new" href="socialUnit.jsp?name=' + socialUnitName + '" title="'+socialUnitName+'">' + socialUnitName.substring(0,10) + '</a>');
+                	thisResultLine.append('<a class="indiv-link" href="socialUnit.jsp?name=' + socialUnitName + '" title="'+socialUnitName+'">' + socialUnitName.substring(0,10) + '</a>');
                 }
             }
             imgInfo += '</li>';
@@ -1385,6 +1390,15 @@ console.info('qdata[%s] = %o', taskId, qdata);
     }
 
     if (taxonomy && taxonomy!='Eubalaena glacialis' && imgInfo) $('#task-' + taskId + ' .annot-' + acmId).append('<div class="img-info">' + imgInfo + '</div>');
+}
+
+function rowClick(ev, el, encId) {
+	let evTarget = $(ev.target);
+	if (evTarget.is(el) || evTarget.is(el.find('.annot-info-num')[0]) || evTarget.is(el.find('.annot-info')[0])) {
+		  var target = (ev.metaKey && ev.button == 0) || (ev.button == 1) ? '_blank' : '_self';
+		  var w = window.open('encounters/encounter.jsp?number='+encId, target);
+		  w.focus();
+    }
 }
 
 function getSelectedProjectIdPrefix() {
@@ -1674,7 +1688,7 @@ console.info('waiting to try again...');
       			altIDString = ', altID '+altIDString;
     		}
 
-		$('#results').html('One match found (<a target="_new" href="encounters/encounter.jsp?number=' +
+		$('#results').html('One match found (<a href="encounters/encounter.jsp?number=' +
 			res.matchAnnotations[0].encounter.catalogNumber +
 			'">' + res.matchAnnotations[0].encounter.catalogNumber +
 			'</a> id ' + (res.matchAnnotations[0].encounter.individualID || 'unknown') + altIDString +
@@ -1695,7 +1709,7 @@ console.info('waiting to try again...');
 	if (altIDString && altIDString.length > 0) {
 		altIDString = ' (altID: '+altIDString+')';
 	}
-		h += '<li data-i="' + i + '"><a target="_new" href="encounters/encounter.jsp?number=' +
+		h += '<li data-i="' + i + '"><a href="encounters/encounter.jsp?number=' +
 			res.matchAnnotations[i].encounter.catalogNumber + '">' +
 			res.matchAnnotations[i].encounter.catalogNumber + altIDString + '</a> (' +
 			(res.matchAnnotations[i].encounter.individualID || 'unidentified') + '), score = ' +
@@ -1781,11 +1795,11 @@ console.warn(' ===> approvalButtonClick(encID=%o, indivID=%o, encID2=%o, taskId=
 			console.warn(d);
 			if (d.success) {
 				jQuery(msgTarget).html('<i><b>Update successful</b></i>');
-				var indivLink = ' <a class="indiv-link" title="open individual page" target="_new" href="individuals.jsp?number=' + d.individualId + '">' + d.individualName + '</a>';
+				var indivLink = ' <a class="indiv-link" title="open individual page" href="individuals.jsp?number=' + d.individualId + '">' + d.individualName + '</a>';
 				if (encID2) {
 					$(".enc-title .indiv-link").remove();
 					$(".enc-title #enc-action").remove();
-					$(".enc-title").append('<span> of <a class="indiv-link" title="open individual page" target="_new" href="individuals.jsp?number=' + d.individualId + '">' + d.individualName + '</a></span>');
+					$(".enc-title").append('<span> of <a class="indiv-link" title="open individual page" href="individuals.jsp?number=' + d.individualId + '">' + d.individualName + '</a></span>');
 					$(".enc-title").append('<div id="enc-action"><i><b>  Update Successful</b></i></div>');
 					// updates encounters in results list with name and link to indy
 					$("#encnum"+d.encounterId).append(indivLink); // unlikely, should be the query encounter


### PR DESCRIPTION
The clickable element did not have a target attribute while opening the URL. The target attribute has been passed, for the clickable element to show standard link behaviour. Also, all links on the page had target = "_new" attribute. This has been excluded for the internal links, for them to show standard link behaviour.

PR fixes #366

**Changes**
- New functions: rowClick and Edited Functions: displayAnnotDetails in iaResults.jsp
- Callout: The menu which opens upon right-clicking on the clickable element does not show the 'Open link in new tab' option. Only an anchor 'a' element shows this. The anchor elements within the clickable element can be right-clicked to open in new tab. This was called out previously in earlier PRs while applying a similar fix on other pages.
