### PR TITLE
Match Against set to false for manual annotation

### DIFF
--- a/src/main/webapp/encounters/manualAnnotation.jsp
+++ b/src/main/webapp/encounters/manualAnnotation.jsp
@@ -46,7 +46,7 @@ catch (NumberFormatException nex) {}
 
 String iaClass = request.getParameter("iaClass");
 String maparam = request.getParameter("matchAgainst");
-boolean matchAgainst = (maparam == null) || Util.booleanNotFalse(maparam);
+boolean matchAgainst = Util.booleanNotFalse(maparam);
 String rtparam = request.getParameter("removeTrivial");
 boolean removeTrivial = (rtparam == null) || Util.booleanNotFalse(rtparam);
 String encounterId = request.getParameter("encounterId");


### PR DESCRIPTION
The matchAgainst value which is responsible for the display of 'Start Match' / 'Start Another Match' is obtained from the URL query parameter.  This was being set to true even when the parameter was not passed in the request. The (maparam == null) condition check has been excluded so that the value is set to false and 'Start Match' / 'Start Another Match' is not displayed for manual annotation.

PR fixes #276

**Changes**
- String variable matchAgainst edited in manualAnnotation.jsp
