### PR TITLE
Issue431

### DIFF
--- a/src/main/webapp/iaResults.jsp
+++ b/src/main/webapp/iaResults.jsp
@@ -1256,27 +1256,12 @@ function displayAnnotDetails(taskId, num, illustrationUrl, acmIdPassed) {
 
 					thisResultLine.prop('title', 'From Encounter: '+encId);
 
-					let click = false
-					thisResultLine.click(function(ev) {
-						  click = true;
-						  rowClick(ev, thisResultLine, encId);
-					});
-					//For browsers such as Chrome where 'click' does not work for scroll wheel click
-					thisResultLine.mousedown(function(ev) { 
-						  if (!click && ev.button == 1) {
-							  rowClick(ev, thisResultLine, encId); 
-						  }
-						});
-
-					// make annot info clickable
-					thisAnnotInfo.click(function(event) {
-						console.log("clicked on annot info");
-						let tar = $(event.target).parent();
-						if (tar.is(thisResultLine)||tar.is(thisResultLine.find('.annot-info-num')[0])||tar.is(thisResultLine.find('.annot-info')[0])) {
-							window.location.href = 'encounters/encounter.jsp?number='+encId;
-						}
-					});
-
+					thisResultLine.find('.annot-info').each(function() {
+						var content = $(this).contents();
+						var href = 'encounters/encounter.jsp?number='+encId;
+						var newAnchor = $('<a></a>').attr('href', href).css('white-space', 'nowrap').append(content);
+						$(this).replaceWith(newAnchor);
+				});
 					//console.log("Main asset encId = "+encId);
                     h += ' for <a  class="enc-link"  href="encounters/encounter.jsp?number=' + encId + '" title="open encounter ' + encId + '">Encounter: '+encDisplay+'</a>';
                     //thisResultLine.append('<a class="enc-link"  href="encounters/encounter.jsp?number=' + encId + '" title="encounter ' + encId + '">Encounter LINE APPEND</a>');
@@ -1403,14 +1388,6 @@ console.info('qdata[%s] = %o', taskId, qdata);
     if (taxonomy && taxonomy!='Eubalaena glacialis' && imgInfo) $('#task-' + taskId + ' .annot-' + acmId).append('<div class="img-info">' + imgInfo + '</div>');
 }
 
-function rowClick(ev, el, encId) {
-	let evTarget = $(ev.target);
-	if (evTarget.is(el) || evTarget.is(el.find('.annot-info-num')[0]) || evTarget.is(el.find('.annot-info')[0])) {
-		  var target = (ev.metaKey && ev.button == 0) || (ev.button == 1) ? '_blank' : '_self';
-		  var w = window.open('encounters/encounter.jsp?number='+encId, target);
-		  w.focus();
-    }
-}
 
 function getSelectedProjectIdPrefix() {
 	let selectedValue = $("#projectDropdown option:selected").val();

--- a/src/main/webapp/iaResults.jsp
+++ b/src/main/webapp/iaResults.jsp
@@ -1257,9 +1257,9 @@ function displayAnnotDetails(taskId, num, illustrationUrl, acmIdPassed) {
 					thisResultLine.prop('title', 'From Encounter: '+encId);
 
 					thisResultLine.find('.annot-info').each(function() {
-						var content = $(this).contents();
-						var href = 'encounters/encounter.jsp?number='+encId;
-						var newAnchor = $('<a></a>').attr('href', href).css('white-space', 'nowrap').append(content);
+						const content = $(this).contents();
+						const href = 'encounters/encounter.jsp?number='+encId;
+						const newAnchor = $('<a></a>').attr('href', href).css('white-space', 'nowrap').append(content);
 						$(this).replaceWith(newAnchor);
 				});
 					//console.log("Main asset encId = "+encId);

--- a/src/main/webapp/iaResults.jsp
+++ b/src/main/webapp/iaResults.jsp
@@ -1256,6 +1256,7 @@ function displayAnnotDetails(taskId, num, illustrationUrl, acmIdPassed) {
 
 					thisResultLine.prop('title', 'From Encounter: '+encId);
 
+					//To make the browser behave consistent with other links when encounter number is left/middle/right clicked, change the encounter number to a link
 					thisResultLine.find('.annot-info').each(function() {
 						const content = $(this).contents();
 						const href = 'encounters/encounter.jsp?number='+encId;


### PR DESCRIPTION
PR fixes #431 and #366

**Changes**
on match result page, now 

1. click on neutral part of bar to select for match comparison; bar becomes green
2. can still click to access individual link
3. can still click to inspect match visualization
4. can still click to select the match
5. lighter hover to indicate what pointer location
6. All links on the /iaResults.jsp?taskId=[guid] page left click open to current tab, middle click to new tab silent, and right click opens the standard menu