### PR TITLE
cleaned up sighting managment error messages

### DIFF
--- a/src/main/java/org/ecocean/servlet/OccurrenceAddEncounter.java
+++ b/src/main/java/org/ecocean/servlet/OccurrenceAddEncounter.java
@@ -124,7 +124,7 @@ public class OccurrenceAddEncounter extends HttpServlet {
       } 
       else {
         //out.println(ServletUtilities.getHeader(request));
-        out.println("<strong>Error:</strong> You can't add this encounter to an occurrence when it's already assigned to another one, or you may be trying to add this encounter to a nonexistent occurrence.");
+        out.println("<strong>Error:</strong> You are trying to add this encounter to a sighting ID that does not exist.");
         //out.println(ServletUtilities.getFooter(context));
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         myShepherd.rollbackDBTransaction();

--- a/src/main/java/org/ecocean/servlet/OccurrenceCreate.java
+++ b/src/main/java/org/ecocean/servlet/OccurrenceCreate.java
@@ -120,7 +120,7 @@ public class OccurrenceCreate extends HttpServlet {
         myShepherd.rollbackDBTransaction();
         myShepherd.closeDBTransaction();
         //out.println(ServletUtilities.getHeader(request));
-        out.println("<strong>Error:</strong> An occurrence with this identifier already exists in the database. Select a different identifier and try again.");
+        out.println("<strong>Error:</strong> You are trying to create a new sighting ID, but the sighting ID already exists.");
         //out.println("<p><a href=\"http://" + CommonConfiguration.getURLLocation(request) + "/encounters/encounter.jsp?number=" + request.getParameter("number") + "\">Return to encounter " + request.getParameter("number") + ".</a></p>\n");
         //out.println(ServletUtilities.getFooter(context));
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);


### PR DESCRIPTION
Error messages around sighting ID management were causing confusion in support case; cleaned up to clarify the failure state. Still need to be extracted out for localization

PR fixes #453

**Changes**
- copy change for Create Sighting ID failure message
- copy change for Failure to find Sighting ID message
