### PR TITLE
Coordinates made editable at sighting level

### DIFF
--- a/src/main/java/org/ecocean/Occurrence.java
+++ b/src/main/java/org/ecocean/Occurrence.java
@@ -18,6 +18,7 @@ import org.ecocean.media.MediaAsset;
 import javax.json.JsonException;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.datanucleus.api.rest.orgjson.JSONObject;
 import org.datanucleus.api.rest.orgjson.JSONArray;
@@ -363,6 +364,14 @@ public class Occurrence implements java.io.Serializable {
     String latStr = (decimalLatitude!=null) ? decimalLatitude.toString() : "";
     String lonStr = (decimalLongitude!=null) ? decimalLongitude.toString() : "";
     return (latStr+", "+lonStr);
+  }
+  
+  public void setLatLongString(final String latitude, final String longitude) {
+	  if (StringUtils.isAnyBlank(latitude, longitude)) {
+		  return;
+	  }
+	  setDecimalLatitude(Double.valueOf(latitude));
+      setDecimalLongitude(Double.valueOf(longitude));
   }
 
   public ArrayList<String> getMarkedIndividualNamesForThisOccurrence(){

--- a/src/main/java/org/ecocean/servlet/OccurrenceSetGroupBehavior.java
+++ b/src/main/java/org/ecocean/servlet/OccurrenceSetGroupBehavior.java
@@ -27,7 +27,7 @@ public class OccurrenceSetGroupBehavior extends HttpServlet {
   }
 
 
-  private void setDateLastModified(Occurrence enc) {
+  protected void setDateLastModified(Occurrence enc) {
     String strOutputDateTime = ServletUtilities.getDate();
     enc.setDWCDateLastModified(strOutputDateTime);
   }

--- a/src/main/java/org/ecocean/servlet/OccurrenceSetLatitudeLongitude.java
+++ b/src/main/java/org/ecocean/servlet/OccurrenceSetLatitudeLongitude.java
@@ -1,0 +1,86 @@
+package org.ecocean.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.ecocean.CommonConfiguration;
+import org.ecocean.Occurrence;
+import org.ecocean.Shepherd;
+
+/**
+ * Updates latitude, longitude for an occurrence.
+ */
+public class OccurrenceSetLatitudeLongitude extends OccurrenceSetGroupBehavior {
+	
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public void doPost(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+		final String context = ServletUtilities.getContext(request);
+	    final String latitude = request.getParameter("latitude");
+	    final String longitude = request.getParameter("longitude");
+	    
+	    if (StringUtils.isAnyBlank(latitude, longitude)) {
+	    	final String message = "<strong>Error:</strong> I don't have enough information to complete your request.";
+	    	printResponse(request, response, HttpServletResponse.SC_BAD_REQUEST, message, context);
+	    	return;
+	    }
+	    
+	    final Shepherd myShepherd = new Shepherd(context);
+	    myShepherd.setAction("OccurrenceSetLatitudeLongitude.class");
+    	myShepherd.beginDBTransaction();
+    	
+        final Occurrence occ = myShepherd.getOccurrence(request.getParameter("number"));
+        setDateLastModified(occ);
+        
+		final String latLongStringNew = latitude+", "+longitude;
+		String latLongString = StringUtils.EMPTY;
+		
+		try {
+			latLongString = occ.getLatLonString();
+			occ.setLatLongString(latitude, longitude);
+			occ.addComments("<p><em>" + request.getRemoteUser() + " on " + (new java.util.Date()).toString() + "</em><br>Changed latitude, longitude from:<br><i>" + latLongString + "</i><br>to:<br><i>" + latLongStringNew + "</i></p>");
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			myShepherd.rollbackDBTransaction();
+			myShepherd.closeDBTransaction();
+			final String message = "<strong>Failure:</strong> Occurrence latitude, longitude was NOT updated because of an error: "+e.getLocalizedMessage();
+			printResponse(request, response, HttpServletResponse.SC_BAD_REQUEST, message, context);
+			return;
+		}
+        
+        myShepherd.commitDBTransaction();
+        final String message = "<strong>Success:</strong> Occurrence latitude, longitude was updated from:<br><i>" + latLongString + "</i><br>to:<br><i>" + latLongStringNew + "</i>";
+        printResponse(request, response, HttpServletResponse.SC_OK, message, context);
+    
+	    myShepherd.closeDBTransaction();
+    }
+	
+	/**
+	 * Prints the servlet response using HttpServletResponse object.
+	 * 
+	 * @param request HttpServletRequest
+	 * @param response HttpServletResponse
+	 * @param status HttpStatus
+	 * @param message Print message
+	 * @param context Context
+	 * @throws IOException
+	 */
+	protected void printResponse(final HttpServletRequest request, final HttpServletResponse response, final int status, final String message, final String context) throws IOException {
+		response.setContentType("text/html");
+		final PrintWriter out = response.getWriter();
+		response.setStatus(status);
+		out.println(ServletUtilities.getHeader(request));
+        out.println(message);
+        out.println("<p><a href=\""+request.getScheme()+"://" + CommonConfiguration.getURLLocation(request) + "/occurrence.jsp?number=" + request.getParameter("number") + "\">Return to occurrence " + request.getParameter("number") + "</a></p>\n");
+        out.println(ServletUtilities.getFooter(context));
+        out.close();
+	}
+	
+}

--- a/src/main/resources/bundles/en/occurrence.properties
+++ b/src/main/resources/bundles/en/occurrence.properties
@@ -81,6 +81,7 @@ numMarkedIndividuals = Number marked individuals participating
 estimatedNumMarkedIndividuals = Estimated total individuals participating
 setGroupBehavior = Set Group Behavior
 setIndividualCount = Set Individual Count
+setLatitudeLongitude = Set Latitude Longitude
 set = Set
 newIndividualCount = Estimated number of total individuals in the occurrence
 

--- a/src/main/resources/bundles/es/occurrence.properties
+++ b/src/main/resources/bundles/es/occurrence.properties
@@ -64,6 +64,7 @@ numMarkedIndividuals = N\u00famero marcado individuos participantes
 estimatedNumMarkedIndividuals = Total estimado de personas que participan
 setGroupBehavior = Establecer el comportamiento del grupo
 setIndividualCount = Establezca Recuento individual
+setLatitudeLongitude = Establecer latitud y longitud
 set = Conjunto
 newIndividualCount = N\u00famero estimado de personas totales en la ocurrencia
 

--- a/src/main/resources/bundles/fr/occurrence.properties
+++ b/src/main/resources/bundles/fr/occurrence.properties
@@ -77,6 +77,7 @@ numMarkedIndividuals = Nombre d'individus marqu\u00e9s participant
 estimatedNumMarkedIndividuals = Nombre total estim\u00e9 de participants
 setGroupBehavior = D\u00e9finir le comportement du groupe
 setIndividualCount = D\u00e9finir le nombre d'individus
+setLatitudeLongitude = D\u00e9finir la latitude et la longitude
 set = D\u00e9finir
 newIndividualCount = Nombre estim\u00e9 d'individus dans l'occurence
 

--- a/src/main/resources/bundles/it/occurrence.properties
+++ b/src/main/resources/bundles/it/occurrence.properties
@@ -71,6 +71,7 @@ numMarkedIndividuals = Numero di individui contrassegnati
 estimatedNumMarkedIndividuals =  Numero stimato di individui contrassegnati
 setGroupBehavior = Imposta comportamento del gruppo
 setIndividualCount = Imposta conteggio individuale
+setLatitudeLongitude = Imposta latitudine longitudine
 set = Impostato
 newIndividualCount = Conteggio nuovi individui
 # below fields added for search page

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -241,6 +241,7 @@
 				             /GenalexExportCodominantMSDataBySize = authc, roles[researcher]
 				             /SOCPROGExport = authc, roles[researcher]
 				             /OccurrenceSetGroupBehavior = authc, roles[researcher]
+				             /OccurrenceSetLatitudeLongitude = authc, roles[researcher]
 				             /EncounterSetBehavior = authc, roles[researcher]
 				      /CJS = authc, roles[researcher]
 				      /software.jsp = authc, roles[researcher]
@@ -923,6 +924,11 @@
     <servlet>
       <servlet-name>OccurrenceSetGroupBehavior</servlet-name>
       <servlet-class>org.ecocean.servlet.OccurrenceSetGroupBehavior</servlet-class>
+  </servlet>
+  
+  <servlet>
+      <servlet-name>OccurrenceSetLatitudeLongitude</servlet-name>
+      <servlet-class>org.ecocean.servlet.OccurrenceSetLatitudeLongitude</servlet-class>
   </servlet>
 
   <!--
@@ -2410,6 +2416,11 @@
       <servlet-mapping>
         <servlet-name>OccurrenceSetGroupBehavior</servlet-name>
         <url-pattern>/OccurrenceSetGroupBehavior</url-pattern>
+  </servlet-mapping>
+  
+  <servlet-mapping>
+        <servlet-name>OccurrenceSetLatitudeLongitude</servlet-name>
+        <url-pattern>/OccurrenceSetLatitudeLongitude</url-pattern>
   </servlet-mapping>
 <!--
   <servlet-mapping>

--- a/src/main/webapp/occurrence.jsp
+++ b/src/main/webapp/occurrence.jsp
@@ -493,7 +493,40 @@ if(visible){
     <%=occ.getDecimalLongitude()%> /
     <%=occ.getBearing()%> m /
     <%=occ.getDistance()%> m
+    &nbsp; 
+	<%if (hasAuthority && CommonConfiguration.isCatalogEditable(context)) {%>
+		<a id="latLongButton" style="color:blue;cursor: pointer;"><img width="20px" height="20px" style="border-style: none;align: center;" src="images/Crystal_Clear_action_edit.png" /></a>	
+	<%}%>
 </p>
+<div id="dialogLatLong" title="<%=props.getProperty("setLatitudeLongitude") %>" style="display:none">
+	<table border="1">
+	  <tr>
+	    <td align="left" valign="top">
+	      <form name="set_latitudeLongitude" method="post" action="OccurrenceSetLatitudeLongitude">
+	            <input name="number" type="hidden" value="<%=request.getParameter("number")%>"/> 
+                <%=props.getProperty("latitude")%>:
+                <input name="latitude" id="latitude" type="text" maxlength="20"></input>
+				<%=props.getProperty("longitude")%>:
+				<input name="longitude" id="longitude" type="text" maxlength="20"></input> 
+	        	<input name="latLongButton" type="submit" id="latLongButton" value="<%=props.getProperty("set") %>">
+	        </form>
+	    </td>
+	  </tr>
+	</table>
+</div>
+	  
+<script>
+	var dlglatLong = $("#dialogLatLong").dialog({
+	  autoOpen: false,
+	  draggable: false,
+	  resizable: false,
+	  width: 600
+	});
+	
+	$("a#latLongButton").click(function() {
+	  dlglatLong.dialog("open");
+	});
+</script>
 <%
 }
 %>


### PR DESCRIPTION
Latitude and Longitude have been made editable at the sighting level as per the #370 description. This follows the pattern of the edit `Group Behaviour`. OccurrenceSetLatitudeLongitude.java, extending OccurrenceSetGroupBehavior.java, has been created for the save action of the latitude and longitude fields.

PR fixes #370

**Changes**
- Callout: The `Set Latitude Longitude` value in the properties files for other languages is based on Google Translations and by referring to some of the existing texts in those files. This might need to be checked for accuracy.
