### PR TITLE
Display roles without context on login user page

### DIFF
--- a/src/main/java/org/ecocean/Shepherd.java
+++ b/src/main/java/org/ecocean/Shepherd.java
@@ -1007,10 +1007,7 @@ public class Shepherd {
     int numRoles=roles.size();
     String rolesFound="";
     for(int i=0;i<numRoles;i++){
-      String context="context0";
-      if(roles.get(i).getContext()!=null){context=roles.get(i).getContext();}
-      String contextName=ContextConfiguration.getNameForContext(context);
-      rolesFound+=(contextName+":"+roles.get(i).getRolename()+"\r");
+      rolesFound+=(roles.get(i).getRolename()+"\r");
     }
     acceptedEncounters.closeAll();
     return rolesFound;

--- a/src/main/java/org/ecocean/servlet/UserCreate.java
+++ b/src/main/java/org/ecocean/servlet/UserCreate.java
@@ -207,7 +207,7 @@ public class UserCreate extends HttpServlet {
                 role.setUsername(username);
                 role.setContext("context"+d);
                 myShepherd.getPM().makePersistent(role);
-                addedRoles+=("SEPARATORSTART"+ContextConfiguration.getNameForContext("context"+d)+":"+roles[i]+"SEPARATOREND");
+                addedRoles+=("SEPARATORSTART"+roles[i]+"SEPARATOREND");
                 //System.out.println(addedRoles);
                 myShepherd.commitDBTransaction();
                 myShepherd.beginDBTransaction();


### PR DESCRIPTION
The logic which appends context to roles has been excluded for Login Success (`/LoginUser`) and User Confirmation (`/UserCreate`) pages.

PR fixes #423 
