### PR TITLE
fix home page link to use username in search

### DIFF
--- a/src/main/java/org/ecocean/User.java
+++ b/src/main/java/org/ecocean/User.java
@@ -141,6 +141,7 @@ public class User implements Serializable {
         info.put("imageURL", Util.jsonNull(this.getUserImageURL(context)));
         if (includeSensitive) {
             info.put("email", this.getEmailAddress());
+            info.put("username", this.getUsername());
         }
         return info;
     }


### PR DESCRIPTION
solves #522 

- alters api json output for `UserHome` and `UserInfo` to include `username` property
- (frontend changes here)