### PR TITLE
Improved matchAgainst for manual annotation to use the same logic as …

### DIFF
--- a/src/main/webapp/encounters/manualAnnotation.jsp
+++ b/src/main/webapp/encounters/manualAnnotation.jsp
@@ -45,8 +45,8 @@ try {
 catch (NumberFormatException nex) {}
 
 String iaClass = request.getParameter("iaClass");
-String maparam = request.getParameter("matchAgainst");
-boolean matchAgainst = Util.booleanNotFalse(maparam);
+//String maparam = request.getParameter("matchAgainst");
+//boolean matchAgainst = Util.booleanNotFalse(maparam);
 String rtparam = request.getParameter("removeTrivial");
 boolean removeTrivial = (rtparam == null) || Util.booleanNotFalse(rtparam);
 String encounterId = request.getParameter("encounterId");
@@ -428,7 +428,10 @@ try{
 	    ma.addFeature(ft);
 	    ma.setDetectionStatus("complete");
 	    Annotation ann = new Annotation(null, ft, iaClass);
-	    ann.setMatchAgainst(matchAgainst);
+		IAJsonProperties iaConf = IAJsonProperties.iaConfig();
+	    if (IBEISIA.validForIdentification(ann, context) && iaConf.isValidIAClass(enc.getTaxonomy(myShepherd), iaClass)) {
+            ann.setMatchAgainst(true);
+        }
 	    ann.setViewpoint(viewpoint);
 	    String encMsg = "(no encounter)";
 	    if (enc != null) {


### PR DESCRIPTION
…detector.

PR fixes #276 (part 2)

**Changes**
- matchAgsinst for a manually drawn annot can no longer be set by URL
- matchAgainst for an annotation is now set using the same logic as when an annotation is created by detection...by inspecting IA.json
