### PR TITLE
Added encounter's audit trail when adding image

### DIFF
--- a/src/main/java/org/ecocean/servlet/MediaAssetAttach.java
+++ b/src/main/java/org/ecocean/servlet/MediaAssetAttach.java
@@ -108,6 +108,8 @@ public class MediaAssetAttach extends HttpServlet {
     if (args.optString("attach")!=null && args.optString("attach").equals("true")) {
         for (MediaAsset ma : mas) {
             enc.addMediaAsset(ma);
+            String comments = "Attached MediaAsset " + ma.getId() + ".";
+            enc.addComments("<p><em>" + request.getRemoteUser() + " on " + (new java.util.Date()).toString() + "</em><br>" + comments + " </p>");
         }
         res.put("action","attach");
         res.put("success",true);


### PR DESCRIPTION
adds a message to audit trail comment when a MediaAsset is added to Encounter.

PR fixes #414 
