### PR TITLE
display original user-supplied filename in various capacities

### DIFF
--- a/src/main/java/org/ecocean/media/AssetStore.java
+++ b/src/main/java/org/ecocean/media/AssetStore.java
@@ -157,6 +157,12 @@ public abstract class AssetStore implements java.io.Serializable {
 
     public abstract String getFilename(MediaAsset ma);  //this should be null if there is no such thing.  "filename" is subjective here (e.g. youtube id?)
 
+    // human-facing, "user-chosen" filename that may include complex characters like utf8 etc
+    // defaults to just using getFilename() above, but can and should be overridden if applicable
+    public String getUserFilename(MediaAsset ma) {
+        return this.getFilename(ma);
+    }
+
     public abstract MediaAsset create(JSONObject params);
 
     //this should be unique (as possible) for a combination of params -- used for searching, see find()

--- a/src/main/java/org/ecocean/media/LocalAssetStore.java
+++ b/src/main/java/org/ecocean/media/LocalAssetStore.java
@@ -329,6 +329,12 @@ System.out.println("LocalAssetStore attempting to delete file=" + file);
     }
 
     @Override
+    public String getUserFilename(MediaAsset ma) {
+        if ((ma.getParameters() != null) && (ma.getParameters().optString("userFilename", null) != null)) return ma.getParameters().getString("userFilename");
+        return this.getFilename(ma);
+    }
+
+    @Override
     public String hashCode(JSONObject params) {
         if (params == null) return null;
         Path path = pathFromParameters(params);

--- a/src/main/java/org/ecocean/media/MediaAsset.java
+++ b/src/main/java/org/ecocean/media/MediaAsset.java
@@ -1071,6 +1071,7 @@ public class MediaAsset implements java.io.Serializable {
               jobj.put("userLongitude",this.getLongitude());
               jobj.put("userDateTime",this.getUserDateTime());
               jobj.put("filename", this.getFilename());  //this can "vary" depending on store type
+              jobj.put("userFilename", this.getUserFilename());
             }
 
             jobj.put("occurrenceID",this.getOccurrenceID());

--- a/src/main/java/org/ecocean/media/MediaAsset.java
+++ b/src/main/java/org/ecocean/media/MediaAsset.java
@@ -407,6 +407,12 @@ public class MediaAsset implements java.io.Serializable {
         return store.getFilename(this);
     }
 
+    // "user-provided" (fancy, may have utf8 etc) displayable filename
+    public String getUserFilename() {
+        if (store == null) return null;
+        return store.getUserFilename(this);
+    }
+
     public ArrayList<String> getLabels() {
         return labels;
     }

--- a/src/main/java/org/ecocean/resumableupload/UploadServlet.java
+++ b/src/main/java/org/ecocean/resumableupload/UploadServlet.java
@@ -301,6 +301,9 @@ System.out.println("FlowFilename: " + FlowFilename);
 System.out.println("FlowRelativePath: " + FlowRelativePath);
 System.out.println("FlowFilePath: " + FlowFilePath);
 
+                    // hacky, but gets us userFilename
+                    request.getSession().setAttribute("userFilename:" + FlowFilename, FlowRelativePath);
+
 		FlowInfo info = storage.get(FlowChunkSize, FlowTotalSize,
 				FlowIdentifier, FlowFilename, FlowRelativePath, FlowFilePath);
 		if (!info.valid()) {

--- a/src/main/java/org/ecocean/resumableupload/UploadServlet.java
+++ b/src/main/java/org/ecocean/resumableupload/UploadServlet.java
@@ -264,7 +264,7 @@ System.out.println("flowChunkNumber " + flowChunkNumber);
 
             for (FileItem item : parts) {
                 if (!item.isFormField()) continue;
-System.out.println(item);
+System.out.println(item.getFieldName() + " -> " + item);
                 switch (item.getFieldName()) {
                     case "flowChunkSize":
                         FlowChunkSize = HttpUtils.toInt(item.getString(), -1);

--- a/src/main/java/org/ecocean/servlet/EncounterForm.java
+++ b/src/main/java/org/ecocean/servlet/EncounterForm.java
@@ -1314,6 +1314,7 @@ System.out.println("ENCOUNTER SAVED???? newnum=" + newnum);
   private void makeMediaAssetsFromJavaFileItemObject(FileItem item, String encID, AssetStore astore, Encounter enc, ArrayList<Annotation> newAnnotations, String genus, String specificEpithet){
     String sanitizedItemName = ServletUtilities.cleanFileName(item.getName());
     JSONObject sp = astore.createParameters(new File(enc.subdir() + File.separator + sanitizedItemName));
+    sp.put("userFilename", item.getName());
     sp.put("key", Util.hashDirectories(encID) + "/" + sanitizedItemName);
     MediaAsset ma = new MediaAsset(astore, sp);
     File tmpFile = ma.localPath().toFile();  //conveniently(?) our local version to save ma.cacheLocal() from having to do anything?
@@ -1363,6 +1364,7 @@ System.out.println("ENCOUNTER SAVED???? newnum=" + newnum);
     System.out.println("Entering makeMediaAssetsFromJavaFileObject");
 
     JSONObject sp = astore.createParameters(new File(enc.subdir() + File.separator + item.getName()));
+    sp.put("userFilename", item.getName());
     sp.put("key", Util.hashDirectories(encID) + "/" + item.getName());
     MediaAsset ma = new MediaAsset(astore, sp);
     File tmpFile = ma.localPath().toFile();  //conveniently(?) our local version to save ma.cacheLocal() from having to do anything?

--- a/src/main/java/org/ecocean/servlet/MediaAssetCreate.java
+++ b/src/main/java/org/ecocean/servlet/MediaAssetCreate.java
@@ -252,6 +252,7 @@ NOTE: for now(?) we *require* a *valid* setId *and* that the asset *key be prefi
                     if (fname.indexOf("..") > -1) continue;  //no hax0ring plz
                     File inFile = new File(uploadTmpDir, fname);
                     params = targetStore.createParameters(inFile);
+                    params.put("userFilename", fname);
                     if (accessKey != null) params.put("accessKey", accessKey);
                     targetMA = targetStore.create(params);
                     try {

--- a/src/main/java/org/ecocean/servlet/MediaAssetCreate.java
+++ b/src/main/java/org/ecocean/servlet/MediaAssetCreate.java
@@ -246,13 +246,14 @@ NOTE: for now(?) we *require* a *valid* setId *and* that the asset *key be prefi
 
                 //TODO we should probably also use the "SETID/" prefix (see below) standard for local too right?????
                 String fname = params.optString("filename", null);
+                String userFilename = params.optString("userFilename", fname);
                 String url = params.optString("url", null);
                 String accessKey = params.optString("accessKey", null);  //kinda specialty use to validate certain anon-uploaded cases (e.g. match.jsp)
                 if (fname != null) {  //this is local
                     if (fname.indexOf("..") > -1) continue;  //no hax0ring plz
                     File inFile = new File(uploadTmpDir, fname);
                     params = targetStore.createParameters(inFile);
-                    params.put("userFilename", fname);
+                    params.put("userFilename", userFilename);
                     if (accessKey != null) params.put("accessKey", accessKey);
                     targetMA = targetStore.create(params);
                     try {

--- a/src/main/java/org/ecocean/servlet/export/EncounterSearchExportMetadataExcel.java
+++ b/src/main/java/org/ecocean/servlet/export/EncounterSearchExportMetadataExcel.java
@@ -199,7 +199,7 @@ public class EncounterSearchExportMetadataExcel extends HttpServlet {
       newEasyColumn("Encounter.occurrenceRemarks", columns);
 
 
-      Method maGetFilename = MediaAsset.class.getMethod("getFilename", null);
+      Method maGetFilename = MediaAsset.class.getMethod("getUserFilename", null);
       Method maLocalPath   = MediaAsset.class.getMethod("localPath", null);
       // This will include labels in a labeledKeyword value
       Method keywordGetName   = Keyword.class.getMethod("getDisplayName");

--- a/src/main/java/org/ecocean/servlet/importer/StandardImport.java
+++ b/src/main/java/org/ecocean/servlet/importer/StandardImport.java
@@ -1697,6 +1697,7 @@ public class StandardImport extends HttpServlet {
     // String keywordOI = getString(row, keywordOIKey);
     // if (keywordOI!=null) keyword = myShepherd.getOrCreateKeyword(keywordOI);
     // if (keyword!=null) ma.addKeyword(keyword);
+    System.out.println("getMediaAsset() created " + ma + " with params: " + assetParams);
     return ma;
   }
 

--- a/src/main/java/org/ecocean/servlet/importer/StandardImport.java
+++ b/src/main/java/org/ecocean/servlet/importer/StandardImport.java
@@ -1564,7 +1564,8 @@ public class StandardImport extends HttpServlet {
     }
 
     String localPath = getString(row, "Encounter.mediaAsset"+i, colIndexMap, verbose, missingColumns, unusedColumns,feedback);
-    System.out.println("     localPath: "+localPath);
+    String userFilename = localPath;
+    System.out.println("     localPath/userFilename: " + userFilename);
     if (Util.stringExists(localPath)){
       localPath = localPath.replaceAll("[^a-zA-Z0-9\\. ]", "");
     }
@@ -1647,6 +1648,7 @@ public class StandardImport extends HttpServlet {
     // create MediaAsset and return it
     JSONObject assetParams = astore.createParameters(f);
     assetParams.put("_localDirect", f.toString());
+    assetParams.put("userFilename", userFilename);
 
     MediaAsset ma = null;
     try {

--- a/src/main/webapp/encounters/encounter.jsp
+++ b/src/main/webapp/encounters/encounter.jsp
@@ -5050,6 +5050,7 @@ button#upload-button {
 
   var keyToFilename = {};
   var filenames = [];
+    var userFilenames = [];
   var pendingUpload = -1;
 
   $("button#add-image").click(function(){$(".flow-box").show()})
@@ -5066,6 +5067,7 @@ button#upload-button {
 
   flow.on('fileAdded', function(file, event){
     $('#file-activity').show();
+    file.userFilename = file.name;
     if(file && file.name){
       file.name = file.name.replace(/[^a-zA-Z0-9\. ]/g, "");
     }
@@ -5085,8 +5087,9 @@ button#upload-button {
     var el = findElement(file.name, file.size);
     updateProgress(el, -1, 'completed', 'rgba(200,250,180,0.3)');
     console.log('success %o %o', file, message);
-    console.log('filename: '+file.name);
+    console.log('filename: %o | userFilename: %o', file.name, file.userFilename);
     filenames.push(file.name);
+    userFilenames.push(file.userFilename);
     pendingUpload--;
     if (pendingUpload == 0) uploadFinished();
   });
@@ -5170,7 +5173,7 @@ button#upload-button {
   }
   function uploadFinished() {
     if (filenames.length > 0) {
-      console.log("creating mediaAsset for filename "+filenames[0]);
+      console.log("creating mediaAsset for filename=[%o] userFilename=[%o]", filenames[0], userFilenames[0]);
 
       let locationID = '<%=enc.getLocationID()%>';
       console.log("locationID for new asset: "+locationID);
@@ -5183,7 +5186,10 @@ button#upload-button {
         data: JSON.stringify({
           "MediaAssetCreate": [
             {"assets": [
-               {"filename": filenames[0] }
+               {
+                    "filename": filenames[0],
+                    "userFilename": userFilenames[0],
+               }
               ]
             }
           ],

--- a/src/main/webapp/encounters/encounterMediaGallery.jsp
+++ b/src/main/webapp/encounters/encounterMediaGallery.jsp
@@ -158,7 +158,7 @@ function forceLink(el) {
 
 
 
-		      String filename = ma.getFilename();
+		      String filename = ma.getUserFilename();
 		      //System.out.println("    EMG: got ma at "+filename);
 
 		      String individualID="";
@@ -849,7 +849,7 @@ jQuery(document).ready(function() {
         $('.image-enhancer-wrapper').each(function(i, el) {
             var mid = imageEnhancer.mediaAssetIdFromElement($(el));
 	    var ma = assetById(mid);
-            var h = '<div class="gallery-download" onclick="event.stopPropagation();" ><a href="../imagedl/' + mid + '/' + encodeURI(ma.filename) + '" title="Download" download="' + encodeURI(ma.filename) + '">' + ma.filename + '</a></div>';
+            var h = '<div class="gallery-download" onclick="event.stopPropagation();" ><a href="../imagedl/' + mid + '/' + encodeURI(ma.filename) + '" title="Download" download="' + encodeURI(ma.userFilename) + '">' + ma.userFilename + '</a></div>';
             $(el).closest('figure').after(h);
             //$(el).closest('.my-gallery').after(h);
         });
@@ -993,7 +993,7 @@ function enhancerCaption(el, opt) {
 	var ma = assetById(mid);
 //console.warn("====== enhancerCaption %o ", ma);
 	if (!ma || !ma.sourceAsset || !ma.sourceAsset.store.type == 'YouTube') return;
-	var title = ma.sourceAsset.filename || '';
+	var title = ma.sourceAsset.userFilename || '';
 	if (ma.sourceAsset.metadata && ma.sourceAsset.metadata.basic) {
 		title = ma.sourceAsset.metadata.basic.title || 'Untitled';
 		title += ' [from ' + (ma.sourceAsset.metadata.basic.author_name || 'Unknown source') + ']';

--- a/src/main/webapp/iaResults.jsp
+++ b/src/main/webapp/iaResults.jsp
@@ -1210,8 +1210,8 @@ function displayAnnotDetails(taskId, num, illustrationUrl, acmIdPassed) {
             if(res.responseJSON.annotations[returnNum] && res.responseJSON.annotations[returnNum].encounterDate){
                 imgInfo += ' <b>' + res.responseJSON.annotations[returnNum].encounterDate.substring(0,16) + '</b> ';
             }
-            if (mainAsset.filename) {
-                var fn = mainAsset.filename;
+            if (mainAsset.userFilename) {
+                var fn = mainAsset.userFilename;
                 var j = fn.lastIndexOf('/');
                 if (j > -1) fn = fn.substring(j + 1);
                 imgInfo += ' ' + fn + ' ';

--- a/src/main/webapp/import/reviewDirectory.jsp
+++ b/src/main/webapp/import/reviewDirectory.jsp
@@ -105,8 +105,15 @@ ol.filelist li {
     	<ol class="filelist">
   		<% 
   		for (File photo: imageFiles) {
+                        String displayName = photo.getName();
+                        String userFilename = (String)request.getSession().getAttribute("userFilename:" + displayName);
+                        if (userFilename != null) {
+                                // something is encoding the strings as ISO8859 so we have to do the conversion here
+                                byte[] charset = userFilename.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1);
+                                displayName = new String(charset, java.nio.charset.StandardCharsets.UTF_8);
+                        }
   			%>
-  			<li><%=photo.getName()%></li>
+                            <li><%=displayName%></li>
   			<%
 		}
   		%>

--- a/src/main/webapp/obrowse.jsp
+++ b/src/main/webapp/obrowse.jsp
@@ -283,6 +283,8 @@ java.util.Properties" %>
 		}
                 h += "<ul style=\"width: 65%\">";
 		h += "<li>store: <b>" + ma.getStore() + "</b></li>";
+		h += "<li>userFilename: <b>" + ma.getUserFilename() + "</b></li>";
+		h += "<li>filename: <b>" + ma.getFilename() + "</b></li>";
 		h += "<li>labels: <b>" + showLabels(ma.getLabels()) + "</b></li>";
 		h += "<li>features: " + showFeatureList(ma.getFeatures(), req, myShepherd) + "</li>";
 		h += "<li>safeURL(): " + ma.safeURL() + "</li>";


### PR DESCRIPTION
addresses #412 
- creates new (optional) MediaAsset parameter `userFilename` to store filename as user provided it
- `asset.getUserFilename()` added, defaults to `getFilename()` when above unset
- added to standard MediaAsset json output
- utilized in various UI elements from original issue:

**Export**
![userFilename-export](https://github.com/WildMeOrg/Wildbook/assets/901250/9617d588-03db-4bf1-a752-703ab21f42f4)

**Encounter image gallery**
![userFilename-encounter-display](https://github.com/WildMeOrg/Wildbook/assets/901250/a7d2e0dc-3983-46ca-b908-a242d898dd61)

**obrowse**
![userFilename-obrowse](https://github.com/WildMeOrg/Wildbook/assets/901250/711e5dee-dc4d-4f83-91a2-daf62307ddd3)
