### PR TITLE
Manual Annotation without iaClass configured

### DIFF
--- a/src/main/webapp/encounters/manualAnnotation.jsp
+++ b/src/main/webapp/encounters/manualAnnotation.jsp
@@ -15,7 +15,8 @@
 		java.nio.charset.StandardCharsets,
 		java.io.UnsupportedEncodingException,
 		org.ecocean.identity.IBEISIA,
-		java.util.ArrayList
+		java.util.ArrayList,
+		org.apache.commons.collections4.CollectionUtils
 		"
 %>
 
@@ -218,27 +219,28 @@ try{
 	    }
 	}
 
-	if(viewpoint!=null){
-		clist = "<p>2. Select annotation iaClass: <select name=\"iaClass\" class=\"notranslate\" onChange=\"return pulldownUpdate(this);\"><option value=\"\">CHOOSE</option>";
-		//Query q2 = myShepherd.getPM().newQuery("javax.jdo.query.SQL", "select distinct(\"IACLASS\") as v from \"ANNOTATION\" order by v");
-		//results = (List)q2.execute();
-		IAJsonProperties iaj=new IAJsonProperties();
-		List<String> results2=iaj.getValidIAClassesIgnoreRedirects(enc.getTaxonomy(myShepherd));
+	clist = "<p>2. Select annotation iaClass: <select name=\"iaClass\" class=\"notranslate\" onChange=\"return pulldownUpdate(this);\"><option value=\"\">CHOOSE</option>";
+	//Query q2 = myShepherd.getPM().newQuery("javax.jdo.query.SQL", "select distinct(\"IACLASS\") as v from \"ANNOTATION\" order by v");
+	//results = (List)q2.execute();
+	IAJsonProperties iaj=new IAJsonProperties();
+	List<String> results2=iaj.getValidIAClassesIgnoreRedirects(enc.getTaxonomy(myShepherd));
 
-		Iterator<String> it2 = results2.iterator();
-		while (it2.hasNext()) {
-		    String v = (String)it2.next();
-		    //System.out.println("Encooded v: "+v);
-		    if (!Util.stringExists(v)) continue;
-		    //if(IBEISIA.validIAClassForIdentification(v, context)){
-		    	//System.out.println("v:" +v+" versus iaCLass:"+iaClass);
-		    	clist += "<option" + (v.equals(iaClass) ? " selected" : "") + ">" + v + "</option>";
-		    //}
-		}
-		clist += "</select></p>";
-		//q2.closeAll();
+	Iterator<String> it2 = results2.iterator();
+	while (it2.hasNext()) {
+	    String v = (String)it2.next();
+	    //System.out.println("Encooded v: "+v);
+	    if (!Util.stringExists(v)) continue;
+	    //if(IBEISIA.validIAClassForIdentification(v, context)){
+	    	//System.out.println("v:" +v+" versus iaCLass:"+iaClass);
+	    	clist += "<option" + (v.equals(iaClass) ? " selected" : "") + ">" + v + "</option>";
+	    //}
 	}
-
+	if (CollectionUtils.isEmpty(results2)) {
+		final String noneConfigured = "none_configured";
+		clist += "<option value=" + noneConfigured + (noneConfigured.equals(iaClass) ? " selected" : "") + ">" + "none configured" + "</option>";
+	}
+	clist += "</select></p>";
+	//q2.closeAll();
 
 	Feature ft = null;
 	MediaAsset ma = null;
@@ -398,7 +400,7 @@ try{
 	<b><%=vlist%></b>
 	<%
 	}
-	if(!save && viewpoint!=null){
+	if(!save){
 	%>
 	<b><%=clist%></b>
 	<%


### PR DESCRIPTION
'none configured' added to the iaClass dropdown for manual annotation, with the value 'none_configured'.

PR fixes #248

**Changes**

- Callout: The fix for this issue is the 'if condition' starting from line 238 which adds 'none configured' to the iaClass dropdown if there are no iaClasses configured for the species. While fixing this issue, another issue was seen. There was a fix applied previously to have the default viewpoint '---------' option selected while navigating to the page, but the option to select iaClass wasn't getting displayed by default. This issue has also been fixed in this PR by excluding the viewpoint null check since there will always be a default value for the viewpoint.
