### PR TITLE
Supports species validation with subspecies

### DIFF
--- a/src/main/java/org/ecocean/servlet/importer/StandardImport.java
+++ b/src/main/java/org/ecocean/servlet/importer/StandardImport.java
@@ -912,7 +912,7 @@ public class StandardImport extends HttpServlet {
             List<String> configuredSpecies = CommonConfiguration.getIndexedPropertyValues(
                 "genusSpecies", myShepherd.getContext());
             if (configuredSpecies != null && configuredSpecies.size() > 0 &&
-                configuredSpecies.toString().indexOf(enc.getTaxonomyString()) < 0) {
+                configuredSpecies.toString().replaceAll("_"," ").indexOf(enc.getTaxonomyString()) < 0) {
                 // if bad values
                 feedback.logParseError(getColIndexFromColName("Encounter.genus", colIndexMap),
                     genus, row, "UNSUPPORTED VALUE: " + genus);


### PR DESCRIPTION
Subspecies are defined in commonConfiguration.properties with an _. For example:

genusSpecies0 = Giraffa tipperskirchi_thornicrofti

Subspecies validation was failing because users enter the species without the underscore. This change removes the _ so that validation can proceed and users don't have to know about the weird configuration required.

PR fixes #559 

**Changes**
- removes the _ from subspecies validation of values in commonConfiguration.properties