### PR TITLE
Dynamically set Wildbook version via pom.xml Maven build

### DIFF
--- a/src/main/resources/bundles/contexts.properties
+++ b/src/main/resources/bundles/contexts.properties
@@ -1,6 +1,6 @@
 
 #project-related variables
-application.version=6.0.0-EXPERIMENTAL
+application.version=${pom.version}
 defaultContext = context0
 
 


### PR DESCRIPTION
Restores existing version-setting capability already used and working in pom.xml via Maven.

PR fixes #458

**Changes**

- allows ${pom.version} to be replaced in any piece of code during the Maven build and substitute with the version number (e.g., 10.2) defined in pom.xml. This already existed and worked but simply fell out of use. This commit restores it to the place where it is  then called in footer.jsp but should be usable anywhere within the view of the Maven build. 
