### PR TITLE
FIX: weird null behavior

### DIFF
--- a/src/main/webapp/iaResults.jsp
+++ b/src/main/webapp/iaResults.jsp
@@ -1222,7 +1222,7 @@ function displayAnnotDetails(taskId, num, illustrationUrl, acmIdPassed) {
                 var encDisplay = encId;
                 var taxonomy = ft.genus+' '+ft.specificEpithet;
                 //console.log('Taxonomy: '+taxonomy);
-                if (encId.trim().length == 36) encDisplay = encId.substring(0,6)+"...";
+                if (encId && encId.trim().length == 36) encDisplay = encId.substring(0,6)+"...";
 				var indivId = ft.individualId;
 				var socialUnitName;
 				if(isQueryAnnot){

--- a/src/main/webapp/iaResultsAnnotFeed.jsp
+++ b/src/main/webapp/iaResultsAnnotFeed.jsp
@@ -113,9 +113,10 @@ if (request.getParameter("acmId") != null) {
 								//System.out.println("found cached annotation!");
 							}
 							else{
-							
-								anns.addAll(myShepherd.getAnnotationsWithACMId(token));
-								//System.out.println("adding new annotation!");
+								if(myShepherd.getAnnotationsWithACMId(token)!=null){
+									anns.addAll(myShepherd.getAnnotationsWithACMId(token));
+									//System.out.println("adding new annotation!");
+								}
 							}
 							
 						} 


### PR DESCRIPTION
Whiskerbook users uncovered some edge cases where unanticipated null values could cause failure to display match results. A pair of JavaScript and Java errors were thrown and are patched here. General exception handling should be useful across all branches.

**Changes**
- Better null Encounter number handling in iaResults.jsp JavaScript. 
- Better null handling in java in iaResultsAnnotFeed.jsp
