### PR TITLE
Restore default locationID selection to bulk import

### DIFF
--- a/src/main/java/org/ecocean/LocationID.java
+++ b/src/main/java/org/ecocean/LocationID.java
@@ -329,7 +329,7 @@ public class LocationID {
     /*
      * Return an HTML selector of hierarchical locationIDs with indenting
      */
-    public static String getHTMLSelector(boolean multiselect, String selectedID, String qualifier,
+    public static String getHTMLSelector(boolean multiselect, List<String> selectedIDs, String qualifier,
         String htmlID, String htmlName, String htmlClass) {
         String multiselector = "";
 
@@ -338,14 +338,19 @@ public class LocationID {
             htmlName + "\" id=\"" + htmlID + "\" class=\"" + htmlClass + "\" " + multiselector +
             ">\n\r<option value=\"\"></option>\n\r");
 
-        createSelectorOptions(getLocationIDStructure(qualifier), selector, 0, selectedID);
+        createSelectorOptions(getLocationIDStructure(qualifier), selector, 0, selectedIDs);
 
         selector.append("</select>\n\r");
         return selector.toString();
     }
+    
+    public static String getHTMLSelector(boolean multiselect, String selectedID, String qualifier, String htmlID, String htmlName, String htmlClass) {
+    	ArrayList<String> locationIDs = new ArrayList<String>();
+		locationIDs.add(selectedID);
+		return getHTMLSelector(multiselect, locationIDs, qualifier, htmlID, htmlName, htmlClass);
+    }
 
-    private static void createSelectorOptions(JSONObject jsonobj, StringBuffer selector,
-        int nestingLevel, String selectedID) {
+    private static void createSelectorOptions(JSONObject jsonobj, StringBuffer selector, int nestingLevel, List<String> selectedIDs) {
         int localNestingLevel = nestingLevel;
         String selected = "";
         String spacing = "";
@@ -353,7 +358,7 @@ public class LocationID {
         for (int i = 0; i < localNestingLevel; i++) { spacing += "&nbsp;&nbsp;&nbsp;"; }
         // see if we can add this item to the list
         try {
-            if (selectedID != null && jsonobj.getString("id").equals(selectedID))
+            if (selectedIDs != null && selectedIDs.contains(jsonobj.getString("id")))
                 selected = " selected=\"selected\"";
             selector.append("<option value=\"" + jsonobj.getString("id") + "\" " + selected + ">" +
                 spacing + jsonobj.getString("name") + "</option>\n\r");
@@ -365,7 +370,7 @@ public class LocationID {
             int numLocs = locs.length();
             for (int i = 0; i < numLocs; i++) {
                 JSONObject loc = locs.getJSONObject(i);
-                createSelectorOptions(loc, selector, localNestingLevel, selectedID);
+                createSelectorOptions(loc, selector, localNestingLevel, selectedIDs);
             }
         } catch (JSONException e) {}
     }

--- a/src/main/webapp/import.jsp
+++ b/src/main/webapp/import.jsp
@@ -408,7 +408,7 @@ try{
 	}
 	
 	
-	Set<String> locationIds = new HashSet<String>();
+	ArrayList<String> locationIds = new ArrayList<String>();
 
 	    out.println("<p><b style=\"font-size: 1.2em;\">Import Task " + itask.getId() + "</b> (" + itask.getCreated().toString().substring(0,10) + ") <a class=\"button\" href=\"imports.jsp\">back to list</a></p>");
 	    out.println("<br>Data Import Status: <em>"+itask.getStatus()+"</em>");
@@ -447,7 +447,7 @@ try{
 	    	ArrayList<MediaAsset> fixACMIDAssets=new ArrayList<MediaAsset>();
 	       
 	    	JSONArray jarr=new JSONArray();
-	    	if (enc.getLocationID() != null) locationIds.add(enc.getLocationID());
+	    	if (enc.getLocationID() != null && !locationIds.contains(enc.getLocationID())) locationIds.add(enc.getLocationID());
 	        out.println("<tr>");
 	        out.println("<td><a title=\"" + enc.getCatalogNumber() + "\" href=\"encounters/encounter.jsp?number=" + enc.getCatalogNumber() + "\">" + enc.getCatalogNumber().substring(0,8) + "</a></td>");
 	        out.println("<td>" + enc.getDate() + "</td>");
@@ -891,7 +891,7 @@ try{
 		%>
 		 <div style="margin-bottom: 20px;">   	
 		    	<a class="button" style="margin-left: 20px;" onClick="resendToID(); return false;">Send to identification</a> matching against <b>location(s):</b>
-                        <%=LocationID.getHTMLSelector(true, null, null, "id-locationids", "locationID", "") %>
+                        <%=LocationID.getHTMLSelector(true, locationIds, null, "id-locationids", "locationID", "") %>
 		   </div>
 		    	
 		    <%


### PR DESCRIPTION
Restores auto-selection of the bulk import-specific locations IDs, properly scoping ID requests as a result when they are sent from the bulk import's page. The lack of this has caused overscoped matching in Wildbook and much slower, very large jobs in WBIA.

**Changes**
- Allows for multi-selection of the generated HTML for the locationID selector based on a passed in list of 0 or more location IDs. Retains single locationID selection.
- Restores scoped location ID selection by default to the location ID pulldown for matching on the bulk import page. Multiple locationIDs in the bulk import Encounters result in each locationID being included in the default scope

![image](https://github.com/WildMeOrg/Wildbook/assets/154927/c9db7f17-8c23-4244-9cbe-216742b84dc5)
