### PR TITLE
Make sure we don't look up Annotations for match results by ACM ID an…

### DIFF
--- a/src/main/java/org/ecocean/Shepherd.java
+++ b/src/main/java/org/ecocean/Shepherd.java
@@ -5716,12 +5716,15 @@ public class Shepherd {
     }
 
     public ArrayList<Annotation> getAnnotationsWithACMId(String acmId) {
-        String filter = "this.acmId == \"" + acmId + "\"";
-        Extent annClass = pm.getExtent(Annotation.class, true);
-        Query anns = pm.newQuery(annClass, filter);
+    	return getAnnotationsWithACMId(acmId,false);
+    }
+    
+    public ArrayList<Annotation> getAnnotationsWithACMId(String acmId, boolean enforceEncounterAssociation) {  	
+    	String filter = "select from org.ecocean.Annotation where acmId == \"" + acmId + "\"";
+        if(enforceEncounterAssociation)filter = "select from org.ecocean.Annotation where acmId == \"" + acmId + "\" && enc.annotations.contains(this) VARIABLES org.ecocean.Encounter enc";   
+        Query anns = pm.newQuery(filter);
         Collection c = (Collection)(anns.execute());
         ArrayList<Annotation> al = new ArrayList(c);
-
         anns.closeAll();
         if ((al != null) && (al.size() > 0)) {
             return al;

--- a/src/main/webapp/iaResultsAnnotFeed.jsp
+++ b/src/main/webapp/iaResultsAnnotFeed.jsp
@@ -113,8 +113,8 @@ if (request.getParameter("acmId") != null) {
 								//System.out.println("found cached annotation!");
 							}
 							else{
-								if(myShepherd.getAnnotationsWithACMId(token)!=null){
-									anns.addAll(myShepherd.getAnnotationsWithACMId(token));
+								if(myShepherd.getAnnotationsWithACMId(token,true)!=null){
+									anns.addAll(myShepherd.getAnnotationsWithACMId(token,true));
 									//System.out.println("adding new annotation!");
 								}
 							}


### PR DESCRIPTION
…d then get an unused, oprhaned version

Orphaned annotations can display confusing results when looked upo by ACM ID only in match results. This prevents the use of orphaned annotations for look up in match results.

PR fixes #619 

**Changes**
- Shepherd.java: Makes sure Annotations retreieved by ACM ID can have Encounter ownership enforced. Legcy method signature still supported and important future pruning of these orphaned annotations.
- iaResultsAnnotFeed.jsp: Uses the new method, enforcing annotation ownership.
