### PR TITLE
fix broken calls to getHTMLSelector()

### DIFF
--- a/src/main/webapp/appadmin/admin.jsp
+++ b/src/main/webapp/appadmin/admin.jsp
@@ -75,11 +75,11 @@ context=ServletUtilities.getContext(request);
                                            
         
 
-<%=LocationID.getHTMLSelector(false,null,null,"oldLocCode","oldLocCode","class")%>
+<%=LocationID.getHTMLSelector(false,(String)null,null,"oldLocCode","oldLocCode","class")%>
 
 
 
-              <p>New location code: <%=LocationID.getHTMLSelector(false,null,null,"newLocCode","newLocCode","class")%> <br/>
+              <p>New location code: <%=LocationID.getHTMLSelector(false,(String)null,null,"newLocCode","newLocCode","class")%> <br/>
                 <br> 
                 <input name="Update" type="submit" id="Update" value="Update">
                </p>

--- a/src/main/webapp/appadmin/locationIDTester.jsp
+++ b/src/main/webapp/appadmin/locationIDTester.jsp
@@ -41,7 +41,7 @@ myShepherd.setAction("locationIDTester.jsp");
 
 <p>
 <form>
-<%=LocationID.getHTMLSelector(true,null,null,"id","name","class")%>
+<%=LocationID.getHTMLSelector(true,(String)null,null,"id","name","class")%>
 </form>
 </p>
 
@@ -60,7 +60,7 @@ myShepherd.setAction("locationIDTester.jsp");
 
 <p>
 <form>
-<%=LocationID.getHTMLSelector(true,null,"indocet","id","name","class")%>
+<%=LocationID.getHTMLSelector(true,(String)null,"indocet","id","name","class")%>
 </form>
 </p>
 

--- a/src/main/webapp/submit.jsp
+++ b/src/main/webapp/submit.jsp
@@ -861,7 +861,7 @@ if(CommonConfiguration.showReleaseDate(context)){
       </div>
 
       <div class="col-xs-6 col-sm-6 col-md-6 col-lg-8">
-          <%=LocationID.getHTMLSelector(false, null,qualifier,"locationID","locationID","form-control") %>
+          <%=LocationID.getHTMLSelector(false,(String)null,qualifier,"locationID","locationID","form-control") %>
 
       </div>
     </div>


### PR DESCRIPTION
a change to `LocationID.java` introduced a new variation of the method `getHTMLSelector()` which created ambiguous call from a few jsp pages. these were fixed by casting null to a string.