### PR TITLE
properly notify user when a match fails due to empty matching set

### DIFF
--- a/src/main/java/org/ecocean/servlet/IAGateway.java
+++ b/src/main/java/org/ecocean/servlet/IAGateway.java
@@ -393,6 +393,7 @@ public class IAGateway extends HttpServlet {
                     taskList.put(taskRes);
                     res.put("tasks", taskList);
                     res.put("success", false);
+                    res.put("skipRequeue", true);
                     return res;
                 }
                 JSONObject jobj = new JSONObject();
@@ -740,7 +741,7 @@ public class IAGateway extends HttpServlet {
                 System.out.println(
                     "INFO: IAGateway.processQueueMessage() 'identify' from successful --> " +
                     rtn.toString());
-                if (!rtn.optBoolean("success", false)) {
+                if (!rtn.optBoolean("success", false) && !rtn.optBoolean("skipRequeue", false)) {
                     requeueIncrement = true;
                     requeue = true;
                     myShepherd.rollbackDBTransaction();

--- a/src/main/java/org/ecocean/servlet/IAGateway.java
+++ b/src/main/java/org/ecocean/servlet/IAGateway.java
@@ -385,6 +385,16 @@ public class IAGateway extends HttpServlet {
                 taskRes.put("success", false);
                 taskRes.put("error", ex.toString());
                 System.out.println(">>>>>>> parentTask: " + parentTask);
+                // in fact, this exception should be treated differently
+                if (ex.toString().contains("emptyTargetAnnotations")) {
+                    System.out.println("unrecoverable failure; will NOT requeue " + subTask);
+                    taskRes.put("subTaskId", subTask.getId());
+                    taskRes.put("subTaskIndex", i);
+                    taskList.put(taskRes);
+                    res.put("tasks", taskList);
+                    res.put("success", false);
+                    return res;
+                }
                 JSONObject jobj = new JSONObject();
                 jobj.put("identify", new JSONObject());
                 jobj.getJSONObject("identify").put("annotationIds", new JSONArray());


### PR DESCRIPTION
attempt to fail properly when an _empty matching set_ is used to match against.
testing must be done, see (2) below.

PR fixes #524 

:warning: this is only a draft because it might only fix _part_ of the problem:
1. the code changes _should_ properly short-circuit matching execution when an empty matching set is used (rather than requeue the job)
2. **what is incomplete:** will this properly set the _task results_ such that the **jsp page can report this back to user**?