### PR TITLE
Move data integrity checks above admin lockdown to ensure research-le…

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -72,7 +72,11 @@
 				#/xxxapi/** = authcBasicWildbook,roles[rest-readonly]
                 /LightRest/** = authcBasicWildbook,roles[researcher]
 
-
+			  /appadmin/dataIntegrity.jsp = authc
+			  /appadmin/iaBreakdownBySpecies.jsp = authc, roles[researcher]
+			  /appadmin/sharedAnnotations.jsp = authc
+			  /appadmin/duplicateAnnotations.jsp = authc
+			  /appadmin/dataValuesCheck.jsp = authc
 
                 /appadmin/scanTaskAdmin.jsp = authc, roles[researcher]
 				/appadmin/users.jsp = authc, roles[admin]
@@ -492,11 +496,7 @@
 		  /surveys/surveyMapEmbed.jsp = authc
 		  /obrowse.jsp = authc
 
-          /appadmin/dataIntegrity.jsp = authc
-		  /appadmin/iaBreakdownBySpecies.jsp = authc, roles[researcher]
-		  /appadmin/sharedAnnotations.jsp = authc
-		  /appadmin/duplicateAnnotations.jsp = authc
-		  /appadmin/dataValuesCheck.jsp = authc
+
 			</param-value>
         </init-param>
     </filter>


### PR DESCRIPTION
…vel accessibility

Data Integrity checks should be accessible to users. This moves their permissions above the appadmin blanket admin-level lockdown.

PR fixes #645 

**Changes**
- Move researcher-level data integrity checks above admin lockdown, making them accessible to those with login privileges
