### PR TITLE
bugfix: template can cause NPE

### DIFF
--- a/src/main/java/org/ecocean/servlet/ServletUtilities.java
+++ b/src/main/java/org/ecocean/servlet/ServletUtilities.java
@@ -176,7 +176,7 @@ public class ServletUtilities {
                 CommonConfiguration.getURLToMastheadGraphic(templateContext));
 
             templateFile = templateFile.replaceAll("SITE_NAME", siteName);
-            templateFile = templateFile.replaceAll("USER_NAME", username);
+            templateFile = templateFile.replaceAll("USER_NAME", ((username == null) ? "" : username));
             templateFile = templateFile.replaceAll("NOTIFICATION_DETAILS", notifications);
             templateFile = templateFile.replaceAll("LANGUAGE_SELECTOR", languageString);
             templateFile = templateFile.replaceAll("SELECTED_IMAGE_URL", selectedImgURL);


### PR DESCRIPTION
template code would throw a null pointer exception when username was null (e.g. user not logged in).