### PR TITLE
More efficient query (faster) where multiple location IDs scope the ID query

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -945,19 +945,36 @@ public class Annotation implements java.io.Serializable {
         if (expandedLocationIds.size() > 0) {
             // locFilter += "enc.locationID == ''";
             // loc ID's were breaking for Hawaiian names with apostrophe(s) and stuff, so overkill now
-            for (int i = 0; i < expandedLocationIds.size(); i++) {
+            
+        	//OLD WAY
+        	/*
+        	for (int i = 0; i < expandedLocationIds.size(); i++) {
                 String orString = " || ";
                 if (locFilter.equals("")) orString = "";
                 String expandedLoc = expandedLocationIds.get(i);
                 expandedLoc = expandedLoc.replaceAll("'", "\\\\'");
                 locFilter += (orString + "enc.locationID == '" + expandedLoc + "'");
             }
+            */
+        	
+        	//NEW WAY
+        	String literal = "{";
+        	for (int i = 0; i < expandedLocationIds.size(); i++) {
+        		if(i>0)literal+=",";
+                String expandedLoc = expandedLocationIds.get(i);
+                expandedLoc = expandedLoc.replaceAll("'", "\\\\'");
+                literal+="'"+expandedLoc+"'";
+            }
+        	literal+="}";
+        	locFilter=literal+".contains(enc.locationID)";
+        	
+        	
         }
         if (useNullLocation) {
             if (!locFilter.equals("")) locFilter += " || ";
-            locFilter += "enc.locationID == null";
+            locFilter ="("+locFilter+ " enc.locationID == null" +")";
         }
-        if (!locFilter.equals("")) f += " && (" + locFilter + ") ";
+        if (!locFilter.equals("")) f += " && " + locFilter + " ";
         // "owner" ... which requires we have userId in the taskParams
         JSONArray owner = j.optJSONArray("owner");
         if ((owner != null) && (userId != null)) {


### PR DESCRIPTION
Where >1 location ID scopes an ID query (e.g., (enc.locationID=='place1') || enc.locationID=='place2' )), query completion time rises dramatically (e.g., 1 sec. -> 180 seconds). due to inefficient JDOQL -> SQL translation by DataNucelus. Changing to "literal" scoping produces approx. 100-1000x improvement in query execution time by reducing query complexity and leveraging in memory comparison.

**Changes**
- ID query building now leverages literals for location ID
