### PR TITLE
Prevents empty target annotation lists from being requeued

### DIFF
--- a/src/main/java/org/ecocean/servlet/IAGateway.java
+++ b/src/main/java/org/ecocean/servlet/IAGateway.java
@@ -464,11 +464,13 @@ public class IAGateway extends HttpServlet {
             IBEISIA.waitForIAPriming();
             JSONObject sent = IBEISIA.beginIdentifyAnnotations(qanns, matchingSet, queryConfigDict,
                 userConfidence, myShepherd, task, baseUrl, fastlane);
-            if (!sent.optBoolean("success", false)) {
+            if (!sent.optBoolean("success", false) && sent.toString().indexOf("emptyTargetAnnotations")==-1) {
+
                 String errorMsg = sent.optString("error", "(unknown error)");
                 System.out.println("beginIdentifyAnnotations() was unsuccessful due to " +
                     errorMsg + "; hopefully we requeue");
                 throw new IOException("beginIdentifyAnnotations() failed due to " + errorMsg);
+ 
             }
             ann.setIdentificationStatus(IBEISIA.STATUS_PROCESSING);
             taskRes.put("beginIdentify", sent);


### PR DESCRIPTION
When there are no matching target annotations for an ID job (i.e., no data in the database to match against), that job kept getting requeued until the maximum number of requeues was exceeded, bogging down the ID qeueue with wasted querying and retries. This expires the job if "emptyTargetAnnotations" is flagged and prevents requeuing. 

**Changes**
- Prevents requeuing if there is nothing to match against.