### PR TITLE
fix dead-end for "confirm no match" button without project

### DIFF
--- a/src/main/webapp/iaResults.jsp
+++ b/src/main/webapp/iaResults.jsp
@@ -1879,16 +1879,24 @@ function negativeButtonClick(encId, oldDisplayName) {
 
 	var confirmMsg = 'Confirm no match?\n\n';
 	confirmMsg += 'By clicking \'OK\', you are confirming that there is no correct match in the results below. ';
+     var nextName = '<%=nextName%>';
+     if (nextName == 'null') nextName = false;
+     var nextNameInput = $('#negative-button-name').val();
+     console.log('negativeButtonClick(): encId=%o, oldDisplayName=%o, nextName=%o, nextNameInput=%o', encId, oldDisplayName, nextName, nextNameInput);
+     if (!nextName && !nextNameInput) return alert('You must provide a name for the new individual.');
+     if (!nextName && nextNameInput) nextName = nextNameInput;  // just for displaying below
 	if (oldDisplayName!=="undefined" && oldDisplayName && oldDisplayName !== "" && oldDisplayName.length) {
-		confirmMsg+= 'The name <%=nextName%> will be added to individual '+oldDisplayName + '.';
+	     confirmMsg+= 'The name ' + nextName + ' will be added to individual '+oldDisplayName + '.';
 	} else {
-		confirmMsg+= 'A new individual will be created with name <%=nextName%> and applied to encounter '+encDisplayString(encId) +'.';
+	     confirmMsg+= 'A new individual will be created with name ' + nextName + ' and applied to encounter '+encDisplayString(encId) +'.';
 	}
 	confirmMsg+= 'Click \'OK\' to record your decision.';
 
 	let paramStr = 'encId='+encId+'&noMatch=true';
 	let projectId = '<%=projectIdPrefix%>';
-	if (projectId&&projectId.length) {
+     if (nextNameInput) {
+		paramStr += '&nextNameInput=' + encodeURIComponent(nextNameInput);
+	} else if (projectId&&projectId.length) {
 		paramStr += '&useNextProjectId=true&projectIdPrefix='+encodeURIComponent(projectId);
 	}
 
@@ -1929,10 +1937,13 @@ function addNegativeButton(encId, oldDisplayName) {
         */
 	//if (<%=usesAutoNames%>) {
         if (true) {
-		console.log("Adding auto name/confirm negative button!");
+			var nextName = '<%=nextName%>';
+		console.log("Adding auto name/confirm negative button! nextName = %o", nextName);
 		var negativeButton = '<input onclick=\'negativeButtonClick(\"'+encId+'\", \"'+oldDisplayName+'\");\' type="button" value="Confirm No Match" />';
-		console.log("negativeButton = "+negativeButton);
-		//var negativeButton = '<input onclick="negativeButtonClick();" type="button" value="Confirm No Match" />';
+		   if (!nextName || (nextName == 'null')) {
+			   negativeButton = '<input id="negative-button-name" placeholder="Enter name for new individual" /> ' + negativeButton;
+		   }
+
 		headerDefault = negativeButton;
 		//console.log("NEGATIVE BUTTON: About to attach "+negativeButton+" to "+JSON.stringify($('div#enc-action')));
 		$('div#enc-action').html(negativeButton);

--- a/src/main/webapp/iaResultsNoMatch.jsp
+++ b/src/main/webapp/iaResultsNoMatch.jsp
@@ -40,7 +40,9 @@ if (request.getParameter("encId")!=null && request.getParameter("noMatch")!=null
 		String projectIdPrefix = request.getParameter("projectIdPrefix");
 		String researchProjectName = null;
 		String researchProjectUUID = null;
-		String nextNameString = "";
+		String nextNameInput = request.getParameter("nextNameInput");
+
+		String nextNameString = "";  // this is set but never used wtf?  FIXME
 		// okay, are we going to use an incremental name from the project side?
 		if (Util.stringExists(projectIdPrefix)) {
 			Project projectForAutoNaming = myShepherd.getProjectByProjectIdPrefix(projectIdPrefix.trim());
@@ -87,6 +89,8 @@ if (request.getParameter("encId")!=null && request.getParameter("noMatch")!=null
 			validToName = true;
 		}
 
+		if (Util.stringExists(nextNameInput)) validToName = true;
+
 		if (!validToName) {
 			rtn.put("error", "Was unable to set the next automatic name. Got key="+nextNameKey+" and val="+nextName);
 			out.println(rtn.toString());
@@ -103,10 +107,16 @@ if (request.getParameter("encId")!=null && request.getParameter("noMatch")!=null
 			IndividualAddEncounter.executeEmails(myShepherd, request,mark,true, enc, context, langCode);
 		}
 
+		// validToName should never be false here wtf FIXME
 		if (validToName&&"true".equals(useNextProjectId)) {
 			System.out.println("trying to set next PROJECT automatic name.......");
 			Project projectForAutoNaming = myShepherd.getProjectByProjectIdPrefix(projectIdPrefix.trim());
 			mark.addIncrementalProjectId(projectForAutoNaming);
+
+		} else if (nextNameInput != null) {
+			System.out.println("setting manually named nextNameInput=" + nextNameInput + " onto " + mark);
+			mark.addName(nextNameInput);
+
 		} else {
 			System.out.println("trying to set USER BASED automatic name.......");
 			// old user based id


### PR DESCRIPTION
PR fixes #598 

when match results are presented to a user _without a project filter_, this allows a user to click "Confirm No Match" button and create a new individual with a name they provide.