### PR TITLE
version change for rabbitmq lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.1.2</version>
+      <version>5.21.0</version>
     </dependency>
 
     <!--	 Dependencies related to prometheus.	 -->


### PR DESCRIPTION
library version update for rabbitmq (based on dependabot [PR473](https://github.com/WildMeOrg/Wildbook/pull/473))