### PR TITLE
Prevent login from overriding session timeout defined in web.xml

### DIFF
--- a/src/main/java/org/ecocean/api/Login.java
+++ b/src/main/java/org/ecocean/api/Login.java
@@ -65,7 +65,6 @@ public class Login extends ApiBase {
                     // get the user (aka subject) associated with this request.
                     Subject subject = SecurityUtils.getSubject();
                     Session session = subject.getSession();
-                    session.setTimeout(1000 * 60 * 60 * 24 * 30);
                     subject.login(token);
                     user.setLastLogin((new Date()).getTime());
                     myShepherd.commitDBTransaction();


### PR DESCRIPTION
Login.java defined a long session timeout that overrides the default in web.xml. This commit removes the single line of code that restores the default, expected timeout.

PR fixes #690 

**Changes**
- Removes code line overriding default session timeout
