### PR TITLE
Switch welcome.jsp to /react/login/

### DIFF
--- a/src/main/webapp/header.jsp
+++ b/src/main/webapp/header.jsp
@@ -263,7 +263,7 @@ if(request.getUserPrincipal()!=null){
                 var action = $(element).data('action');
 
                 if (action === 'login'){
-                     window.open('<%=urlLoc %>/welcome.jsp', '_blank');
+                     window.open('<%=urlLoc %>/react/login/', '_blank');
                 }
                 else {
 


### PR DESCRIPTION
Switches the timeout modal popup to use /react/login/ versus the old, deprecated /welcome.jsp.

PR fixes #699 

**Changes**
- Switch a single Javascript reference from /welcome.jsp to /react/login/
