### PR TITLE
[react][readme] Update instruction ports to match defaults, clarify PUBLIC_URL

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,14 +7,12 @@
 ### steps to build and deploy react
 
 1. create a folder `react` under deployed `wildbook/` dir
-2. create a `.env` under the root of `REPO/frontend/`, add public-facing url like this:
-  - `PUBLIC_URL=http://localhost:8080/react/` (for local tomcat)
-  - `PUBLIC_URL=https://public.url.example.com/react/`
-   add site name like this:
-  - `SITE_NAME=Amphibian Wildbook`  
+2. create a `.env` for React environment variables under the root of `REPO/frontend/`. In this file:
+    1. Add the public URL. For local tomcat development, use `PUBLIC_URL=http://localhost:81/react/` (or whatever port your local server is running on). For public deployment, use the following, where `public.url.example.com` is your deployed URL: `PUBLIC_URL=https://public.url.example.com/react/`
+    2. Add site name like this: `SITE_NAME=Amphibian Wildbook`
 3. cd to `REPO/frontend/` and run `npm run build`
 4. copy everything under `frontend/build/` to the `wildbook/react/` created in step 1
-5. refresh your browser page by visiting either `http://localhost:8080/react/` for local testing or `https://public.url.example.com/react/` for the public-facing deployment
+5. refresh your browser page by visiting either `http://localhost:81/react/` for local testing or `https://public.url.example.com/react/` for the public-facing deployment
 
 
 ### steps to setup dev environment


### PR DESCRIPTION
I'm getting the basic dev environment set up and have a couple fixes/suggestions for the React readme. Please let me know if I've gotten anything wrong, of course.

**Changes**
- Fix the port number in the instructions to match the [default](https://github.com/carllelandtaylor/Wildbook/blob/81c2cb987e8f1d250f70594dcf93014060db68fe/devops/deploy/_env.template#L33) and the [devops readme](https://github.com/carllelandtaylor/Wildbook/blob/master/devops/README.md?plain=1#L35).
- Clarify that the .env file is for React environment variables, and when you use which value for `PUBLIC_URL`.