### PR TITLE
fix google map key issue

### DIFF
--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useContext } from "react";
+import React, { useState, useRef, useContext, useEffect } from "react";
 import GoogleMapReact from "google-map-react";
 import BrutalismButton from "./BrutalismButton";
 import ThemeContext from "../ThemeColorProvider";
@@ -74,7 +74,14 @@ const MapComponent = ({ center, zoom = 10, setBounds, setTempBounds }) => {
     drawingRef.current = !drawingRef.current;
   };
 
-  const key = window?.wildbookGlobals?.gtmKey || "";
+  const [key, setKey] = useState(null);
+
+  useEffect(() => {
+    if (window?.wildbookGlobals?.gMapKey) {
+      setKey(window?.wildbookGlobals?.gMapKey);
+      console.log("key3", window?.wildbookGlobals?.gMapKey);
+    }
+  }, [window?.wildbookGlobals]);
 
   return (
     <div style={{ height: "400px", width: "100%" }}>
@@ -102,13 +109,25 @@ const MapComponent = ({ center, zoom = 10, setBounds, setTempBounds }) => {
           <FormattedMessage id="DRAW" />
         )}
       </BrutalismButton>
-      <GoogleMapReact
-        bootstrapURLKeys={{ key: key }}
-        defaultCenter={center}
-        defaultZoom={zoom}
-        yesIWantToUseGoogleMapApiInternals
-        onGoogleApiLoaded={({ map, maps }) => handleApiLoaded(map, maps)}
-      />
+      {key ? (
+        <GoogleMapReact
+          key={key}
+          bootstrapURLKeys={{ key: key }}
+          defaultCenter={center}
+          defaultZoom={zoom}
+          yesIWantToUseGoogleMapApiInternals
+          onGoogleApiLoaded={({ map, maps }) => handleApiLoaded(map, maps)}
+        />
+      ) : (
+        <div
+          className="d-flex justify-content-center align-items-center text-center w-100 h-100"
+          style={{
+            fontSize: "24px",
+          }}
+        >
+          <FormattedMessage id="MAP_LOADING" />
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -79,7 +79,6 @@ const MapComponent = ({ center, zoom = 10, setBounds, setTempBounds }) => {
   useEffect(() => {
     if (window?.wildbookGlobals?.gMapKey) {
       setKey(window?.wildbookGlobals?.gMapKey);
-      console.log("key3", window?.wildbookGlobals?.gMapKey);
     }
   }, [window?.wildbookGlobals]);
 
@@ -125,7 +124,7 @@ const MapComponent = ({ center, zoom = 10, setBounds, setTempBounds }) => {
             fontSize: "24px",
           }}
         >
-          <FormattedMessage id="MAP_LOADING" />
+          <FormattedMessage id="MAP_IS_LOADING" />
         </div>
       )}
     </div>

--- a/frontend/src/locale/de.json
+++ b/frontend/src/locale/de.json
@@ -239,5 +239,6 @@
     "CITATION_CITATION_DETAILS_1": "S. Gero, J. Levenson, J. Van Oast, J. Holmberg, A. Marine-Biologist, C. Researcher, O. Cean. (2016). Kollaborativer Datensatz von: Flukebook.org. Konsolidiert und heruntergeladen: 15. Juni 2016.",
     "CITATION_CITATION_DETAILS_2": "J. Levenson, S. Gero, J. Van Oast und J. Holmberg. 2015. Flukebook: cloudbasierte Foto-Identifikationsanalysetools für die Meeresforschung. Erreichbar unter: https://www.flukebook.org",
     "CITATION_FORWARD": "Um die Zitierung jeder Publikation / jedes Berichts, der / das die von Wild Me bereitgestellten Daten / Werkzeuge verwendet hat, zur Aufnahme in unsere Referenzliste an info@wildme.org weiterzuleiten.",
-    "CITATION_DISCLAIMER": "Wild Me oder die ursprünglichen Datenanbieter nicht für Fehler in den Daten verantwortlich machen. Obwohl wir alle Anstrengungen unternommen haben, um die Qualität der Datenbank zu gewährleisten, können wir die Genauigkeit dieser Datensätze nicht garantieren."
+    "CITATION_DISCLAIMER": "Wild Me oder die ursprünglichen Datenanbieter nicht für Fehler in den Daten verantwortlich machen. Obwohl wir alle Anstrengungen unternommen haben, um die Qualität der Datenbank zu gewährleisten, können wir die Genauigkeit dieser Datensätze nicht garantieren.",
+    "MAP_IS_LOADING" : "Karte wird geladen"
 }

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -239,5 +239,6 @@
     "CITATION_CITATION_DETAILS_1": "S.Gero, J. Levenson, J. Van Oast., J Holmberg, A. Marine-Biologist, C. Researcher, O. Cean. (2016). Collaborative dataset from: Flukebook.org. Consolidated and downloaded: June 15, 2016.",
     "CITATION_CITATION_DETAILS_2": "J. Levenson, S. Gero, J. Van Oast, and J. Holmberg. 2015. Flukebook: a cloud-based photo-identification analysis tools for marine mammal research. Accessible at: https://www.flukebook.org",
     "CITATION_FORWARD": "To forward the citation of any publication / report that made use of the data / tools provided by Wild Me for inclusion in our list of references by submitting to info@wildme.org.",
-    "CITATION_DISCLAIMER": "Not to hold Wild Me or the original data providers liable for errors in the data. While we have made every effort to ensure the quality of the database, we cannot guarantee the accuracy of these datasets."
+    "CITATION_DISCLAIMER": "Not to hold Wild Me or the original data providers liable for errors in the data. While we have made every effort to ensure the quality of the database, we cannot guarantee the accuracy of these datasets.",
+    "MAP_IS_LOADING" : "Map is loading"
 }

--- a/frontend/src/locale/es.json
+++ b/frontend/src/locale/es.json
@@ -238,5 +238,6 @@
     "CITATION_CITATION_DETAILS_1": "S. Gero, J. Levenson, J. Van Oast, J. Holmberg, A. Marine-Biologist, C. Researcher, O. Cean. (2016). Conjunto de datos colaborativo de: Flukebook.org. Consolidado y descargado: 15 de junio de 2016.",
     "CITATION_CITATION_DETAILS_2": "J. Levenson, S. Gero, J. Van Oast y J. Holmberg. 2015. Flukebook: herramientas de análisis de identificación fotográfica basadas en la nube para la investigación de mamíferos marinos. Disponible en: https://www.flukebook.org",
     "CITATION_FORWARD": "Reenviar la cita de cualquier publicación / informe que haya utilizado los datos / herramientas proporcionados por Wild Me para su inclusión en nuestra lista de referencias enviándola a info@wildme.org.",
-    "CITATION_DISCLAIMER": "No responsabilizar a Wild Me ni a los proveedores de datos originales por errores en los datos. Aunque hemos hecho todo lo posible por garantizar la calidad de la base de datos, no podemos garantizar la exactitud de estos conjuntos de datos."
+    "CITATION_DISCLAIMER": "No responsabilizar a Wild Me ni a los proveedores de datos originales por errores en los datos. Aunque hemos hecho todo lo posible por garantizar la calidad de la base de datos, no podemos garantizar la exactitud de estos conjuntos de datos.",
+    "MAP_IS_LOADING" : "El mapa se está cargando"
 }

--- a/frontend/src/locale/fr.json
+++ b/frontend/src/locale/fr.json
@@ -238,5 +238,6 @@
     "CITATION_CITATION_DETAILS_1": "S. Gero, J. Levenson, J. Van Oast, J. Holmberg, A. Marine-Biologist, C. Researcher, O. Cean. (2016). Ensemble de données collaboratif de : Flukebook.org. Consolidé et téléchargé : 15 juin 2016.",
     "CITATION_CITATION_DETAILS_2": "J. Levenson, S. Gero, J. Van Oast et J. Holmberg. 2015. Flukebook : outils d'analyse d'identification photographique basés sur le cloud pour la recherche sur les mammifères marins. Accessible sur : https://www.flukebook.org",
     "CITATION_FORWARD": "Transmettre la citation de toute publication / rapport qui a utilisé les données / outils fournis par Wild Me pour inclusion dans notre liste de références en l'envoyant à info@wildme.org.",
-    "CITATION_DISCLAIMER": "Ne pas tenir Wild Me ou les fournisseurs de données originaux responsables des erreurs dans les données. Bien que nous ayons fait tout notre possible pour garantir la qualité de la base de données, nous ne pouvons garantir l'exactitude de ces ensembles de données."
+    "CITATION_DISCLAIMER": "Ne pas tenir Wild Me ou les fournisseurs de données originaux responsables des erreurs dans les données. Bien que nous ayons fait tout notre possible pour garantir la qualité de la base de données, nous ne pouvons garantir l'exactitude de ces ensembles de données.",
+    "MAP_IS_LOADING" : "La carte est en cours de chargement"
 }

--- a/frontend/src/locale/it.json
+++ b/frontend/src/locale/it.json
@@ -238,5 +238,6 @@
     "CITATION_CITATION_DETAILS_1": "S. Gero, J. Levenson, J. Van Oast, J. Holmberg, A. Marine-Biologist, C. Researcher, O. Cean. (2016). Dataset collaborativo da: Flukebook.org. Consolidato e scaricato: 15 giugno 2016.",
     "CITATION_CITATION_DETAILS_2": "J. Levenson, S. Gero, J. Van Oast e J. Holmberg. 2015. Flukebook: strumenti di analisi basati su cloud per l'identificazione fotografica per la ricerca sui mammiferi marini. Accessibile su: https://www.flukebook.org",
     "CITATION_FORWARD": "Trasmettere la citazione di qualsiasi pubblicazione / rapporto che ha utilizzato i dati / strumenti forniti da Wild Me per l'inclusione nel nostro elenco di riferimenti inviandola a info@wildme.org.",
-    "CITATION_DISCLAIMER": "Non ritenere Wild Me o i fornitori di dati originali responsabili per errori nei dati. Sebbene abbiamo fatto tutto il possibile per garantire la qualità del database, non possiamo garantire l'accuratezza di questi dataset."
+    "CITATION_DISCLAIMER": "Non ritenere Wild Me o i fornitori di dati originali responsabili per errori nei dati. Sebbene abbiamo fatto tutto il possibile per garantire la qualità del database, non possiamo garantire l'accuratezza di questi dataset.",
+    "MAP_IS_LOADING" : "Mappa in caricamento"
 }


### PR DESCRIPTION
fix an issue on map page: changed state(key) did not trigger third party component(react google map) re-rendering, thus map was not updated with key from property files, so map always showed "development use only". updated code will fix this issue. now if key is null(initial value), show a loading status instead of map

PR does not fix a numbered issue