### PR TITLE
Migrate default config to Dockerized example

### DIFF
--- a/src/main/webapp/appadmin/editAssetStore.jsp
+++ b/src/main/webapp/appadmin/editAssetStore.jsp
@@ -40,7 +40,7 @@ out.println("<h2>" + as + "</h2><p>original configuration: <b>" + as.getConfig()
 
 // here is where you set the new values you want!  note this varies by AssetStore type, so be careful?
 AssetStoreConfig newConfig = new AssetStoreConfig();
-newConfig.put("root", "/var/lib/tomcat8/webapps/wildbook_data_dir");
+newConfig.put("root", "/usr/local/tomcat/webapps/wildbook_data_dir");
 newConfig.put("webroot", "http://example.com/wildbook_data_dir");
 
 out.println("<p>new configuration: <b>" + newConfig + "</b></p>");


### PR DESCRIPTION
Default asset store config was not a good example for Dockerized Wildbook

**Changes**
- Provide a Docker-compatible example for users