### PR TITLE
expose redirect URL from Apache Shiro back to React

### DIFF
--- a/frontend/src/FrontDesk.jsx
+++ b/frontend/src/FrontDesk.jsx
@@ -52,7 +52,6 @@ export default function FrontDesk() {
   };
 
   useEffect(() => {
-    getAllNotifications();
     checkLoginStatus();
     const intervalId = setInterval(() => {
       checkLoginStatus();
@@ -60,6 +59,12 @@ export default function FrontDesk() {
 
     return () => clearInterval(intervalId);
   }, []);
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      getAllNotifications();
+    }
+  }, [isLoggedIn]);
 
   if (loading) return <LoadingScreen />;
 

--- a/frontend/src/UnAuthenticatedSwitch.jsx
+++ b/frontend/src/UnAuthenticatedSwitch.jsx
@@ -1,15 +1,15 @@
 import React from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import Login from "./pages/Login";
 import Footer from "./components/Footer";
 import AlertBanner from "./components/AlertBanner";
 import UnAuthenticatedAppHeader from "./components/UnAuthenticatedAppHeader";
-import NotFound from "./pages/errorPages/NotFound";
 import Unauthorized from "./pages/errorPages/Unauthorized";
 import Citation from "./pages/Citation";
 
 export default function UnAuthenticatedSwitch({ showAlert, setShowAlert }) {
   const [header, setHeader] = React.useState(true);
+  const location = useLocation();
 
   return (
     <div className="d-flex flex-column min-vh-100">
@@ -41,10 +41,14 @@ export default function UnAuthenticatedSwitch({ showAlert, setShowAlert }) {
             element={<Unauthorized setHeader={setHeader} />}
           />
           <Route path="/citation" element={<Citation />} />
-          <Route path="/encounter-search" element={<Login />} />
+          
           <Route path="/login" element={<Login />} />
           <Route path="/" element={<Login />} />
-          <Route path="*" element={<NotFound setHeader={setHeader} />} />
+          <Route
+            path = "*"
+            element={<Navigate to={`/login?redirect=${location.pathname}`}/>}
+          />
+          {/* <Route path="*" element={<NotFound setHeader={setHeader} />} /> */}
         </Routes>
       </div>
       <Footer />

--- a/frontend/src/UnAuthenticatedSwitch.jsx
+++ b/frontend/src/UnAuthenticatedSwitch.jsx
@@ -46,7 +46,7 @@ export default function UnAuthenticatedSwitch({ showAlert, setShowAlert }) {
           <Route path="/" element={<Login />} />
           <Route
             path = "*"
-            element={<Navigate to={`/login?redirect=${location.pathname}`}/>}
+            element={<Navigate to={`/login?redirect=${location.pathname}${location.search}${location.hash}`}/>}
           />
         </Routes>
       </div>

--- a/frontend/src/UnAuthenticatedSwitch.jsx
+++ b/frontend/src/UnAuthenticatedSwitch.jsx
@@ -48,7 +48,6 @@ export default function UnAuthenticatedSwitch({ showAlert, setShowAlert }) {
             path = "*"
             element={<Navigate to={`/login?redirect=${location.pathname}`}/>}
           />
-          {/* <Route path="*" element={<NotFound setHeader={setHeader} />} /> */}
         </Routes>
       </div>
       <Footer />

--- a/frontend/src/locale/de.json
+++ b/frontend/src/locale/de.json
@@ -246,5 +246,6 @@
     "SESSION_LOGIN_MODAL_CONTENT" : "Sie wurden vom System abgemeldet.",
     "SESSION_EXTEND" : "Verlängern",
     "SESSION_LOGIN" : "Anmelden",
-    "SESSION_CLOSE" : "Schließen"
+    "SESSION_CLOSE" : "Schließen",
+    "LOADING" : "Laden"
 }

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -246,5 +246,6 @@
     "SESSION_LOGIN_MODAL_CONTENT" : "You've been logged out of the system.",
     "SESSION_EXTEND" : "Extend",
     "SESSION_LOGIN" : "Login",
-    "SESSION_CLOSE" : "Close"
+    "SESSION_CLOSE" : "Close",
+    "LOADING" : "Loading"
 }

--- a/frontend/src/locale/es.json
+++ b/frontend/src/locale/es.json
@@ -239,11 +239,12 @@
     "CITATION_CITATION_DETAILS_2": "J. Levenson, S. Gero, J. Van Oast y J. Holmberg. 2015. Flukebook: herramientas de análisis de identificación fotográfica basadas en la nube para la investigación de mamíferos marinos. Disponible en: https://www.flukebook.org",
     "CITATION_FORWARD": "Reenviar la cita de cualquier publicación / informe que haya utilizado los datos / herramientas proporcionados por Wild Me para su inclusión en nuestra lista de referencias enviándola a info@wildme.org.",
     "CITATION_DISCLAIMER": "No responsabilizar a Wild Me ni a los proveedores de datos originales por errores en los datos. Aunque hemos hecho todo lo posible por garantizar la calidad de la base de datos, no podemos garantizar la exactitud de estos conjuntos de datos.",
-    "MAP_IS_LOADING" : "El mapa se está cargando",
-    "SESSION_WARNING_CONTENT" : "Tu sesión está a punto de expirar.",
-    "SESSION_WARNING_TITLE" : "Advertencia de tiempo de sesión",
-    "SESSION_LOGIN_MODAL_CONTENT" : "Has sido desconectado del sistema.",
-    "SESSION_EXTEND" : "Extender",
-    "SESSION_LOGIN" : "Iniciar sesión",
-    "SESSION_CLOSE" : "Cerrar"
+    "MAP_IS_LOADING": "El mapa se está cargando",
+    "SESSION_WARNING_CONTENT": "Tu sesión está a punto de expirar.",
+    "SESSION_WARNING_TITLE": "Advertencia de tiempo de sesión",
+    "SESSION_LOGIN_MODAL_CONTENT": "Has sido desconectado del sistema.",
+    "SESSION_EXTEND": "Extender",
+    "SESSION_LOGIN": "Iniciar sesión",
+    "SESSION_CLOSE": "Cerrar",
+    "LOADING": "Cargando"
 }

--- a/frontend/src/locale/fr.json
+++ b/frontend/src/locale/fr.json
@@ -245,5 +245,6 @@
     "SESSION_LOGIN_MODAL_CONTENT" : "Vous avez été déconnecté du système.",
     "SESSION_EXTEND" : "Prolonger",
     "SESSION_LOGIN" : "Connexion",
-    "SESSION_CLOSE" : "Fermer"
+    "SESSION_CLOSE" : "Fermer",
+    "LOADING" : "Chargement"
 }

--- a/frontend/src/locale/it.json
+++ b/frontend/src/locale/it.json
@@ -245,5 +245,6 @@
     "SESSION_LOGIN_MODAL_CONTENT" : "Sei stato disconnesso dal sistema.",
     "SESSION_EXTEND" : "Estendi",
     "SESSION_LOGIN" : "Accedi",
-    "SESSION_CLOSE" : "Chiudi"
+    "SESSION_CLOSE" : "Chiudi",
+    "LOADING" : "Caricamento"
 }

--- a/frontend/src/models/auth/useLogin.js
+++ b/frontend/src/models/auth/useLogin.js
@@ -1,42 +1,46 @@
-import { useState } from 'react';
-import axios from 'axios';
-import { get } from 'lodash-es';
-import { useIntl } from 'react-intl';
+import { useState } from "react";
+import axios from "axios";
+import { get } from "lodash-es";
+import { useIntl } from "react-intl";
 
 export default function useLogin() {
   const intl = useIntl();
 
   const errorMessage = intl.formatMessage({
-    id: 'LOGIN_INVALID_EMAIL_OR_PASSWORD',
+    id: "LOGIN_INVALID_EMAIL_OR_PASSWORD",
   });
 
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  const authenticate = async (username, password, nextLocation) => {
+  const authenticate = async (username, password) => {
     try {
       setLoading(true);
       const response = await axios.request({
         url: `/api/v3/login`,
-        method: 'post',
+        method: "post",
         data: {
           username,
           password,
         },
       });
 
-      const successful = get(response, 'data.success', false);
+      const nextLocation = get(response, "data.redirectUrl", null);
+
+      const successful = get(response, "data.success", false);
+
+      console.log("nextLocation", nextLocation);
 
       if (successful) {
         let url = `${process.env.PUBLIC_URL}/home`;
         if (nextLocation) {
-          url = nextLocation?.pathname;
-          url = nextLocation?.search
-            ? url + nextLocation.search
-            : url;
-          url = nextLocation?.hash ? url + nextLocation.hash : url;
-        }
-        window.location.href = url;
+          // url = nextLocation?.pathname;
+          // url = nextLocation?.search
+          //   ? url + nextLocation.search
+          //   : url;
+          // url = nextLocation?.hash ? url + nextLocation.hash : url;
+          window.location.href = nextLocation;
+        } else window.location.href = url;
         // Fun quirk - a reload is required if there is a hash in the URL.
         // https://stackoverflow.com/questions/10612438/javascript-reload-the-page-with-hash-value
         if (nextLocation?.hash) window.location.reload();
@@ -46,7 +50,7 @@ export default function useLogin() {
     } catch (loginError) {
       setLoading(false);
       setError(errorMessage);
-      console.error('Error logging in');
+      console.error("Error logging in");
       console.error(loginError);
     }
   };

--- a/frontend/src/models/auth/useLogin.js
+++ b/frontend/src/models/auth/useLogin.js
@@ -29,7 +29,11 @@ export default function useLogin() {
 
       // use .startsWith("/") to prevent open redirects
       const successful = get(response, "data.success", false);
-      const nextLocation = get(response, "data.redirectUrl", null) || `${new URL(process.env.PUBLIC_URL).pathname}${new URLSearchParams(location.search).get("redirect")?.startsWith("/")}`;
+
+      const nextLocation = get(response, "data.redirectUrl", null)
+        || (new URLSearchParams(location.search).get("redirect")?.startsWith("/")
+          ? `${new URL(process.env.PUBLIC_URL).pathname}${new URLSearchParams(location.search).get("redirect")}${location.hash}`
+          : null);
 
       if (successful) {
         let url = nextLocation || `${process.env.PUBLIC_URL}/home`;

--- a/frontend/src/models/auth/useLogin.js
+++ b/frontend/src/models/auth/useLogin.js
@@ -29,6 +29,7 @@ export default function useLogin() {
 
       // use .startsWith("/") to prevent open redirects
       const successful = get(response, "data.success", false);
+      const nextLocation = get(response, "data.redirectUrl", null) || `${new URL(process.env.PUBLIC_URL).pathname}${new URLSearchParams(location.search).get("redirect")?.startsWith("/")}`;
 
       const nextLocation = get(response, "data.redirectUrl", null)
         || (new URLSearchParams(location.search).get("redirect")?.startsWith("/")

--- a/frontend/src/models/auth/useLogin.js
+++ b/frontend/src/models/auth/useLogin.js
@@ -35,11 +35,6 @@ export default function useLogin() {
           ? `${new URL(process.env.PUBLIC_URL).pathname}${new URLSearchParams(location.search).get("redirect")}${location.hash}`
           : null);
 
-      const nextLocation = get(response, "data.redirectUrl", null)
-        || (new URLSearchParams(location.search).get("redirect")?.startsWith("/")
-          ? `${new URL(process.env.PUBLIC_URL).pathname}${new URLSearchParams(location.search).get("redirect")}${location.hash}`
-          : null);
-
       if (successful) {
         let url = nextLocation || `${process.env.PUBLIC_URL}/home`;
         window.location.href = url;

--- a/frontend/src/models/auth/useLogin.js
+++ b/frontend/src/models/auth/useLogin.js
@@ -27,14 +27,14 @@ export default function useLogin() {
         },
       });
 
-      const nextLocation = get(response, "data.redirectUrl", null) || `${new URL(process.env.PUBLIC_URL).pathname}${new URLSearchParams(location.search).get("redirect")}`;
+      // use .startsWith("/") to prevent open redirects
       const successful = get(response, "data.success", false);
+      const nextLocation = get(response, "data.redirectUrl", null) || `${new URL(process.env.PUBLIC_URL).pathname}${new URLSearchParams(location.search).get("redirect")?.startsWith("/")}`;
 
       if (successful) {
-        let url = `${process.env.PUBLIC_URL}/home`;
-        if (nextLocation) {
-          window.location.href = nextLocation;
-        } else window.location.href = url;
+        let url = nextLocation || `${process.env.PUBLIC_URL}/home`;
+        window.location.href = url;
+
         // Fun quirk - a reload is required if there is a hash in the URL.
         // https://stackoverflow.com/questions/10612438/javascript-reload-the-page-with-hash-value
         if (nextLocation?.hash) window.location.reload();

--- a/frontend/src/models/auth/useLogin.js
+++ b/frontend/src/models/auth/useLogin.js
@@ -29,7 +29,11 @@ export default function useLogin() {
 
       // use .startsWith("/") to prevent open redirects
       const successful = get(response, "data.success", false);
-      const nextLocation = get(response, "data.redirectUrl", null) || `${new URL(process.env.PUBLIC_URL).pathname}${new URLSearchParams(location.search).get("redirect")?.startsWith("/")}`;
+
+      const nextLocation = get(response, "data.redirectUrl", null)
+        || (new URLSearchParams(location.search).get("redirect")?.startsWith("/")
+          ? `${new URL(process.env.PUBLIC_URL).pathname}${new URLSearchParams(location.search).get("redirect")}${location.hash}`
+          : null);
 
       const nextLocation = get(response, "data.redirectUrl", null)
         || (new URLSearchParams(location.search).get("redirect")?.startsWith("/")

--- a/frontend/src/models/auth/useLogin.js
+++ b/frontend/src/models/auth/useLogin.js
@@ -2,9 +2,11 @@ import { useState } from "react";
 import axios from "axios";
 import { get } from "lodash-es";
 import { useIntl } from "react-intl";
+import { useLocation } from "react-router-dom";
 
 export default function useLogin() {
   const intl = useIntl();
+  const location = useLocation();
 
   const errorMessage = intl.formatMessage({
     id: "LOGIN_INVALID_EMAIL_OR_PASSWORD",
@@ -25,20 +27,12 @@ export default function useLogin() {
         },
       });
 
-      const nextLocation = get(response, "data.redirectUrl", null);
-
+      const nextLocation = get(response, "data.redirectUrl", null) || `${new URL(process.env.PUBLIC_URL).pathname}${new URLSearchParams(location.search).get("redirect")}`;
       const successful = get(response, "data.success", false);
-
-      console.log("nextLocation", nextLocation);
 
       if (successful) {
         let url = `${process.env.PUBLIC_URL}/home`;
         if (nextLocation) {
-          // url = nextLocation?.pathname;
-          // url = nextLocation?.search
-          //   ? url + nextLocation.search
-          //   : url;
-          // url = nextLocation?.hash ? url + nextLocation.hash : url;
           window.location.href = nextLocation;
         } else window.location.href = url;
         // Fun quirk - a reload is required if there is a hash in the URL.

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -194,14 +194,21 @@ function LoginPage() {
                 type="submit"
                 onClick={handleSubmit}
                 color={theme.primaryColors.primary500}
-                // color='#00ACCE'
-                // borderColor='#00ACCE'
                 borderColor={theme.primaryColors.primary500}
                 disabled={actionDisabled}
               >
                 {intl.formatMessage({
                   id: "LOGIN_SIGN_IN",
                 })}
+
+                {loading && (
+                  <div
+                    className="spinner-border spinner-border-sm ms-1"
+                    role="status"
+                  >
+                    <span className="visually-hidden">Loading...</span>
+                  </div>
+                )}
               </BrutalismButton>
 
               {show && error && (

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { Container, Row, Col, Form, InputGroup } from "react-bootstrap";
 import { useState } from "react";
 import BrutalismButton from "../components/BrutalismButton";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import useLogin from "../models/auth/useLogin";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import WildmeLogo from "../components/svg/WildmeLogo";
@@ -206,7 +206,7 @@ function LoginPage() {
                     className="spinner-border spinner-border-sm ms-1"
                     role="status"
                   >
-                    <span className="visually-hidden">Loading...</span>
+                    <span className="visually-hidden"><FormattedMessage id="LOADING"/></span>
                   </div>
                 )}
               </BrutalismButton>

--- a/src/main/java/org/ecocean/api/Login.java
+++ b/src/main/java/org/ecocean/api/Login.java
@@ -16,6 +16,8 @@ import org.apache.shiro.authc.UnknownAccountException;
 import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.session.Session;
 import org.apache.shiro.subject.Subject;
+import org.apache.shiro.web.util.SavedRequest;
+import org.apache.shiro.web.util.WebUtils;
 import org.apache.shiro.SecurityUtils;
 
 import org.ecocean.servlet.ServletUtilities;
@@ -72,6 +74,15 @@ public class Login extends ApiBase {
                     success = true;
                     results = user.infoJSONObject(context, true);
                     results.put("success", true);
+                    
+                    //check for redirect URL
+                    SavedRequest saved=WebUtils.getAndClearSavedRequest(request);
+                    if(saved!=null) {
+                    	results.put("redirectUrl",saved.getRequestUrl());
+                    }
+
+
+                    
                 } catch (UnknownAccountException ex) {
                     // username not found
                     ex.printStackTrace();


### PR DESCRIPTION
This PR allows a Wildbook URL to a secured endpoint to be entered and then redireted back to after login.

For example, /appadmin/dataIntegrity.jsp is secured, and a public request to it should be redirected to /react/login/ before returning the user to /appadmin/dataIntegrity.jsp.

PR fixes #675 

**Changes**
- [x] Part 1: @JasonWildMe adds the "redirectURL" parameter to Login.java's returned JSON payload
- [x] Part 2: @erinz2020 ensures /react/login/ page does not make any calls to the backend Java 
  - remove call to /Collaborate if user is not yet logged in. This interferes with our ability to get the redirect URL.
  - remove call to /UserGetNotifications if user is not yet logged in. This interferes with our ability to get the redirect URL.
- [x] Part 3: @erinz2020 If JSON payload response from Login includes a "redirectUrl" value (e.g., "/appadmin/dataIntegrity.jsp"), redirect to that URL.
- [x] Part 4: @erinz2020 add a spinner on login button to display the status of loading since redirecting might take time

some test points:
1. login/logout normally
2. access protected jsp pages in logged out state, e.g. /individualSearchResults.jsp?username=test  etc
3. access protected react pages in logged out state, e.g. /react/encounter-search?username=test&state=unapproved
4. access url that contains searchQueryId, e.g. encounters/thumbnailSearchResults.jsp?searchQueryId=8cdb3e02-e199-4322-bf80-180168bd1b35&regularQuery=true
5. access url that contains hash 