### PR TITLE
showClassicSubmit property in site-settings api

### DIFF
--- a/src/main/java/org/ecocean/api/SiteSettings.java
+++ b/src/main/java/org/ecocean/api/SiteSettings.java
@@ -28,7 +28,7 @@ import org.json.JSONObject;
 
 public class SiteSettings extends ApiBase {
     public static String[] VALUES_SEX = { "unknown", "male", "female" };
-    public static String[] VALUES_ENCOUNTER_STATES = { "unapproved", "approved", "unidentifiable"};
+    public static String[] VALUES_ENCOUNTER_STATES = { "unapproved", "approved", "unidentifiable" };
 
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
     throws ServletException, IOException {
@@ -69,8 +69,8 @@ public class SiteSettings extends ApiBase {
             CommonConfiguration.getIndexedPropertyValues("measurement", context));
 
         // TODO: there was some discussion in slack about this being derived differently
-        // NOTE: historically this list was generated via CommonConfiguration using 
-        //       List<String> states = CommonConfiguration.getIndexedPropertyValues("encounterState",context)
+        // NOTE: historically this list was generated via CommonConfiguration using
+        // List<String> states = CommonConfiguration.getIndexedPropertyValues("encounterState",context)
         settings.put("encounterState", VALUES_ENCOUNTER_STATES);
 
         IAJsonProperties iaConfig = IAJsonProperties.iaConfig();
@@ -147,6 +147,10 @@ public class SiteSettings extends ApiBase {
             loci.put(locus);
         }
         settings.put("loci", loci);
+
+        settings.put("showClassicSubmit",
+            Util.booleanNotFalse(CommonConfiguration.getProperty("showClassicSubmit", context))
+            );
         // these are sensitive settings, that anon users should not get (e.g. user lists)
         if (currentUser != null) {
             JSONArray jarr = new JSONArray();

--- a/src/main/resources/bundles/commonConfiguration.properties
+++ b/src/main/resources/bundles/commonConfiguration.properties
@@ -111,6 +111,9 @@ showEXIF = true
 #show taxonomy
 showTaxonomy = true
 
+# show option for "classic" submit page in UI
+showClassicSubmit = true
+
 #for multi-species libraries, fill out the genus and species for each supported animal type, starting with genusSpecies0
 genusSpecies0 = Balaenoptera acutorostrata
 


### PR DESCRIPTION
Supports `showClassicSubmit` (boolean) commonConfiguration property and exposes it via site-settings API for frontend usage.

PR fixes #735 

**Changes**
- `showClassicSubmit` boolean in commonConfiguration
- value shown as `showClassicSubmit` in site-settings api json