### PR TITLE
update update_url to suit different path

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -51,7 +51,9 @@ function App() {
     setFilters({});
   };
 
-  const publicUrl = process.env.PUBLIC_URL ? new URL(process.env.PUBLIC_URL).pathname : "/";
+  const publicUrl = process.env.PUBLIC_URL 
+  ? (process.env.PUBLIC_URL.startsWith('http') ? new URL(process.env.PUBLIC_URL).pathname : process.env.PUBLIC_URL)
+  : "/";
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
PUBLIC_URL could be relative path or a full url, so it has to be dealt with differently
if PUBLIC_URL="/react/", use it directly, if it's a full url, parse it and get the path name

