### PR TITLE
10.4 patch public url part 2

### DIFF
--- a/frontend/src/models/auth/useLogin.js
+++ b/frontend/src/models/auth/useLogin.js
@@ -30,14 +30,13 @@ export default function useLogin() {
       // use .startsWith("/") to prevent open redirects
       const successful = get(response, "data.success", false);
       const decodedRedirect = decodeURIComponent(new URLSearchParams(location.search).get("redirect"));
+
       const backendRedirect = get(response, "data.redirectUrl", null);
       const reactRedirect = decodedRedirect.startsWith("/")
       ? `${process.env.PUBLIC_URL}${decodedRedirect}${location.hash}`
       : null;
+      
       const nextLocation = backendRedirect || reactRedirect;
-      console.log("123", backendRedirect);
-      console.log("456", reactRedirect);
-      console.log("789", nextLocation);
 
       if (successful) {
         let url = nextLocation || `${process.env.PUBLIC_URL}/home`;

--- a/frontend/src/models/auth/useLogin.js
+++ b/frontend/src/models/auth/useLogin.js
@@ -30,10 +30,14 @@ export default function useLogin() {
       // use .startsWith("/") to prevent open redirects
       const successful = get(response, "data.success", false);
       const decodedRedirect = decodeURIComponent(new URLSearchParams(location.search).get("redirect"));
-      const nextLocation = get(response, "data.redirectUrl", null)
-        || decodedRedirect.startsWith("/")
-          ? `${process.env.PUBLIC_URL}${decodedRedirect}${location.hash}`
-          : null;
+      const backendRedirect = get(response, "data.redirectUrl", null);
+      const reactRedirect = decodedRedirect.startsWith("/")
+      ? `${process.env.PUBLIC_URL}${decodedRedirect}${location.hash}`
+      : null;
+      const nextLocation = backendRedirect || reactRedirect;
+      console.log("123", backendRedirect);
+      console.log("456", reactRedirect);
+      console.log("789", nextLocation);
 
       if (successful) {
         let url = nextLocation || `${process.env.PUBLIC_URL}/home`;

--- a/frontend/src/models/auth/useLogin.js
+++ b/frontend/src/models/auth/useLogin.js
@@ -32,7 +32,7 @@ export default function useLogin() {
       const decodedRedirect = decodeURIComponent(new URLSearchParams(location.search).get("redirect"));
       const nextLocation = get(response, "data.redirectUrl", null)
         || decodedRedirect.startsWith("/")
-          ? `${new URL(process.env.PUBLIC_URL).pathname}${decodedRedirect}${location.hash}`
+          ? `${process.env.PUBLIC_URL}${decodedRedirect}${location.hash}`
           : null;
 
       if (successful) {


### PR DESCRIPTION
when building redirect url in useLogin.js, no need to parse it to get path name. we can use it directly