### PR TITLE
pom.xml fix for servers (and lock in opensearch version)

### DIFF
--- a/devops/development/docker-compose.yml
+++ b/devops/development/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       JAVA_OPTS: "-Djava.awt.headless=true -Xms4096m -Xmx4096m"
 
   opensearch:
-    image: opensearchproject/opensearch:latest
+    image: opensearchproject/opensearch:2.15.0
     healthcheck:
       test: ["CMD-SHELL", "curl --silent --fail 127.0.0.1:9200/_cluster/health || exit 1"]
       interval: 10s

--- a/pom.xml
+++ b/pom.xml
@@ -676,7 +676,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.2</version>
+        <version>3.3.2</version>
         <configuration>
           <packagingExcludes>WEB-INF/web.xml</packagingExcludes>
         </configuration>


### PR DESCRIPTION
change needed so maven can compile on servers

PR fixes #839 

**Changes**
- maven war plugin version change
- lock opensearch docker image version