### PR TITLE
Set the appropriate OpenSearch class to support hyphens in lifeStage …

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -4105,6 +4105,7 @@ public class Encounter extends Base implements java.io.Serializable {
         map.put("individualDisplayName", keywordNormalType);
         map.put("organizations", keywordNormalType);
         map.put("otherCatalogNumbers", keywordNormalType);
+        map.put("lifeStage", keywordNormalType);
 
         // https://stackoverflow.com/questions/68760699/matching-documents-where-multiple-fields-match-in-an-array-of-objects
         map.put("measurements", new org.json.JSONObject("{\"type\": \"nested\"}"));


### PR DESCRIPTION
…values. Requires reindex.

Supports Encounter searching on lifeStage values with hyphens in them, such as "male-with-brood".

PR fixes #850 

**Changes**
-Set correct OpenSearch class for lifeStage