### PR TITLE
Fix Encounter single submission multi-algorithm, cloneEncounter bug

### DIFF
--- a/src/main/java/org/ecocean/identity/IBEISIA.java
+++ b/src/main/java/org/ecocean/identity/IBEISIA.java
@@ -1499,13 +1499,9 @@ public class IBEISIA {
             		}
             	}
             	
-            	//check number of encounters
-            	System.out.println("ZZZZ Sending "+needIdentifyingMap.keySet().size() +" encounters to ID.");
             	
             	//send to ID by Encounter
             	for(String encUUID:needIdentifyingMap.keySet()) {
-            		
-            		System.out.println("ZZZZ Sending enc "+encUUID+" to ID.");
             		
             		ArrayList<Annotation> annots = needIdentifyingMap.get(encUUID);
 

--- a/src/main/java/org/ecocean/identity/IBEISIA.java
+++ b/src/main/java/org/ecocean/identity/IBEISIA.java
@@ -1480,15 +1480,61 @@ public class IBEISIA {
                 }
             }
             if (needIdentifying.size() > 0) {
-                Task task = IA.intakeAnnotations(myShepherd2, needIdentifying, parentTask, false);
-                // Here is a place we check downstream. IA.intakeAnnotations() will check the anns vs the identification classes in IA.properties,
-                // and return null if nobody was valid.
-                if (task != null) {
-                    rtn.put("identificationTaskId", task.getId());
-                    if (parentTask != null) parentTask.addChild(task);
-                    myShepherd2.storeNewTask(task);
-                }
-            } else {
+            	
+            	//split the results into encounters
+            	HashMap<String,ArrayList<Annotation>> needIdentifyingMap = new HashMap<String,ArrayList<Annotation>>();
+            	for(Annotation annot:needIdentifying) {
+            		Encounter enc=annot.findEncounter(myShepherd2);
+            		if(enc!=null) {
+            			if(needIdentifyingMap.containsKey(enc.getCatalogNumber())) {
+            				ArrayList<Annotation> annots = needIdentifyingMap.get(enc.getCatalogNumber());
+            				annots.add(annot);
+            				needIdentifyingMap.put(enc.getCatalogNumber(), annots);
+            			}
+            			else {
+            				ArrayList<Annotation> annots = new ArrayList<Annotation>();
+            				annots.add(annot);
+            				needIdentifyingMap.put(enc.getCatalogNumber(), annots);
+            			}
+            		}
+            	}
+            	
+            	//check number of encounters
+            	System.out.println("ZZZZ Sending "+needIdentifyingMap.keySet().size() +" encounters to ID.");
+            	
+            	//send to ID by Encounter
+            	for(String encUUID:needIdentifyingMap.keySet()) {
+            		
+            		System.out.println("ZZZZ Sending enc "+encUUID+" to ID.");
+            		
+            		ArrayList<Annotation> annots = needIdentifyingMap.get(encUUID);
+
+                    JSONObject j = new JSONObject();
+               		JSONObject taskParameters = j.optJSONObject("taskParameters");
+               		if (taskParameters == null) taskParameters = new JSONObject();
+               		JSONObject tp = new JSONObject();
+                    JSONObject mf = new JSONObject();
+                    taskParameters.put("matchingSetFilter", mf);
+            		
+                	Task subParentTask = new Task();  
+                    subParentTask.setParameters(taskParameters);
+                    myShepherd.storeNewTask(subParentTask);
+                    myShepherd.updateDBTransaction();
+                    
+                    Task task = IA.intakeAnnotations(myShepherd2, annots, subParentTask, false);
+                    // Here is a place we check downstream. IA.intakeAnnotations() will check the anns vs the identification classes in IA.properties,
+                    // and return null if nobody was valid.
+                    if (task != null) {
+                        rtn.put("identificationTaskId", task.getId());
+                        if (subParentTask != null) subParentTask.addChild(task);
+                        myShepherd2.storeNewTask(task);
+                    }
+            		
+            	}
+
+
+            } 
+            else {
                 System.out.println(
                     "[INFO]: No annotations were suitable for identification. Check resulting identification class(es).");
                 myShepherd2.rollbackDBTransaction();

--- a/src/main/java/org/ecocean/identity/IBEISIA.java
+++ b/src/main/java/org/ecocean/identity/IBEISIA.java
@@ -1518,14 +1518,14 @@ public class IBEISIA {
             		
                 	Task subParentTask = new Task();  
                     subParentTask.setParameters(taskParameters);
-                    myShepherd.storeNewTask(subParentTask);
-                    myShepherd.updateDBTransaction();
+                    myShepherd2.storeNewTask(subParentTask);
+                    myShepherd2.updateDBTransaction();
                     
                     Task childTask = IA.intakeAnnotations(myShepherd2, annots, subParentTask, false);
-  	              	myShepherd.storeNewTask(childTask);
-  	              	myShepherd.updateDBTransaction();
+  	              	myShepherd2.storeNewTask(childTask);
+  	              	myShepherd2.updateDBTransaction();
   	              	subParentTask.addChild(childTask);
-  	              	myShepherd.updateDBTransaction();
+  	              	myShepherd2.updateDBTransaction();
             		
             	}
 

--- a/src/main/java/org/ecocean/identity/IBEISIA.java
+++ b/src/main/java/org/ecocean/identity/IBEISIA.java
@@ -1521,14 +1521,11 @@ public class IBEISIA {
                     myShepherd.storeNewTask(subParentTask);
                     myShepherd.updateDBTransaction();
                     
-                    Task task = IA.intakeAnnotations(myShepherd2, annots, subParentTask, false);
-                    // Here is a place we check downstream. IA.intakeAnnotations() will check the anns vs the identification classes in IA.properties,
-                    // and return null if nobody was valid.
-                    if (task != null) {
-                        rtn.put("identificationTaskId", task.getId());
-                        if (subParentTask != null) subParentTask.addChild(task);
-                        myShepherd2.storeNewTask(task);
-                    }
+                    Task childTask = IA.intakeAnnotations(myShepherd2, annots, subParentTask, false);
+  	              	myShepherd.storeNewTask(childTask);
+  	              	myShepherd.updateDBTransaction();
+  	              	subParentTask.addChild(childTask);
+  	              	myShepherd.updateDBTransaction();
             		
             	}
 
@@ -1539,7 +1536,7 @@ public class IBEISIA {
                     "[INFO]: No annotations were suitable for identification. Check resulting identification class(es).");
                 myShepherd2.rollbackDBTransaction();
             }
-            myShepherd2.closeDBTransaction();
+            myShepherd2.rollbackAndClose();
         }
         return rtn;
     }


### PR DESCRIPTION
Fixes the situation where Encounter cloning (>1 animal in photo) and multi-algorithm matching cause only one algorithm's results to be shown rather than all algorithms.

PR fixes #632 

**Changes**
- Switch IBEISIA to use Encounter-based annotation submission to the matching queue. previously it was all annotations across the original and cloned Encounter.
