### PR TITLE
annotation export: regrouped/labeled ind info, added enc info

### DIFF
--- a/src/main/java/org/ecocean/servlet/export/EncounterAnnotationExportExcelFile.java
+++ b/src/main/java/org/ecocean/servlet/export/EncounterAnnotationExportExcelFile.java
@@ -204,12 +204,14 @@ public class EncounterAnnotationExportExcelFile extends HttpServlet {
                     annViewpoint, columns);
                 aanViewpointK.setMaNum(maNum);
             }
-            ExportColumn markedIndividualSex = new ExportColumn(MarkedIndividual.class,
-                "Encounter.sex", markedIndividualSexName, columns);
-            ExportColumn markedIndividuallifeStage = new ExportColumn(MarkedIndividual.class,
-                "Encounter.lifeStage", markedIndividualLifeStageName, columns);
-
+            // individual names and summaries
             MultiValueExportColumn.addNameColumns(numNameCols, columns);
+            ExportColumn markedIndividualSex = new ExportColumn(MarkedIndividual.class,
+                "IndividualSummary.sex", markedIndividualSexName, columns);
+            ExportColumn markedIndividuallifeStage = new ExportColumn(MarkedIndividual.class,
+                "IndividualSummary.lifeStage", markedIndividualLifeStageName, columns);
+
+            // encounter information
             newEasyColumn("Encounter.genus", columns);
             newEasyColumn("Encounter.specificEpithet", columns);
             newEasyColumn("Encounter.verbatimLocality", columns);
@@ -222,6 +224,8 @@ public class EncounterAnnotationExportExcelFile extends HttpServlet {
             newEasyColumn("Encounter.day", columns);
             newEasyColumn("Encounter.hour", columns);
             newEasyColumn("Encounter.minutes", columns);
+            newEasyColumn("Encounter.sex", columns);
+            newEasyColumn("Encounter.lifeStage", columns);
             newEasyColumn("Encounter.occurrenceRemarks", columns);
             ExportColumn OccurrenceComments = new ExportColumn(Occurrence.class,
                 "Occurrence.comments", occurrenceComments, columns);


### PR DESCRIPTION
On investigation, found that lifestage and sex were both pulling from individual. addressed both to avoid future confusion and grouped fields logically

PR fixes #862 

**Changes**
- relabeled the final state info from the individual
- grouped differently to be clearly associated with individual
- added encounter-specific life stage and sex
