### PR TITLE
Projects hide

### DIFF
--- a/devops/deploy/.dockerfiles/tomcat/commonConfiguration.properties
+++ b/devops/deploy/.dockerfiles/tomcat/commonConfiguration.properties
@@ -25,12 +25,6 @@
 #file system folder in which marked individual data will be stored (e.g. data files)
 #markedIndividualDirectoryLocation=individuals
 
-# default behaviors for Project object
-loggedOutDefaultDesired = true
-defaultProjectOrganizationParameter = IndoCet
-defaultProjName = Indocet Opportunistic Sightings
-defaultProjId = IndoCetOppS-
-
 #file system folder in which adoption data will be stored (e.g. photos)
 #adoptionLocation=adoptions
 

--- a/devops/development/.dockerfiles/tomcat/commonConfiguration.properties
+++ b/devops/development/.dockerfiles/tomcat/commonConfiguration.properties
@@ -25,12 +25,6 @@
 #file system folder in which marked individual data will be stored (e.g. data files)
 #markedIndividualDirectoryLocation=individuals
 
-# default behaviors for Project object
-loggedOutDefaultDesired = true
-defaultProjectOrganizationParameter = IndoCet
-defaultProjName = Indocet Opportunistic Sightings
-defaultProjId = IndoCetOppS-
-
 #file system folder in which adoption data will be stored (e.g. photos)
 #adoptionLocation=adoptions
 

--- a/src/main/java/org/ecocean/CommonConfiguration.java
+++ b/src/main/java/org/ecocean/CommonConfiguration.java
@@ -385,22 +385,6 @@ public class CommonConfiguration {
         return getProperty("newSubmissionEmail", context).trim();
     }
 
-    public static String getDefaultSelectedProject(String context) {
-        return getProperty("defaultProjName", context).trim();
-    }
-
-    public static String getDefaultProjectOrganizationParameter(String context) {
-        return getProperty("defaultProjectOrganizationParameter", context).trim();
-    }
-
-    public static String getDefaultSelectedProjectId(String context) {
-        return getProperty("defaultProjId", context).trim();
-    }
-
-    public static boolean getLoggedOutDefaultDesired(String context) {
-        return parseBoolean(getProperty("loggedOutDefaultDesired", context), false);
-    }
-
     public static String getR(String context) {
         return getProperty("R", context).trim();
     }

--- a/src/main/resources/bundles/commonConfiguration.properties
+++ b/src/main/resources/bundles/commonConfiguration.properties
@@ -6,12 +6,6 @@
 #file system folder in which marked individual data will be stored (e.g. data files)
 #markedIndividualDirectoryLocation=individuals
 
-# default behaviors for Project object
-loggedOutDefaultDesired = true
-defaultProjectOrganizationParameter = IndoCet
-defaultProjName = Indocet Opportunistic Sightings
-defaultProjId = IndoCetOppS-
-
 dataDirectoryName = wildbook_data_dir
 
 #URL to the graphic to be displayed at the top of every page through header.jsp

--- a/src/main/webapp/submit.jsp
+++ b/src/main/webapp/submit.jsp
@@ -124,26 +124,25 @@ function populateProjectNameDropdown(options, values, selectedOption, isVisible,
 		defaultSelectItemId = null;
 		loggedOutDefaultDesired = false;
 	}
-	// if(options.length<1){
-	// 	isVisible=false;
-	// }
+	if(options.length<1){
+	 	isVisible=false;
+	}
 		let projectNameHtml = '';
-		projectNameHtml += '<div class="col-xs-6 col-md-4">';
-		if(loggedOutDefaultDesired){
+
+		if(isVisible){
+			projectNameHtml += '<div class="col-xs-6 col-md-4"><label class="control-label"><%=props.getProperty("projectMultiSelectLabel") %></label></div><div class="col-xs-6 col-lg-8"><select name="proj-id-dropdown" id="proj-id-dropdown" class="form-control" multiple="multiple">';
+		}
+
+		//options
+    if(loggedOutDefaultDesired){
 			projectNameHtml += '<input type="hidden" name="defaultProject" id="defaultProject" value="' + getDefaultSelectedProjectId() + '" />';
 			// console.log("hidden default project selected with name: " + getDefaultSelectedProjectId());
 		}
-		if(isVisible){
-			projectNameHtml += '<label class="control-label "><%=props.getProperty("projectMultiSelectLabel") %></label>';
-			projectNameHtml += '<select name="proj-id-dropdown" id="proj-id-dropdown" class="form-control" multiple="multiple">';
-		}else{
-			projectNameHtml += '<select style="display: none;" name="proj-id-dropdown" id="proj-id-dropdown" class="form-control" multiple="multiple">';
-		}
-		projectNameHtml += '<option value=""></option>';
-		if(defaultSelectItem){
+    if(defaultSelectItem){
 			projectNameHtml += '<option value="' + defaultSelectItemId + '" selected>'+ defaultSelectItem +'</option>';
 			options = options.remove(defaultSelectItem);
 		}
+    projectNameHtml += '<option value=""></option>';
 		for(let i=0; i<options.length; i++){
 			if(options[i] === selectedOption){
 				projectNameHtml += '<option value="'+ values[i] +'" selected>'+ options[i] +'</option>';
@@ -151,7 +150,8 @@ function populateProjectNameDropdown(options, values, selectedOption, isVisible,
 				projectNameHtml += '<option value="'+ values[i] + '">'+ options[i] +'</option>';
 			}
 		}
-		projectNameHtml += '</div>';
+    
+		projectNameHtml += '</div></div>';
 		$("#proj-id-dropdown-container").empty();
 		$("#proj-id-dropdown-container").append(projectNameHtml);
 }
@@ -988,7 +988,7 @@ if(CommonConfiguration.showProperty("maximumElevationInMeters",context)){
 
   <fieldset>
 
-		<div class="form-group form-inline" id="proj-id-dropdown-container">
+		<div class="form-group" id="proj-id-dropdown-container">
 		</div>
 
     <div class="form-group">

--- a/src/main/webapp/submit.jsp
+++ b/src/main/webapp/submit.jsp
@@ -96,7 +96,7 @@ $(document).ready( function() {
    $('#locationID').select2({width: '100%', height:'50px'});
    $('#country').select2({width: '100%', height:'50px'});
 
-	populateProjectNameDropdown([],[],"", false, getDefaultSelectedProject(), getDefaultSelectedProjectId(), getLoggedOutDefaultDesired());
+	populateProjectNameDropdown([],[],"", false);
 	<%
 	if(user != null){
 		%>
@@ -115,15 +115,11 @@ $(document).ready( function() {
 	%>
 });
 
-function populateProjectNameDropdown(options, values, selectedOption, isVisible, defaultSelectItem, defaultSelectItemId, loggedOutDefaultDesired){
-	let useCustomStyle = '<%= ServletUtilities.useCustomStyle(request,CommonConfiguration.getDefaultProjectOrganizationParameter(context)) %>' == "true"?true: false;
-	if(useCustomStyle){
-		//do nothing unusual
-	}else{
-		defaultSelectItem = null;
-		defaultSelectItemId = null;
-		loggedOutDefaultDesired = false;
-	}
+function populateProjectNameDropdown(options, values, selectedOption, isVisible, defaultSelectItem, defaultSelectItemId){
+
+	defaultSelectItem = null;
+	defaultSelectItemId = null;
+	
 	if(options.length<1){
 	 	isVisible=false;
 	}
@@ -134,10 +130,6 @@ function populateProjectNameDropdown(options, values, selectedOption, isVisible,
 		}
 
 		//options
-    if(loggedOutDefaultDesired){
-			projectNameHtml += '<input type="hidden" name="defaultProject" id="defaultProject" value="' + getDefaultSelectedProjectId() + '" />';
-			// console.log("hidden default project selected with name: " + getDefaultSelectedProjectId());
-		}
     if(defaultSelectItem){
 			projectNameHtml += '<option value="' + defaultSelectItemId + '" selected>'+ defaultSelectItem +'</option>';
 			options = options.remove(defaultSelectItem);
@@ -167,26 +159,6 @@ Array.prototype.remove = function() {
     return this;
 };
 
-function getDefaultSelectedProject(){
-	let defaultProject = '<%= CommonConfiguration.getDefaultSelectedProject(context) %>';
-	return defaultProject;
-}
-
-function getDefaultProjectOrganizationParameter(){
-	let defaultProjectOrganizationParameter = '<%= CommonConfiguration.getDefaultProjectOrganizationParameter(context) %>';
-	return defaultProjectOrganizationParameter;
-}
-
-function getDefaultSelectedProjectId(){
-	let defaultProjectId = '<%= CommonConfiguration.getDefaultSelectedProjectId(context) %>';
-	return defaultProjectId;
-}
-
-function getLoggedOutDefaultDesired(){
-	let loggedOutDefaultDesired = '<%= CommonConfiguration.getLoggedOutDefaultDesired(context) %>';
-	return loggedOutDefaultDesired;
-}
-
 function doAjaxForProject(requestJSON,userId){
 	$.ajax({
 			url: wildbookGlobals.baseUrl + '../ProjectGet',
@@ -200,7 +172,7 @@ function doAjaxForProject(requestJSON,userId){
 				if(projectNameResults){
 					projNameOptions = projectNameResults.map(entry =>{return entry.researchProjectName});
 					projNameIds = projectNameResults.map(entry =>{return entry.projectIdPrefix});
-					populateProjectNameDropdown(projNameOptions,projNameIds,"", true, getDefaultSelectedProject(), getDefaultSelectedProjectId(), getLoggedOutDefaultDesired());
+					populateProjectNameDropdown(projNameOptions,projNameIds,"", true);
 				}
 			},
 			error: function(x,y,z) {


### PR DESCRIPTION
projects dropdown now displays conditionally if the user has projects to access. does not display anonymously

PR fixes #280 

**Changes**
- cleaned up display so field matches overall page
- hide/display based on projects available to be added to
- removed configuration options and related code that causes a default project to be selected as it was unused (confirmed across production) and messy
