### PR TITLE
Toggle old report an encounter page

### DIFF
--- a/frontend/src/AuthenticatedSwitch.jsx
+++ b/frontend/src/AuthenticatedSwitch.jsx
@@ -13,7 +13,7 @@ import Citation from "./pages/Citation";
 import ReportEncounter from "./pages/ReportsAndManagamentPages/ReportEncounter";
 import ReportConfirm from "./pages/ReportsAndManagamentPages/ReportConfirm";
 
-export default function AuthenticatedSwitch({ showAlert, setShowAlert }) {
+export default function AuthenticatedSwitch({ showAlert, setShowAlert, showclassicsubmit }) {
   const { data } = useGetMe();
   const username = data?.username;
   const avatar =
@@ -37,6 +37,7 @@ export default function AuthenticatedSwitch({ showAlert, setShowAlert }) {
           avatar={avatar}
           showAlert={showAlert}
           setShowAlert={setShowAlert}
+          showclassicsubmit={showclassicsubmit}
         />
       </div>
 

--- a/frontend/src/FrontDesk.jsx
+++ b/frontend/src/FrontDesk.jsx
@@ -14,6 +14,7 @@ import {
   sessionWarningTime,
   sessionCountdownTime,
 } from "./constants/sessionWarning";
+import useGetSiteSettings from "./models/useGetSiteSettings";
 
 export default function FrontDesk() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -25,6 +26,8 @@ export default function FrontDesk() {
     Cookies.get("showAlert") === "false" ? false : true,
   );
   const [loading, setLoading] = useState(true);
+  const { data } = useGetSiteSettings();
+  const showclassicsubmit = data?.showClassicSubmit;
 
   const checkLoginStatus = () => {
     axios
@@ -89,6 +92,7 @@ export default function FrontDesk() {
         <AuthenticatedSwitch
           showAlert={showAlert}
           setShowAlert={setShowAlert}
+          showclassicsubmit={showclassicsubmit}
         />
       </AuthContext.Provider>
     );
@@ -105,6 +109,7 @@ export default function FrontDesk() {
         <UnauthenticatedSwitch
           showAlert={showAlert}
           setShowAlert={setShowAlert}
+          showclassicsubmit={showclassicsubmit}
         />
       </AuthContext.Provider>
     );

--- a/frontend/src/UnAuthenticatedSwitch.jsx
+++ b/frontend/src/UnAuthenticatedSwitch.jsx
@@ -9,9 +9,10 @@ import Citation from "./pages/Citation";
 import ReportEncounter from "./pages/ReportsAndManagamentPages/ReportEncounter";
 import ReportConfirm from "./pages/ReportsAndManagamentPages/ReportConfirm";
 
-export default function UnAuthenticatedSwitch({ showAlert, setShowAlert }) {
+export default function UnAuthenticatedSwitch({ showAlert, setShowAlert, showclassicsubmit }) {
   const [header, setHeader] = React.useState(true);
   const location = useLocation();
+  console.log("showclassicsubmit", showclassicsubmit);
 
   const redirParam = encodeURIComponent(
     `${location.pathname}${location.search}${location.hash}`,
@@ -29,7 +30,7 @@ export default function UnAuthenticatedSwitch({ showAlert, setShowAlert }) {
         }}
       >
         {showAlert && <AlertBanner setShowAlert={setShowAlert} />}
-        <UnAuthenticatedAppHeader />
+        <UnAuthenticatedAppHeader showclassicsubmit={showclassicsubmit}/>
       </div>
 
       <div

--- a/frontend/src/UnAuthenticatedSwitch.jsx
+++ b/frontend/src/UnAuthenticatedSwitch.jsx
@@ -9,10 +9,13 @@ import Citation from "./pages/Citation";
 import ReportEncounter from "./pages/ReportsAndManagamentPages/ReportEncounter";
 import ReportConfirm from "./pages/ReportsAndManagamentPages/ReportConfirm";
 
-export default function UnAuthenticatedSwitch({ showAlert, setShowAlert, showclassicsubmit }) {
+export default function UnAuthenticatedSwitch({
+  showAlert,
+  setShowAlert,
+  showclassicsubmit,
+}) {
   const [header, setHeader] = React.useState(true);
   const location = useLocation();
-  console.log("showclassicsubmit", showclassicsubmit);
 
   const redirParam = encodeURIComponent(
     `${location.pathname}${location.search}${location.hash}`,
@@ -30,7 +33,7 @@ export default function UnAuthenticatedSwitch({ showAlert, setShowAlert, showcla
         }}
       >
         {showAlert && <AlertBanner setShowAlert={setShowAlert} />}
-        <UnAuthenticatedAppHeader showclassicsubmit={showclassicsubmit}/>
+        <UnAuthenticatedAppHeader showclassicsubmit={showclassicsubmit} />
       </div>
 
       <div

--- a/frontend/src/components/AuthenticatedAppHeader.jsx
+++ b/frontend/src/components/AuthenticatedAppHeader.jsx
@@ -10,7 +10,7 @@ import Menu from "./header/Menu";
 import FooterVisibilityContext from "../FooterVisibilityContext";
 import Logo from "./svg/Logo";
 
-export default function AuthenticatedAppHeader({ username, avatar }) {
+export default function AuthenticatedAppHeader({ username, avatar, showclassicsubmit }) {
   const { visible } = useContext(FooterVisibilityContext);
 
   const {
@@ -68,7 +68,7 @@ export default function AuthenticatedAppHeader({ username, avatar }) {
                   marginLeft: "auto",
                 }}
               >
-                <Menu username={username} />
+                <Menu username={username} showclassicsubmit={showclassicsubmit}/>
               </Nav>
               <NotificationButton
                 collaborationTitle={collaborationTitle}

--- a/frontend/src/components/UnAuthenticatedAppHeader.jsx
+++ b/frontend/src/components/UnAuthenticatedAppHeader.jsx
@@ -10,7 +10,7 @@ import { FormattedMessage } from "react-intl";
 import FooterVisibilityContext from "../FooterVisibilityContext";
 import Logo from "./svg/Logo";
 
-export default function AuthenticatedAppHeader() {
+export default function AuthenticatedAppHeader({showclassicsubmit}) {
   const { visible } = useContext(FooterVisibilityContext);
   const [dropdownShows, setDropdownShows] = useState({
     dropdown1: false,
@@ -74,7 +74,7 @@ export default function AuthenticatedAppHeader() {
                   marginLeft: "auto",
                 }}
               >
-                {unAuthenticatedMenu.map((item, idx) => (
+                {unAuthenticatedMenu(showclassicsubmit).map((item, idx) => (
                   <Nav key={idx} className="me-auto">
                     <NavDropdown
                       title={

--- a/frontend/src/components/header/Menu.jsx
+++ b/frontend/src/components/header/Menu.jsx
@@ -5,7 +5,7 @@ import DownIcon from "../svg/DownIcon";
 import RightIcon from "../svg/RightIcon";
 import { authenticatedMenu } from "../../constants/navMenu";
 
-export default function Menu({ username }) {
+export default function Menu({ username, showclassicsubmit }) {
   const [dropdownColor, setDropdownColor] = useState("transparent");
 
   const [dropdownShows, setDropdownShows] = useState({});
@@ -21,7 +21,7 @@ export default function Menu({ username }) {
 
   return (
     <>
-      {authenticatedMenu(username).map((item, idx) => (
+      {authenticatedMenu(username, showclassicsubmit).map((item, idx) => (
         <Nav className="me-auto" key={idx}>
           <NavDropdown
             className="header-dropdown"

--- a/frontend/src/constants/navMenu.js
+++ b/frontend/src/constants/navMenu.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
-const authenticatedMenu = (username) => [
+const authenticatedMenu = (username, showclassicsubmit) => [
   {
     Submit: [
       {
@@ -13,15 +13,19 @@ const authenticatedMenu = (username) => [
         ),
         href: `${process.env.PUBLIC_URL}/report`,
       },
-      {
-        name: (
-          <FormattedMessage
-            id="MENU_LEARN_REPORTENCOUNTER_CLASSIC"
-            defaultMessage="Report an Encounter(Classic)"
-          />
-        ),
-        href: "/submit.jsp",
-      },
+      ...(showclassicsubmit
+        ? [
+            {
+              name: (
+                <FormattedMessage
+                  id="MENU_LEARN_REPORTENCOUNTER_CLASSIC"
+                  defaultMessage="Report an Encounter(Classic)"
+                />
+              ),
+              href: "/submit.jsp",
+            },
+          ]
+        : []),
       {
         name: (
           <FormattedMessage
@@ -282,7 +286,7 @@ const authenticatedMenu = (username) => [
   },
 ];
 
-const unAuthenticatedMenu = [
+const unAuthenticatedMenu = (showclassicsubmit) => [
   {
     Submit: [
       {
@@ -294,15 +298,19 @@ const unAuthenticatedMenu = [
         ),
         href: `${process.env.PUBLIC_URL}/report`,
       },
-      {
-        name: (
-          <FormattedMessage
-            id="MENU_LEARN_REPORTENCOUNTER_CLASSIC"
-            defaultMessage="Report an Encounter(Classic)"
-          />
-        ),
-        href: "/submit.jsp",
-      },
+      ...(showclassicsubmit
+        ? [
+            {
+              name: (
+                <FormattedMessage
+                  id="MENU_LEARN_REPORTENCOUNTER_CLASSIC"
+                  defaultMessage="Report an Encounter(Classic)"
+                />
+              ),
+              href: "/submit.jsp",
+            },
+          ]
+        : []),
     ],
   },
   {


### PR DESCRIPTION
based on showclassicsubmit from /site-settings, show/hide the old report encounter page on both authenticated header and unauthenticated header