### PR TITLE
fix two different options for map loaders issue

### DIFF
--- a/frontend/src/pages/ReportsAndManagamentPages/PlaceSection.jsx
+++ b/frontend/src/pages/ReportsAndManagamentPages/PlaceSection.jsx
@@ -29,7 +29,6 @@ export const PlaceSection = observer(({ store }) => {
     }
     const loader = new Loader({
       apiKey: mapKey,
-      version: "weekly",
     });
 
     loader


### PR DESCRIPTION
remove the “version: weekly" option from loader so the map won't be loaded twice with different options(which will cause map display issue)

PR does not fix numbered issue.
Test cases:
check the place section of encounter submission page, check the two maps: 1. below location ID select 2. inside location ID select dropdown, all maps should show correctly