### PR TITLE
map use center and zoom data from /site-settings

### DIFF
--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -5,13 +5,19 @@ import ThemeContext from "../ThemeColorProvider";
 import { FormattedMessage } from "react-intl";
 import useGetSiteSettings from "../models/useGetSiteSettings";
 
-const MapComponent = ({ center, zoom = 10, setBounds, setTempBounds = () => {} }) => {
+const MapComponent = ({ setBounds, setTempBounds = () => {} }) => {
   const theme = useContext(ThemeContext);
-  const key = useGetSiteSettings()?.data?.googleMapsKey;
-
   const [rectangle, setRectangle] = useState(null);
   const drawingRef = useRef(false);
   const [isDrawing, setIsDrawing] = useState(false);
+
+  const { data } = useGetSiteSettings();
+  const key = data?.googleMapsKey;
+  const center = {
+    lat: data?.mapCenterLat || 50,
+    lng: data?.mapCenterLon || 7,
+  };
+  const zoom = data?.mapZoom || 4;
 
   const handleApiLoaded = (map, maps) => {
     let rect = new maps.Rectangle({

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -14,8 +14,8 @@ const MapComponent = ({ setBounds, setTempBounds = () => {} }) => {
   const { data } = useGetSiteSettings();
   const key = data?.googleMapsKey;
   const center = {
-    lat: data?.mapCenterLat || 50,
-    lng: data?.mapCenterLon || 7,
+    lat: data?.mapCenterLat || 0,
+    lng: data?.mapCenterLon || 0,
   };
   const zoom = data?.mapZoom || 4;
 

--- a/frontend/src/components/filterFields/LocationFilterMap.jsx
+++ b/frontend/src/components/filterFields/LocationFilterMap.jsx
@@ -146,8 +146,6 @@ export default function LocationFilterMap({ onChange, data }) {
         bounds={bounds}
         setBounds={setBounds}
         setTempBounds={setTempBounds}
-        center={{ lat: -1.286389, lng: 36.817223 }}
-        zoom={5}
         onChange={onChange}
       />
       <FormGroupMultiSelect


### PR DESCRIPTION
The map component previously used hardcoded values for the center and zoom settings. It now retrieves this data dynamically from the /api/v3/site-settings endpoint, allowing for platform-specific configurations.

PR fixes #802 