### PR TITLE
Update bulk import filename display

### DIFF
--- a/src/main/java/org/ecocean/servlet/importer/StandardImport.java
+++ b/src/main/java/org/ecocean/servlet/importer/StandardImport.java
@@ -294,6 +294,7 @@ public class StandardImport extends HttpServlet {
 
                 creator = AccessControl.getUser(request, myShepherd);
                 itask = new ImportTask(creator);
+                // This is where the url parameters are stored in the ImportTask
                 itask.setPassedParameters(request);
                 itask.setStatus("started");
                 if (request.getParameter("taskID") != null) {
@@ -457,7 +458,7 @@ public class StandardImport extends HttpServlet {
         out.println("<div class=\"col-sm-12 col-md-6 col-lg-6 col-xl-6\">"); // half page bootstrap column
         out.println("<h2>Import Overview</h2>");
         out.println("<ul>");
-        out.println("<li>Excel File Name: " + filename + "</li>");
+        out.println("<li>Excel File Name: " + request.getParameter("originalFilename") + "</li>");
         out.println("<li>Excel File Successfully Found = " + dataFound + "</li>");
         out.println("<li>Excel Sheets in File = " + numSheets + "</li>");
         out.println("<li>Excel Rows = " + physicalNumberOfRows + "</li>");

--- a/src/main/webapp/import.jsp
+++ b/src/main/webapp/import.jsp
@@ -417,7 +417,8 @@ try{
 	    out.println("<p id=\"refreshPara\" class=\"caption\">Refreshing results in <span id=\"countdown\"></span> seconds.</p><script>$('#refreshPara').hide();</script>");
 	    
 	    if(itask.getParameters()!=null){
-	    	out.println("<br>Filename: "+itask.getParameters().getJSONObject("_passedParameters").getJSONArray("filename").toString());
+	    	String filenameParam = itask.getParameters().getJSONObject("_passedParameters").has("originalFilename") ? "originalFilename" : "filename";
+	    	out.println("<br>Filename: "+itask.getParameters().getJSONObject("_passedParameters").getJSONArray(filenameParam).toString());
 	    }	
 	    out.println("<br><table id=\"import-table-details\" xdata-page-size=\"6\" xdata-height=\"650\" data-toggle=\"table\" data-pagination=\"false\" ><thead><tr>");
 	    String[] headers = new String[]{"Encounter", "Date", "Occurrence", "Individual", "#Images","Match Results by Class"};

--- a/src/main/webapp/import/spreadsheet.jsp
+++ b/src/main/webapp/import/spreadsheet.jsp
@@ -37,21 +37,26 @@ if (!org.ecocean.servlet.ReCAPTCHA.sessionIsHuman(request)) {
 %>
 
 <style type="text/css">
-	.hiddenFilename {
+	#hiddenFilename {
 		display: none;
+	}
+	#originalFilename {
+		display: none
 	}
 </style>
 
 <div id="hiddenFilename"></div>
-
+<div id="originalFilename"></div>
 
 <script>
 function uploadFinished() {
 	console.log("uploadFinished! Callback executing");
 	document.getElementById('updone').innerHTML = '<i>upload finished, redirecting...</i>';
 	var filename = document.getElementById('hiddenFilename').innerHTML;
+	var originalFilename = document.getElementById('originalFilename').innerHTML;
+
 	// forward user to the review page
-	window.location.replace('standard-upload?filename='+filename+"&isUserUpload=true");
+	window.location.replace('standard-upload?filename=' + filename + '&originalFilename=' + originalFilename + '&isUserUpload=true');
 	//window.location.replace('upload?filename='+filename+"&isUserUpload=true");
 }
 </script>

--- a/src/main/webapp/import/uploadFooter.jsp
+++ b/src/main/webapp/import/uploadFooter.jsp
@@ -42,8 +42,9 @@ String commitStr = request.getParameter("commit");
 boolean committing = (commitStr!=null);
 
 String filename = request.getParameter("filename");
-String uuid=Util.generateUUID();
-String uploadAction = "standard-upload?filename="+filename+"&commit=true&isUserUpload=true&taskID="+uuid;
+String originalFilename = request.getParameter("originalFilename");
+String uuid = Util.generateUUID();
+String uploadAction = "standard-upload?filename=" + filename + "&originalFilename=" + originalFilename + "&commit=true&isUserUpload=true&taskID=" + uuid;
 
 // This file is for window-dressing at the bottom of the (java-servlet) uploader at WebImport.java
 

--- a/src/main/webapp/imports.jsp
+++ b/src/main/webapp/imports.jsp
@@ -242,7 +242,10 @@ try{
 	        jobj.put("indivCount", indivCount);
 	        jobj.put("status", status);
 		    if(task.getParameters()!=null){
-		    	jobj.put("filename", task.getParameters().getJSONObject("_passedParameters").getJSONArray("filename").toString());
+				JSONObject passedParams = task.getParameters().optJSONObject("_passedParameters");
+				String filenameParam = "originalFilename";
+				if(!passedParams.has(filenameParam)) filenameParam = "filename";
+				jobj.put("filename", passedParams.optString(filenameParam, ""));
 		    }	
 	        
 	        jsonobj.put(jobj);

--- a/src/main/webapp/javascript/localUploader.js
+++ b/src/main/webapp/javascript/localUploader.js
@@ -233,7 +233,11 @@ function filesChanged(f) {
 function filesChangedSetFilename(f) {
     console.log("filesChangedSetFilename")
     filesChanged(f);
-    let filename = f.files[0].name.replace(/[^a-zA-Z0-9\. ]/g, "")
+    let originalFilename = f.files[0].name;
+    // Add original filename to hidden element on page before string processing
+    document.getElementById("originalFilename").innerHTML = originalFilename;    
+    let filename = originalFilename.replace(/[^a-zA-Z0-9\. ]/g, "")
+    // Add updated filename to hidden element on page after string processing
     document.getElementById("hiddenFilename").innerHTML = filename;    
 }
 

--- a/src/main/webapp/javascript/tests/localUploader_test.js
+++ b/src/main/webapp/javascript/tests/localUploader_test.js
@@ -1,0 +1,22 @@
+QUnit.module('filesChangedSetFilename', () => {
+    QUnit.test('sets original and hidden filename', assert => {
+        let f = {files: [{name: 'my_cool_test.xlsx'}]};
+        filesChangedSetFilename(f);
+        assert.equal(document.getElementById("originalFilename").innerHTML, 'my_cool_test.xlsx');
+        assert.equal(document.getElementById("hiddenFilename").innerHTML, 'mycooltest.xlsx');
+    });
+
+    QUnit.test('handles filename with spaces', assert => {
+        let f = {files: [{name: 'my cool test.txt'}]};
+        filesChangedSetFilename(f);
+        assert.equal(document.getElementById("originalFilename").innerHTML, 'my cool test.txt');
+        assert.equal(document.getElementById("hiddenFilename").innerHTML, 'mycooltest.txt');
+    });
+
+    QUnit.test('handles filename with multiple periods', assert => {
+        let f = {files: [{name: 'my_cool_test.file.xlsx'}]};
+        filesChangedSetFilename(f);
+        assert.equal(document.getElementById("originalFilename").innerHTML, 'my_cool_test.file.xlsx');
+        assert.equal(document.getElementById("hiddenFilename").innerHTML, 'mycooltestfile.xlsx');
+    });
+});

--- a/src/main/webapp/javascript/tests/test.html
+++ b/src/main/webapp/javascript/tests/test.html
@@ -29,5 +29,6 @@
   <script src="forceLayoutAbstract_test.js"></script>
   <script src="coOccurrenceGraph_test.js"></script>
   <script src="jsonParser_test.js"></script>
+  <script src="localUploader_test.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Update bulk import filename display such that the original name will be stored alongside the processed name in the DB and displayed if possible (for records after this update) 

PR fixes #372 

**Changes**
- store original filename in IMPORTTASK.PARAMETERS alongside parsed value
- display original filename if possible, else display parsed value

Update bulk import confirmation route: 
```
http://localhost:81/import/standard-upload?filename=WildbookBulk.xlsx&originalFilename=Wildbook_Bulk.xlsx&isUserUpload=true
```

Update bulk import confirmation overview: 
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/745ebf36-714e-4cc5-820e-437a3a758961">

Updated bulk import summary: 
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/59eb19d8-9974-4cf9-ad4e-730b886e1195">

Updated IMPORTTASK.PARAMETERS Example: 
```
{"_passedParameters":{"filename":["WildbookBulk.xlsx"],"commit":["true"],"isUserUpload":["true"],"originalFilename":["Wildbook_Bulk.xlsx"],"taskID":["9e9f7539-9f9f-4731-9488-9595b44f688a"]}}
```
Bulk Imports List View: 
<img width="1157" alt="image" src="https://github.com/user-attachments/assets/3464447c-284d-44b3-aa02-ba22231aa34b">

