### PR TITLE
Add Occurrence.groupSize to standard Standard Excel Export

### DIFF
--- a/src/main/java/org/ecocean/servlet/export/EncounterSearchExportMetadataExcel.java
+++ b/src/main/java/org/ecocean/servlet/export/EncounterSearchExportMetadataExcel.java
@@ -171,6 +171,7 @@ public class EncounterSearchExportMetadataExcel extends HttpServlet {
             newEasyColumn("Occurrence.groupBehavior", columns);
             newEasyColumn("Occurrence.minGroupSizeEstimate", columns);
             newEasyColumn("Occurrence.bestGroupSizeEstimate", columns);
+            newEasyColumn("Occurrence.groupSize", columns);
             newEasyColumn("Occurrence.maxGroupSizeEstimate", columns);
             newEasyColumn("Occurrence.numAdults", columns);
             newEasyColumn("Occurrence.numJuveniles", columns);


### PR DESCRIPTION
User request to add Occurrence.groupSize to Standard Excel Export.

**Changes**
- Adds a single line of code to enable Occurrence.groupSize field export in Excel
