### PR TITLE
improvements on background/foreground indexing

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -154,7 +154,6 @@ public class Encounter extends Base implements java.io.Serializable {
     private static HashMap<String, ArrayList<Encounter> > _matchEncounterCache = new HashMap<String,
         ArrayList<Encounter> >();
 
-
     // An URL to a thumbnail image representing the encounter.
     private String dwcImageURL;
 
@@ -678,13 +677,12 @@ public class Encounter extends Base implements java.io.Serializable {
         return (this.getNumRightSpots() > 0);
     }
 
-    
     // Sets the recorded length of the shark for this encounter.
     public void setSize(Double mysize) {
         if (mysize != null) { size = mysize; } else { size = null; }
     }
 
-    // @return the length of the shark 
+    // @return the length of the shark
     public double getSize() {
         return size.doubleValue();
     }
@@ -2450,9 +2448,10 @@ public class Encounter extends Base implements java.io.Serializable {
     public Set<String> getTissueSampleIDs() {
         Set<String> ids = new HashSet<String>();
 
-        if (tissueSamples != null) for (TissueSample ts : tissueSamples) {
-            ids.add(ts.getSampleID());
-        }
+        if (tissueSamples != null)
+            for (TissueSample ts : tissueSamples) {
+                ids.add(ts.getSampleID());
+            }
         return ids;
     }
 
@@ -4052,7 +4051,6 @@ public class Encounter extends Base implements java.io.Serializable {
                 encDate = Util.getISO8601Date(encs[encs.length - 1].getDate());
                 if (encDate != null) jgen.writeStringField("individualLastEncounterDate", encDate);
             }
-
             jgen.writeArrayFieldStart("individualSocialUnits");
             for (SocialUnit su : myShepherd.getAllSocialUnitsForMarkedIndividual(indiv)) {
                 Membership mem = su.getMembershipForMarkedIndividual(indiv);
@@ -4183,11 +4181,18 @@ public class Encounter extends Base implements java.io.Serializable {
     public static int[] opensearchSyncIndex(Shepherd myShepherd, int stopAfter)
     throws IOException {
         int[] rtn = new int[2];
+
+        if (OpenSearch.indexingActive()) {
+            System.out.println("Encounter.opensearchSyncIndex() skipped due to indexingActive()");
+            rtn[0] = -1;
+            rtn[1] = -1;
+            return rtn;
+        }
+        OpenSearch.setActiveIndexingBackground();
         String indexName = "encounter";
         OpenSearch os = new OpenSearch();
         List<List<String> > changes = os.resolveVersions(getAllVersions(myShepherd),
             os.getAllVersions(indexName));
-
         if (changes.size() != 2) throw new IOException("invalid resolveVersions results");
         List<String> needIndexing = changes.get(0);
         List<String> needRemoval = changes.get(1);
@@ -4218,6 +4223,7 @@ public class Encounter extends Base implements java.io.Serializable {
             ct++;
         }
         System.out.println("Encounter.opensearchSyncIndex() finished needRemoval");
+        OpenSearch.unsetActiveIndexingBackground();
         return rtn;
     }
 

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -63,8 +63,8 @@ public class OpenSearch {
     public static int BACKGROUND_DELAY_MINUTES = 20;
     public static int BACKGROUND_SLICE_SIZE = 2500;
     public static String QUERY_STORAGE_DIR = "/tmp"; // FIXME
-    public static String ACTIVE_TYPE_FOREGROUND = "opensearch_indexing_foreground";
-    public static String ACTIVE_TYPE_BACKGROUND = "opensearch_indexing_background";
+    static String ACTIVE_TYPE_FOREGROUND = "opensearch_indexing_foreground";
+    static String ACTIVE_TYPE_BACKGROUND = "opensearch_indexing_background";
 
     private int pitRetry = 0;
 
@@ -572,35 +572,35 @@ public class OpenSearch {
         return SystemValue.getLong(myShepherd, INDEX_TIMESTAMP_PREFIX + indexName);
     }
 
-    public boolean indexingActive() {
+    public static boolean indexingActive() {
         return indexingActiveBackground() || indexingActiveForeground();
     }
 
-    public boolean indexingActiveForeground() {
+    public static boolean indexingActiveForeground() {
         return getActive(ACTIVE_TYPE_FOREGROUND);
     }
 
-    public void setActiveIndexingForeground() {
+    public static void setActiveIndexingForeground() {
         setActive(ACTIVE_TYPE_FOREGROUND);
     }
 
-    public void unsetActiveIndexingForeground() {
+    public static void unsetActiveIndexingForeground() {
         unsetActive(ACTIVE_TYPE_FOREGROUND);
     }
 
-    public boolean indexingActiveBackground() {
+    public static boolean indexingActiveBackground() {
         return getActive(ACTIVE_TYPE_BACKGROUND);
     }
 
-    public void setActiveIndexingBackground() {
+    public static void setActiveIndexingBackground() {
         setActive(ACTIVE_TYPE_BACKGROUND);
     }
 
-    public void unsetActiveIndexingBackground() {
+    public static void unsetActiveIndexingBackground() {
         unsetActive(ACTIVE_TYPE_BACKGROUND);
     }
 
-    void setActive(String type) {
+    static void setActive(String type) {
         // we want our own shepherd as the main shepherd may not persist this til later
         Shepherd myShepherd = new Shepherd("context0");
 
@@ -616,7 +616,7 @@ public class OpenSearch {
         }
     }
 
-    void unsetActive(String type) {
+    static void unsetActive(String type) {
         Shepherd myShepherd = new Shepherd("context0");
 
         myShepherd.setAction("OpenSearch.unsetActive");
@@ -632,7 +632,7 @@ public class OpenSearch {
     }
 
     // TODO probably should get in some sort of expire/stale check here
-    boolean getActive(String type) {
+    static boolean getActive(String type) {
         Boolean active = false;
         Shepherd myShepherd = new Shepherd("context0");
 

--- a/src/main/java/org/ecocean/StartupWildbook.java
+++ b/src/main/java/org/ecocean/StartupWildbook.java
@@ -154,7 +154,7 @@ public class StartupWildbook implements ServletContextListener {
     // these get run with each tomcat startup/shutdown, if web.xml is configured accordingly.  see, e.g. https://stackoverflow.com/a/785802
     public void contextInitialized(ServletContextEvent sce) {
         ServletContext sContext = sce.getServletContext();
-        String context = "context0"; 
+        String context = "context0";
 
         System.out.println(new org.joda.time.DateTime() + " ### StartupWildbook initialized for: " +
             servletContextInfo(sContext));
@@ -171,11 +171,13 @@ public class StartupWildbook implements ServletContextListener {
             createMatchGraph();
         }
         // TODO: set strategy for the following (genericize starting "all" consumers, make configurable, move to WildbookIAM.startup, move to plugins, or other)
-        startIAQueues(context); 
+        startIAQueues(context);
         TwitterBot.startServices(context);
         MetricsBot.startServices(context);
         AcmIdBot.startServices(context);
         AnnotationLite.startup(sContext, context);
+        OpenSearch.unsetActiveIndexingBackground(); // since tomcat is just starting, these reset to false
+        OpenSearch.unsetActiveIndexingForeground();
         OpenSearch.backgroundStartup(context);
 
         try {
@@ -307,7 +309,7 @@ public class StartupWildbook implements ServletContextListener {
 
     public void contextDestroyed(ServletContextEvent sce) {
         ServletContext sContext = sce.getServletContext();
-        String context = "context0"; 
+        String context = "context0";
 
         System.out.println("* StartupWildbook destroyed called for: " +
             servletContextInfo(sContext));
@@ -327,7 +329,7 @@ public class StartupWildbook implements ServletContextListener {
 
     public static boolean skipInit(ServletContextEvent sce, String extra) {
         ServletContext sc = sce.getServletContext();
-        
+
 /*   WARNING!  this bad hackery to try to work around "double deployment" ... yuck!
      see:  https://octopus.com/blog/defining-tomcat-context-paths
  */

--- a/src/main/java/org/ecocean/SystemValue.java
+++ b/src/main/java/org/ecocean/SystemValue.java
@@ -91,6 +91,10 @@ public class SystemValue implements java.io.Serializable {
         return _set(myShepherd, key, "JSONObject", val);
     }
 
+    public static SystemValue set(Shepherd myShepherd, String key, Boolean val) {
+        return _set(myShepherd, key, "Boolean", val);
+    }
+
     public static JSONObject getValue(Shepherd myShepherd, String key) {
         SystemValue sv = load(myShepherd, key);
 
@@ -144,6 +148,19 @@ public class SystemValue implements java.io.Serializable {
         if (v.isNull("value")) return null;
         try {
             return v.getString("value");
+        } catch (JSONException ex) {
+            System.out.println("WARNING: parse error on " + v.toString() + ": " + ex.toString());
+            return null;
+        }
+    }
+
+    public static Boolean getBoolean(Shepherd myShepherd, String key) {
+        JSONObject v = getValue(myShepherd, key);
+
+        if (v == null) return null;
+        if (v.isNull("value")) return null;
+        try {
+            return v.getBoolean("value");
         } catch (JSONException ex) {
             System.out.println("WARNING: parse error on " + v.toString() + ": " + ex.toString());
             return null;

--- a/src/main/webapp/appadmin/opensearchSync.jsp
+++ b/src/main/webapp/appadmin/opensearchSync.jsp
@@ -28,8 +28,18 @@ OpenSearch os = new OpenSearch();
 
 if (resetIndex && os.existsIndex("encounter")) {
     os.deleteIndex("encounter");
+    OpenSearch.unsetActiveIndexingForeground();
+    OpenSearch.unsetActiveIndexingBackground();
     out.println("<p>deleted encounter index</p>");
 }
+
+if (OpenSearch.indexingActive()) {
+    out.println("<P>bailing due to active indexing: fore=<b>" + OpenSearch.indexingActiveForeground() + "</b>, back=<b>" + OpenSearch.indexingActiveBackground() + "</b></p>");
+    System.out.println("opensearchSync.jsp bailed due to other active indexing");
+    return;
+}
+
+OpenSearch.setActiveIndexingForeground();
 
 if (!os.existsIndex("encounter")) {
         Encounter enc = new Encounter();
@@ -60,6 +70,7 @@ if (forceNum > 0) {
 
 myShepherd.rollbackAndClose();
 
+OpenSearch.unsetActiveIndexingForeground();
 os.deleteAllPits();
 System.out.println("opensearchSync.jsp finished");
 


### PR DESCRIPTION
helps prevent simultaneous indexing

PR fixes #782 

**Changes**
- some mechanism in OpenSearch class to store active/inactive state of foreground and background indexing
- main fore/background indexing will not run if any fore/background indexing active
- sets active (at start) and inactive (at end) of processes