### PR TITLE
add eslint-disable-line to prevent restricted globals error

### DIFF
--- a/frontend/src/service-worker.js
+++ b/frontend/src/service-worker.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-globals */
+
 // This service worker can be customized!
 // See https://developers.google.com/web/tools/workbox/modules
 // for the list of available Workbox modules, or add any other


### PR DESCRIPTION
This PR addresses an ESLint issue in service-worker.js by adding a directive (/* eslint-disable no-restricted-globals */) to prevent linting errors related to the use of self, which is required in the Service Worker context. 

PR does not fix a numbered issue.