### PR TITLE
add a missing copy

### DIFF
--- a/frontend/src/locale/de.json
+++ b/frontend/src/locale/de.json
@@ -315,6 +315,7 @@
     "INVALID_LAT": "Der Breitengrad muss zwischen -90 und 90 liegen",
     "INVALID_LONG": "Der Längengrad muss zwischen -180 und 180 liegen",
     "BEERROR_REQUIRED" : "Konnte nicht übermittelt werden; erforderliches Feld fehlt: ",
+    "SUBMISSION_FAILED": "Einreichung fehlgeschlagen",
     "BEERROR_INVALID" : "Konnte nicht übermittelt werden; Feldformat war ungültig: ",
     "BEERROR_UNKNOWN" : "Konnte aufgrund eines unbekannten Fehlers nicht abgeschickt werden.",
     "ANON_UPLOAD_IMAGE_WARNING": "Bilder können erst hochgeladen werden, wenn das Captcha abgeschlossen ist.",

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -315,6 +315,7 @@
     "INVALID_LAT": "Latitude must be between -90 and 90",
     "INVALID_LONG": "Longitude must be between -180 and 180",
     "BEERROR_REQUIRED" : "Could not submit; missing required field: ",
+    "SUBMISSION_FAILED" : "Submission Failed",
     "BEERROR_INVALID" : "Could not submit; field format was invalid: ",
     "BEERROR_UNKNOWN" : "Could not submit due to unknown error.",
     "ANON_UPLOAD_IMAGE_WARNING": "Images cannot be uploaded until captcha is complete.",

--- a/frontend/src/locale/es.json
+++ b/frontend/src/locale/es.json
@@ -314,6 +314,7 @@
     "INVALID_LAT": "La latitud debe estar entre -90 y 90",
     "INVALID_LONG": "La longitud debe estar entre -180 y 180",
     "BEERROR_REQUIRED" : "No se ha podido enviar; falta el campo obligatorio: ",
+    "SUBMISSION_FAILED" : "No se pudo enviar; inténtalo de nuevo.",
     "BEERROR_INVALID" : "No se pudo enviar; el formato del campo no era válido: ",
     "BEERROR_UNKNOWN" : "No se pudo enviar debido a un error desconocido.",
     "ANON_UPLOAD_IMAGE_WARNING": "No se pueden subir imágenes hasta que se complete el captcha.",

--- a/frontend/src/locale/fr.json
+++ b/frontend/src/locale/fr.json
@@ -314,6 +314,7 @@
     "INVALID_LAT": "La latitude doit être comprise entre -90 et 90",
     "INVALID_LONG": "La longitude doit être comprise entre -180 et 180",
     "BEERROR_REQUIRED" : "Impossible de soumettre ; champ requis manquant : ",
+    "SUBMISSION_FAILED": "Échec de la soumission",
     "BEERROR_INVALID" : "Impossible de soumettre ; le format du champ n'est pas valide : ",
     "BEERROR_UNKNOWN" : "Impossible de soumettre en raison d'une erreur inconnue.",
     "ANON_UPLOAD_IMAGE_WARNING": "Les images ne peuvent pas être téléchargées tant que le captcha n'est pas complété.",

--- a/frontend/src/locale/it.json
+++ b/frontend/src/locale/it.json
@@ -314,6 +314,7 @@
     "INVALID_LAT": "La latitudine deve essere compresa tra -90 e 90",
     "INVALID_LONG": "La longitudine deve essere compresa tra -180 e 180",
     "BEERROR_REQUIRED" : "Impossibile inviare; manca un campo obbligatorio: ",
+    "SUBMISSION_FAILED" : "Invio fallito",
     "BEERROR_INVALID" : "Impossibile inviare; il formato del campo non era valido: ",
     "BEERROR_UNKNOWN" : "Impossibile inviare a causa di un errore sconosciuto.",
     "ANON_UPLOAD_IMAGE_WARNING": "Non è possibile caricare immagini finché il captcha non è completato.",


### PR DESCRIPTION
a copy is missing on report encounter page: "SUBMISSION_FAILED". it displays when submission is failed but not caused by missing fields/invalid value/unknown error. 