### PR TITLE
fix react favIcon inconsistency issue

### DIFF
--- a/frontend/src/FrontDesk.jsx
+++ b/frontend/src/FrontDesk.jsx
@@ -15,8 +15,10 @@ import {
   sessionCountdownTime,
 } from "./constants/sessionWarning";
 import useGetSiteSettings from "./models/useGetSiteSettings";
+import useDocumentTitle from "./hooks/useDocumentTitle";
 
 export default function FrontDesk() {
+  useDocumentTitle();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [collaborationTitle, setCollaborationTitle] = useState();
   const [collaborationData, setCollaborationData] = useState([]);


### PR DESCRIPTION
favIcon should be consistency across the site. call useDocumentTitle hook in FrontDesk.jsx so all react pages use the same favIcon from /api/v3/site-settings

PR fixes #952 