### PR TITLE
search result changes to allow inaccessible results 

### DIFF
--- a/frontend/src/components/DataTable.jsx
+++ b/frontend/src/components/DataTable.jsx
@@ -17,27 +17,6 @@ const customStyles = {
   },
 };
 
-const conditionalRowStyles = (theme) => [
-  {
-    when: (row) => row.tableID % 2 === 0,
-    style: {
-      backgroundColor: "#ffffff", // Light gray color
-      "&:hover": {
-        backgroundColor: theme?.primaryColors?.primary300 || "#e0f7fa",
-      },
-    },
-  },
-  {
-    when: (row) => row.tableID % 2 !== 0,
-    style: {
-      backgroundColor: "#f2f2f2", // White color
-      "&:hover": {
-        backgroundColor: theme?.primaryColors?.primary300 || "#e0f7fa",
-      },
-    },
-  },
-];
-
 const MyDataTable = ({
   title = "",
   columnNames = [],
@@ -52,6 +31,7 @@ const MyDataTable = ({
   style = {},
   tabs = [],
   isLoading = false,
+  extraStyles = [],
   onSelectedRowsChange = () => {},
   onRowClicked = () => {},
 }) => {
@@ -60,6 +40,28 @@ const MyDataTable = ({
   const [goToPage, setGoToPage] = useState("");
   const perPageOptions = [10, 20, 30, 40, 50];
   const intl = useIntl();
+
+  const conditionalRowStyles = (theme) =>
+    [
+      {
+        when: (row) => row.tableID % 2 === 0,
+        style: {
+          backgroundColor: "#ffffff", // Light gray color
+          "&:hover": {
+            backgroundColor: theme?.primaryColors?.primary300 || "#e0f7fa",
+          },
+        },
+      },
+      {
+        when: (row) => row.tableID % 2 !== 0,
+        style: {
+          backgroundColor: "#f2f2f2", // White color
+          "&:hover": {
+            backgroundColor: theme?.primaryColors?.primary300 || "#e0f7fa",
+          },
+        },
+      },
+    ].concat(extraStyles);
 
   const wrappedColumns = useMemo(
     () =>

--- a/frontend/src/pages/EncounterSearch.jsx
+++ b/frontend/src/pages/EncounterSearch.jsx
@@ -9,6 +9,7 @@ import { useSearchParams } from "react-router-dom";
 import { useIntl } from "react-intl";
 import axios from "axios";
 import { get } from "lodash";
+import ThemeColorContext from "../ThemeColorProvider";
 
 const columns = [
   { name: "INDIVIDUAL_ID", selector: "individualDisplayName" },
@@ -31,6 +32,7 @@ export default function EncounterSearch() {
   const [paramsFormFilters, setParamsFormFilters] = useState([]);
   const paramsObject = Object.fromEntries(searchParams.entries()) || {};
   const [formFilters, setFormFilters] = useState([]);
+  const theme = React.useContext(ThemeColorContext);
 
   const regularQuery = searchParams.get("regularQuery");
 
@@ -272,10 +274,20 @@ export default function EncounterSearch() {
         onPerPageChange={queryID ? setSearchIdResultPerPage1 : setPerPage}
         setSort={setSort}
         loading={false}
+        extraStyles={[
+          {
+            when: (row) => row.access === "none",
+            style: {
+              backgroundColor: theme?.statusColors?.yellow100 || "#fff3cd",
+              "&:hover": {
+                backgroundColor: theme?.primaryColors?.primary300 || "#e0f7fa",
+              },
+            },
+          },
+        ]}
         onRowClicked={(row) => {
           const url = `/encounters/encounter.jsp?number=${row.id}`;
           window.open(url, "_blank");
-          // window.location.href = url;
         }}
         onSelectedRowsChange={(selectedRows) => {
           console.log("Selected Rows: ", selectedRows);

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -4311,6 +4311,21 @@ public class Encounter extends Base implements java.io.Serializable {
         }
     }
 
+    // given a doc from opensearch, can user access it?
+    public static boolean opensearchAccess(org.json.JSONObject doc, User user,
+        Shepherd myShepherd) {
+        if ((doc == null) || (user == null)) return false;
+        if (doc.optBoolean("publiclyReadable", false)) return true;
+        if (doc.optString("submitterUserId", "__FAIL__").equals(user.getId())) return true;
+        if (user.isAdmin(myShepherd)) return true;
+        org.json.JSONArray viewUsers = doc.optJSONArray("viewUsers");
+        if (viewUsers == null) return false;
+        for (int i = 0; i < viewUsers.length(); i++) {
+            if (viewUsers.optString(i, "__FAIL__").equals(user.getId())) return true;
+        }
+        return false;
+    }
+
     @Override public long getVersion() {
         return Util.getVersionFromModified(modified);
     }

--- a/src/main/java/org/ecocean/EncounterQueryProcessor.java
+++ b/src/main/java/org/ecocean/EncounterQueryProcessor.java
@@ -105,7 +105,8 @@ public class EncounterQueryProcessor extends QueryProcessor {
                         return failed;
                     }
                     // Encounter enc = myShepherd.getEncounter(hId);
-                    boolean hasAccess = Encounter.opensearchAccess(h, user, myShepherd);
+                    boolean hasAccess = Encounter.opensearchAccess(h.optJSONObject("_source"), user,
+                        myShepherd);
                     if (hasAccess) encIds.add(hId);
                 }
             } catch (Exception ex) {
@@ -1598,7 +1599,8 @@ public class EncounterQueryProcessor extends QueryProcessor {
                         return new EncounterQueryResult(rEncounters, searchQuery.toString(),
                                 "OpenSearch id " + searchQueryId);
                     }
-                    boolean hasAccess = Encounter.opensearchAccess(h, user, myShepherd);
+                    boolean hasAccess = Encounter.opensearchAccess(h.optJSONObject("_source"), user,
+                        myShepherd);
                     if (hasAccess) {
                         Encounter enc = myShepherd.getEncounter(hId);
                         if (enc != null) rEncounters.add(enc);

--- a/src/main/java/org/ecocean/EncounterQueryProcessor.java
+++ b/src/main/java/org/ecocean/EncounterQueryProcessor.java
@@ -105,7 +105,8 @@ public class EncounterQueryProcessor extends QueryProcessor {
                         return failed;
                     }
                     // Encounter enc = myShepherd.getEncounter(hId);
-                    encIds.add(hId);
+                    boolean hasAccess = Encounter.opensearchAccess(h, user, myShepherd);
+                    if (hasAccess) encIds.add(hId);
                 }
             } catch (Exception ex) {
                 ex.printStackTrace();
@@ -1597,8 +1598,11 @@ public class EncounterQueryProcessor extends QueryProcessor {
                         return new EncounterQueryResult(rEncounters, searchQuery.toString(),
                                 "OpenSearch id " + searchQueryId);
                     }
-                    Encounter enc = myShepherd.getEncounter(hId);
-                    if (enc != null) rEncounters.add(enc);
+                    boolean hasAccess = Encounter.opensearchAccess(h, user, myShepherd);
+                    if (hasAccess) {
+                        Encounter enc = myShepherd.getEncounter(hId);
+                        if (enc != null) rEncounters.add(enc);
+                    }
                 }
             } catch (Exception ex) {
                 ex.printStackTrace();

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -653,35 +653,8 @@ public class OpenSearch {
     public static JSONObject querySanitize(JSONObject query, User user, Shepherd myShepherd)
     throws IOException {
         if ((query == null) || (user == null)) throw new IOException("empty query or user");
-        // do not add permissions clause when we are admin, as user has no restriction
-        if (user.isAdmin(myShepherd)) return query;
-        // if (!Collaboration.securityEnabled("context0")) TODO do we want to allow everything searchable?
-/*
-        JSONObject permClause = new JSONObject("{\"bool\": {\"should\": [] }}");
-            "{\"bool\": {\"should\": [{\"term\": {\"publiclyReadable\": true}}, {\"term\": {\"viewUsers\": \""
- + user.getId() + "\"}} ] }}");
- */
-        JSONArray shouldArr = new JSONArray();
-        shouldArr.put(new JSONObject("{\"term\": {\"publiclyReadable\": true}}"));
-        shouldArr.put(new JSONObject("{\"term\": {\"submitterUserId\": \"" + user.getId() +
-            "\"}}"));
-        shouldArr.put(new JSONObject("{\"term\": {\"viewUsers\": \"" + user.getId() + "\"}}"));
-        JSONObject pshould = new JSONObject();
-        pshould.put("should", shouldArr);
-        JSONObject permClause = new JSONObject();
-        permClause.put("bool", pshould);
-        JSONObject newQuery = new JSONObject(query.toString());
-        try {
-            JSONArray filter = newQuery.getJSONObject("query").getJSONObject("bool").getJSONArray(
-                "filter");
-            filter.put(permClause);
-        } catch (Exception ex) {
-            System.out.println(
-                "OpenSearch.querySanitize() failed to find placement for permissions in query=" +
-                query + "; cause: " + ex);
-            throw new IOException("unable to find placement for permissions clause in query");
-        }
-        return newQuery;
+        // see issue 958 - now we let query pass as-is for anyone, results are scrubbed later XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX FIXME add method ref
+        return query;
     }
 
     public static boolean indexingActive() {

--- a/src/main/java/org/ecocean/api/SearchApi.java
+++ b/src/main/java/org/ecocean/api/SearchApi.java
@@ -101,10 +101,8 @@ public class SearchApi extends ApiBase {
                             JSONObject doc = h.optJSONObject("_source");
                             if (doc == null)
                                 throw new IOException("failed to parse doc in hits[" + i + "]");
-                            // these are kind of noisy
-                            doc.remove("viewUsers");
-                            doc.remove("editUsers");
-                            hitsArr.put(doc);
+                            hitsArr.put(OpenSearch.sanitizeDoc(doc, indexName, myShepherd,
+                                currentUser));
                         }
                         response.setHeader("X-Wildbook-Total-Hits", Integer.toString(totalHits));
                         response.setHeader("X-Wildbook-Search-Query-Id", searchQueryId);


### PR DESCRIPTION
search results allow user to see minimal results for matches they do not have access to

PR fixes #958 

- Do not limit query based on permissions
- API:
  - Return all results, with inaccessible ones containing only minimal fields
  - New field `access` can be used to stylize/filter results based on user permissions
- EncounterQueryProcessor: only allow items with access (skip inaccessible)
