### PR TITLE
950 add meta description in react

### DIFF
--- a/frontend/src/hooks/useDocumentTitle.js
+++ b/frontend/src/hooks/useDocumentTitle.js
@@ -4,7 +4,6 @@ import useGetSiteSettings from "../models/useGetSiteSettings";
 export default function useDocumentTitle() {
   const { data: siteSettings } = useGetSiteSettings();
 
-  console.log("siteSettings", siteSettings);
   document.title = siteSettings?.siteName || "wildbook";
   useEffect(() => {
     if (!siteSettings) return;
@@ -34,13 +33,6 @@ export default function useDocumentTitle() {
       meta.content = siteSettings?.siteAuthor;
       document.getElementsByTagName("head")[0].appendChild(meta);
     }
-
-    console.log(
-      "++++++++++++",
-      siteSettings.siteDescription,
-      siteSettings.siteKeywords,
-      siteSettings.siteAuthor,
-    );
 
     if (link) {
       link.href = iconURL;

--- a/frontend/src/hooks/useDocumentTitle.js
+++ b/frontend/src/hooks/useDocumentTitle.js
@@ -3,10 +3,44 @@ import useGetSiteSettings from "../models/useGetSiteSettings";
 
 export default function useDocumentTitle() {
   const { data: siteSettings } = useGetSiteSettings();
+
+  console.log("siteSettings", siteSettings);
   document.title = siteSettings?.siteName || "wildbook";
   useEffect(() => {
+    if (!siteSettings) return;
     let iconURL = siteSettings?.siteFavicon;
     let link = document.querySelector("link[rel*='icon']");
+    const metaDescription = document.querySelector("meta[name='description']");
+    const metaKeywords = document.querySelector("meta[name='keywords']");
+    const metaAuthor = document.querySelector("meta[name='author']");
+
+    if (!metaDescription) {
+      const meta = document.createElement("meta");
+      meta.name = "description";
+      meta.content = siteSettings?.siteDescription;
+      document.getElementsByTagName("head")[0].appendChild(meta);
+    }
+
+    if (!metaKeywords) {
+      const meta = document.createElement("meta");
+      meta.name = "keywords";
+      meta.content = siteSettings?.siteKeywords;
+      document.getElementsByTagName("head")[0].appendChild(meta);
+    }
+
+    if (!metaAuthor) {
+      const meta = document.createElement("meta");
+      meta.name = "author";
+      meta.content = siteSettings?.siteAuthor;
+      document.getElementsByTagName("head")[0].appendChild(meta);
+    }
+
+    console.log(
+      "++++++++++++",
+      siteSettings.siteDescription,
+      siteSettings.siteKeywords,
+      siteSettings.siteAuthor,
+    );
 
     if (link) {
       link.href = iconURL;

--- a/src/main/java/org/ecocean/api/SiteSettings.java
+++ b/src/main/java/org/ecocean/api/SiteSettings.java
@@ -47,6 +47,9 @@ public class SiteSettings extends ApiBase {
         // note: there is a CommonConfiguration property: htmlShortcutIcon=images/favicon.ico?v=2
         settings.put("siteFavicon", "/images/favicon.ico");
         settings.put("siteName", CommonConfiguration.getHTMLTitle(context));
+        settings.put("siteDescription", CommonConfiguration.getHTMLDescription(context));
+        settings.put("siteKeywords", CommonConfiguration.getHTMLKeywords(context));
+        settings.put("siteAuthor", CommonConfiguration.getHTMLAuthor(context));
         settings.put("locationData", LocationID.getLocationIDStructure());
 
         settings.put("mapCenterLat", CommonConfiguration.getCenterLat(context));


### PR DESCRIPTION
react pages should have the same meta description, key words and author info as jsp pages do do for better SEO.
now we get them from commonConfiguration properties.