### PR TITLE
Restore Encounter Search pathing while legacy Encounter Search is temporatily supported

### DIFF
--- a/src/main/webapp/encounters/encounterSearch.jsp
+++ b/src/main/webapp/encounters/encounterSearch.jsp
@@ -250,7 +250,7 @@ $(".search-collapse-header a").click(function(){
 <p><em><%=encprops.getProperty("instructions")%>
 </em></p>
 
-<form action="/react/login" method="get" name="encounterSearch" id="search">
+<form action="searchResults.jsp" method="get" name="encounterSearch" id="search">
 
   <%
 		if(request.getParameter("referenceImageName")!=null){

--- a/src/main/webapp/encounters/searchResults.jsp
+++ b/src/main/webapp/encounters/searchResults.jsp
@@ -35,7 +35,7 @@ context=ServletUtilities.getContext(request);
 
 
   Shepherd myShepherd = new Shepherd(context);
-  myShepherd.setAction("/react/login");
+  myShepherd.setAction("searchResults.jsp");
   String[] projectIds = null;
   int projectIdCount = 0;
   if(Util.isUUID(request.getParameter("projectId"))){


### PR DESCRIPTION
Previous string replacement seems to have replace some Strings that were functionally part of legacy Encounter Search. This fixes that and is necessary for legacy Encounter Search to reach its corresponding results page.

