### PR TITLE
removes redundant database close that will otherwise happen anyway in …

### DIFF
--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -2609,7 +2609,7 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
                 try {
                     MarkedIndividual indiv = bgShepherd.getMarkedIndividual(indivId);
                     if ((indiv == null) || (indiv.getEncounters() == null)) {
-                        bgShepherd.rollbackAndClose();
+                        //bgShepherd.rollbackAndClose();
                         executor.shutdown();
                         return;
                     }


### PR DESCRIPTION
…the finaly{} block, even if the return is called.

An exception can be thrown due to a database close in the try{} block and then again in the finally{} block. This removes the redundant database close, trusting the finally{} to handle the close, even with the return; out of the function..


