### PR TITLE
Remove an unnecessary and functional blocker indexing line

### DIFF
--- a/src/main/java/org/ecocean/servlet/IndividualRemoveEncounter.java
+++ b/src/main/java/org/ecocean/servlet/IndividualRemoveEncounter.java
@@ -107,7 +107,7 @@ public class IndividualRemoveEncounter extends HttpServlet {
                 }
                 if (!locked) {
                     myShepherd.commitDBTransaction();
-                    if (enc2remove != null) enc2remove.opensearchIndexDeep();
+                    //if (enc2remove != null) enc2remove.opensearchIndexDeep();
                     out.println(ServletUtilities.getHeader(request));
                     response.setStatus(HttpServletResponse.SC_OK);
                     out.println("<strong>Success:</strong> Encounter #" +

--- a/src/main/java/org/ecocean/servlet/OccurrenceRemoveEncounter.java
+++ b/src/main/java/org/ecocean/servlet/OccurrenceRemoveEncounter.java
@@ -83,7 +83,7 @@ public class OccurrenceRemoveEncounter extends HttpServlet {
                 if (!locked) {
                     myShepherd.commitDBTransaction();
                     // out.println(ServletUtilities.getHeader(request));
-                    if (enc2remove != null) enc2remove.opensearchIndexDeep();
+                    //if (enc2remove != null) enc2remove.opensearchIndexDeep();
                     out.println("<strong>Success:</strong> Encounter " +
                         request.getParameter("number") +
                         " was successfully removed from occurrence " + old_name + ".");


### PR DESCRIPTION
This indexing is duplicative (the Shepherd.commitDBTransaction() should index the Encounter) and has been reported as blocking prompt execution.

https://community.wildme.org/t/sharkbook-bug-cannot-remove-identity-from-a-particular-encounter-and-delete-it/4546/2

Removing shows correct indexing and makes the servlet (IndividualRemoveEncounter) speedy again.
