### PR TITLE
Allow finally{} to handle Shepherd close for indexing

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -4720,7 +4720,6 @@ public class Encounter extends Base implements java.io.Serializable {
                     if (enc == null) {
                         // we use origEnc if we can (especially necessary on initial creation of Encounter)
                         if (origEnc != null) origEnc.opensearchIndex();
-                        bgShepherd.rollbackAndClose();
                         executor.shutdown();
                         return;
                     }

--- a/src/main/java/org/ecocean/Occurrence.java
+++ b/src/main/java/org/ecocean/Occurrence.java
@@ -1370,7 +1370,6 @@ public class Occurrence extends Base implements java.io.Serializable {
                 try {
                     Occurrence occur = bgShepherd.getOccurrence(occurId);
                     if ((occur == null) || (occur.getEncounters() == null)) {
-                        bgShepherd.rollbackAndClose();
                         executor.shutdown();
                         return;
                     }


### PR DESCRIPTION
Prevents exceptions showing up in the logs due to duplicate attempts to close a Shepherd during Encounter and Occurrence indexing. 


