### PR TITLE
873 opensearch indexing annotations

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -166,6 +166,14 @@ public class Annotation extends Base implements java.io.Serializable {
         return null;
     }
 
+    @Override public String getAllVersionsSql() {
+        return "SELECT \"ID\", \"VERSION\" AS version FROM \"ANNOTATION\" ORDER BY version";
+    }
+
+    @Override public Base getById(Shepherd myShepherd, String id) {
+        return myShepherd.getAnnotation(id);
+    }
+
     @Override public void setComments(final String comments) {
     }
 

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -165,6 +165,7 @@ public class Annotation extends Base implements java.io.Serializable {
         Encounter enc = this.findEncounter(myShepherd);
         if (enc != null) {
             jgen.writeStringField("encounterId", enc.getId());
+            jgen.writeStringField("encounterSubmitterId", enc.getSubmitterID());
             jgen.writeStringField("encounterLocationId", enc.getLocationID());
             jgen.writeStringField("encounterTaxonomy", enc.getTaxonomyString());
         }

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -214,6 +214,7 @@ public class Annotation extends Base implements java.io.Serializable {
 
     public void setAcmId(String id) {
         this.acmId = id;
+        this.setVersion();
     }
 
     public String getAcmId() {
@@ -230,11 +231,13 @@ public class Annotation extends Base implements java.io.Serializable {
 
     public void setFeatures(ArrayList<Feature> f) {
         features = f;
+        this.setVersion();
     }
 
     public void addFeature(Feature f) {
         if (features == null) features = new ArrayList<Feature>();
         if (!features.contains(f)) features.add(f);
+        this.setVersion();
     }
 
     public String getId() {
@@ -243,6 +246,7 @@ public class Annotation extends Base implements java.io.Serializable {
 
     public void setId(String id) {
         this.id = id;
+        this.setVersion();
     }
 
     public Double getQuality() {
@@ -417,6 +421,7 @@ public class Annotation extends Base implements java.io.Serializable {
 
     public void setViewpoint(String v) {
         viewpoint = v;
+        this.setVersion();
     }
 
     // note!  this can block and take a while if IA has yet to compute the viewpoint!
@@ -534,6 +539,7 @@ public class Annotation extends Base implements java.io.Serializable {
 
     public void setIAClass(String iaClass) {
         this.iaClass = iaClass;
+        this.setVersion();
     }
 
     public boolean hasIAClass() {
@@ -589,6 +595,7 @@ public class Annotation extends Base implements java.io.Serializable {
 
     public void setMatchAgainst(boolean b) {
         matchAgainst = b;
+        this.setVersion();
     }
 
     public String getIdentificationStatus() {
@@ -597,6 +604,7 @@ public class Annotation extends Base implements java.io.Serializable {
 
     public void setIdentificationStatus(String status) {
         this.identificationStatus = status;
+        this.setVersion();
     }
 
     // if this cannot determine a bounding box, then we return null

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -123,22 +123,31 @@ public class Annotation extends Base implements java.io.Serializable {
         return version;
     }
 
+    public long setVersion() {
+        version = System.currentTimeMillis();
+        return version;
+    }
+
     public JSONObject opensearchMapping() {
         JSONObject map = super.opensearchMapping();
+        JSONObject keywordType = new org.json.JSONObject("{\"type\": \"keyword\"}");
 
 /*
-        org.json.JSONObject keywordType = new org.json.JSONObject("{\"type\": \"keyword\"}");
-        org.json.JSONObject keywordNormalType = new org.json.JSONObject(
+        JSONObject keywordNormalType = new org.json.JSONObject(
             "{\"type\": \"keyword\", \"normalizer\": \"wildbook_keyword_normalizer\"}");
-        map.put("date", new org.json.JSONObject("{\"type\": \"date\"}"));
-        map.put("submitters", keywordNormalType);
-        map.put("photographers", keywordNormalType);
-        map.put("informOthers", keywordNormalType);
-
-        // https://stackoverflow.com/questions/68760699/matching-documents-where-multiple-fields-match-in-an-array-of-objects
-        map.put("measurements", new org.json.JSONObject("{\"type\": \"nested\"}"));
-        map.put("metalTags", new org.json.JSONObject("{\"type\": \"nested\"}"));
  */
+
+        // "id" is done in Base
+        map.put("viewpoint", keywordType);
+        map.put("iaClass", keywordType);
+        map.put("acmId", keywordType);
+        map.put("encounterId", keywordType);
+        map.put("encounterLocationId", keywordType);
+        map.put("encounterTaxonomy", keywordType);
+
+        // all case-insensitive keyword-ish types
+        // map.put("fubar", keywordNormalType);
+
         return map;
     }
 

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -142,6 +142,7 @@ public class Annotation extends Base implements java.io.Serializable {
         map.put("iaClass", keywordType);
         map.put("acmId", keywordType);
         map.put("encounterId", keywordType);
+        map.put("encounterSubmitterId", keywordType);
         map.put("encounterLocationId", keywordType);
         map.put("encounterTaxonomy", keywordType);
 

--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -172,17 +172,17 @@ public class Annotation extends Base implements java.io.Serializable {
         }
     }
 
-    // only needed for Base class
-    @Override public String getComments() {
-        return null;
-    }
-
     @Override public String getAllVersionsSql() {
         return "SELECT \"ID\", \"VERSION\" AS version FROM \"ANNOTATION\" ORDER BY version";
     }
 
     @Override public Base getById(Shepherd myShepherd, String id) {
         return myShepherd.getAnnotation(id);
+    }
+
+    // comment cruft only needed for Base class
+    @Override public String getComments() {
+        return null;
     }
 
     @Override public void setComments(final String comments) {

--- a/src/main/java/org/ecocean/Base.java
+++ b/src/main/java/org/ecocean/Base.java
@@ -270,7 +270,6 @@ import org.json.JSONObject;
         }
         OpenSearch.setActiveIndexingBackground();
         OpenSearch os = new OpenSearch();
-        System.out.println(">>>>>>>>>>>>>>>>>>>> " + baseObj.getAllVersionsSql());
         List<List<String> > changes = os.resolveVersions(getAllVersions(myShepherd,
             baseObj.getAllVersionsSql()), os.getAllVersions(indexName));
         if (changes.size() != 2) throw new IOException("invalid resolveVersions results");

--- a/src/main/java/org/ecocean/Base.java
+++ b/src/main/java/org/ecocean/Base.java
@@ -242,6 +242,78 @@ import org.json.JSONObject;
         return rtn;
     }
 
+    // these two methods are kinda hacky needs for opensearchSyncIndex (e.g. the fact
+    // they are not static)
+    public abstract Base getById(Shepherd myShepherd, String id);
+
+    public abstract String getAllVersionsSql();
+
+    // contains some reflection; not pretty, but gets the job done
+    public static int[] opensearchSyncIndex(Shepherd myShepherd, Class cls, int stopAfter)
+    throws IOException {
+        int[] rtn = new int[2];
+        Object tmpObj = null;
+
+        try {
+            tmpObj = cls.newInstance();
+        } catch (Exception ex) {
+            throw new IOException("FAIL: " + ex);
+        }
+        Base baseObj = (Base)tmpObj;
+        String indexName = baseObj.opensearchIndexName();
+        if (OpenSearch.indexingActive()) {
+            System.out.println("Base.opensearchSyncIndex(" + indexName +
+                ") skipped due to indexingActive()");
+            rtn[0] = -1;
+            rtn[1] = -1;
+            return rtn;
+        }
+        OpenSearch.setActiveIndexingBackground();
+        OpenSearch os = new OpenSearch();
+        System.out.println(">>>>>>>>>>>>>>>>>>>> " + baseObj.getAllVersionsSql());
+        List<List<String> > changes = os.resolveVersions(getAllVersions(myShepherd,
+            baseObj.getAllVersionsSql()), os.getAllVersions(indexName));
+        if (changes.size() != 2) throw new IOException("invalid resolveVersions results");
+        List<String> needIndexing = changes.get(0);
+        List<String> needRemoval = changes.get(1);
+        rtn[0] = needIndexing.size();
+        rtn[1] = needRemoval.size();
+        System.out.println("Base.opensearchSyncIndex(" + indexName + "): stopAfter=" + stopAfter +
+            ", needIndexing=" + rtn[0] + ", needRemoval=" + rtn[1]);
+        int ct = 0;
+        for (String id : needIndexing) {
+            Base obj = baseObj.getById(myShepherd, id);
+            try {
+                if (obj != null) os.index(indexName, obj);
+            } catch (Exception ex) {
+                System.out.println("Base.opensearchSyncIndex(" + indexName + "): index failed " +
+                    obj + " => " + ex.toString());
+                ex.printStackTrace();
+            }
+            if (ct % 500 == 0)
+                System.out.println("Base.opensearchSyncIndex(" + indexName + ") needIndexing: " +
+                    ct + "/" + rtn[0]);
+            ct++;
+            if ((stopAfter > 0) && (ct > stopAfter)) {
+                System.out.println("Base.opensearchSyncIndex(" + indexName +
+                    ") breaking due to stopAfter");
+                break;
+            }
+        }
+        System.out.println("Base.opensearchSyncIndex(" + indexName + ") finished needIndexing");
+        ct = 0;
+        for (String id : needRemoval) {
+            os.delete(indexName, id);
+            if (ct % 500 == 0)
+                System.out.println("Base.opensearchSyncIndex(" + indexName + ") needRemoval: " +
+                    ct + "/" + rtn[1]);
+            ct++;
+        }
+        System.out.println("Base.opensearchSyncIndex(" + indexName + ") finished needRemoval");
+        OpenSearch.unsetActiveIndexingBackground();
+        return rtn;
+    }
+
     public static Base createFromApi(JSONObject payload, List<File> files, Shepherd myShepherd)
     throws ApiException {
         throw new ApiException("not yet supported");

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -4339,12 +4339,6 @@ public class Encounter extends Base implements java.io.Serializable {
         return Util.getVersionFromModified(modified);
     }
 
-    public static Map<String, Long> getAllVersions(Shepherd myShepherd) {
-        Encounter enc = new Encounter();
-
-        return getAllVersions(myShepherd, enc.getAllVersionsSql());
-    }
-
     public org.json.JSONObject opensearchMapping() {
         org.json.JSONObject map = super.opensearchMapping();
         org.json.JSONObject keywordType = new org.json.JSONObject("{\"type\": \"keyword\"}");
@@ -4390,67 +4384,6 @@ public class Encounter extends Base implements java.io.Serializable {
         return map;
     }
 
-/*
-    public static int[] opensearchSyncIndex(Shepherd myShepherd)
-    throws IOException {
-        return opensearchSyncIndex(myShepherd, 0);
-    }
-
-    public static int[] opensearchSyncIndex(Shepherd myShepherd, int stopAfter)
-    throws IOException {
-        int[] rtn = new int[2];
-
-        if (OpenSearch.indexingActive()) {
-            System.out.println("Encounter.opensearchSyncIndex() skipped due to indexingActive()");
-            rtn[0] = -1;
-            rtn[1] = -1;
-            return rtn;
-        }
-        OpenSearch.setActiveIndexingBackground();
-        String indexName = "encounter";
-        OpenSearch os = new OpenSearch();
-        List<List<String> > changes = os.resolveVersions(getAllVersions(myShepherd),
-            os.getAllVersions(indexName));
-        if (changes.size() != 2) throw new IOException("invalid resolveVersions results");
-        List<String> needIndexing = changes.get(0);
-        List<String> needRemoval = changes.get(1);
-        rtn[0] = needIndexing.size();
-        rtn[1] = needRemoval.size();
-        System.out.println("Encounter.opensearchSyncIndex(): stopAfter=" + stopAfter +
-            ", needIndexing=" + rtn[0] + ", needRemoval=" + rtn[1]);
-        int ct = 0;
-        for (String id : needIndexing) {
-            Encounter enc = myShepherd.getEncounter(id);
-            try {
-                if (enc != null) os.index(indexName, enc);
-            } catch (Exception ex) {
-                System.out.println("Encounter.opensearchSyncIndex(): index failed " + enc + " => " +
-                    ex.toString());
-                ex.printStackTrace();
-            }
-            if (ct % 500 == 0)
-                System.out.println("Encounter.opensearchSyncIndex needIndexing: " + ct + "/" +
-                    rtn[0]);
-            ct++;
-            if ((stopAfter > 0) && (ct > stopAfter)) {
-                System.out.println("Encounter.opensearchSyncIndex() breaking due to stopAfter");
-                break;
-            }
-        }
-        System.out.println("Encounter.opensearchSyncIndex() finished needIndexing");
-        ct = 0;
-        for (String id : needRemoval) {
-            os.delete(indexName, id);
-            if (ct % 500 == 0)
-                System.out.println("Encounter.opensearchSyncIndex needRemoval: " + ct + "/" +
-                    rtn[1]);
-            ct++;
-        }
-        System.out.println("Encounter.opensearchSyncIndex() finished needRemoval");
-        OpenSearch.unsetActiveIndexingBackground();
-        return rtn;
-    }
- */
     public static Base createFromApi(org.json.JSONObject payload, List<File> files,
         Shepherd myShepherd)
     throws ApiException {

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -4326,15 +4326,23 @@ public class Encounter extends Base implements java.io.Serializable {
         return false;
     }
 
+    @Override public Base getById(Shepherd myShepherd, String id) {
+        return myShepherd.getEncounter(id);
+    }
+
+    @Override public String getAllVersionsSql() {
+        return
+                "SELECT \"CATALOGNUMBER\", CAST(COALESCE(EXTRACT(EPOCH FROM CAST(\"MODIFIED\" AS TIMESTAMP))*1000,-1) AS BIGINT) AS version FROM \"ENCOUNTER\" ORDER BY version";
+    }
+
     @Override public long getVersion() {
         return Util.getVersionFromModified(modified);
     }
 
     public static Map<String, Long> getAllVersions(Shepherd myShepherd) {
-        String sql =
-            "SELECT \"CATALOGNUMBER\", CAST(COALESCE(EXTRACT(EPOCH FROM CAST(\"MODIFIED\" AS TIMESTAMP))*1000,-1) AS BIGINT) AS version FROM \"ENCOUNTER\" ORDER BY version";
+        Encounter enc = new Encounter();
 
-        return getAllVersions(myShepherd, sql);
+        return getAllVersions(myShepherd, enc.getAllVersionsSql());
     }
 
     public org.json.JSONObject opensearchMapping() {
@@ -4382,6 +4390,7 @@ public class Encounter extends Base implements java.io.Serializable {
         return map;
     }
 
+/*
     public static int[] opensearchSyncIndex(Shepherd myShepherd)
     throws IOException {
         return opensearchSyncIndex(myShepherd, 0);
@@ -4441,7 +4450,7 @@ public class Encounter extends Base implements java.io.Serializable {
         OpenSearch.unsetActiveIndexingBackground();
         return rtn;
     }
-
+ */
     public static Base createFromApi(org.json.JSONObject payload, List<File> files,
         Shepherd myShepherd)
     throws ApiException {
@@ -4704,5 +4713,4 @@ public class Encounter extends Base implements java.io.Serializable {
             myShepherd.rollbackDBTransaction();
         }
     }
-
 }

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -2609,7 +2609,7 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
                 try {
                     MarkedIndividual indiv = bgShepherd.getMarkedIndividual(indivId);
                     if ((indiv == null) || (indiv.getEncounters() == null)) {
-                        //bgShepherd.rollbackAndClose();
+                        // bgShepherd.rollbackAndClose();
                         executor.shutdown();
                         return;
                     }
@@ -2657,9 +2657,17 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
                    .toString();
     }
 
+    @Override public Base getById(Shepherd myShepherd, String id) {
+        return myShepherd.getMarkedIndividual(id);
+    }
+
     @Override public long getVersion() {
         // Returning 0 for now since the class does not have a 'modified' attribute to compute this value, to be fixed in future.
         return 0;
+    }
+
+    @Override public String getAllVersionsSql() {
+        return "SELECT \"INDIVIDUALID\", CAST(0 AS BIGINT) FROM \"MARKEDINDIVIDUAL\"";
     }
 
     public static Map<String, Long> getAllVersions(Shepherd myShepherd) {

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -2669,11 +2669,4 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
     @Override public String getAllVersionsSql() {
         return "SELECT \"INDIVIDUALID\", CAST(0 AS BIGINT) FROM \"MARKEDINDIVIDUAL\"";
     }
-
-    public static Map<String, Long> getAllVersions(Shepherd myShepherd) {
-        // see above
-        String sql = "SELECT \"INDIVIDUALID\", CAST(0 AS BIGINT) FROM \"MARKEDINDIVIDUAL\"";
-
-        return getAllVersions(myShepherd, sql);
-    }
 }

--- a/src/main/java/org/ecocean/Occurrence.java
+++ b/src/main/java/org/ecocean/Occurrence.java
@@ -1408,11 +1408,19 @@ public class Occurrence extends Base implements java.io.Serializable {
         return Util.getVersionFromModified(modified);
     }
 
+    @Override public Base getById(Shepherd myShepherd, String id) {
+        return myShepherd.getOccurrence(id);
+    }
+
+    @Override public String getAllVersionsSql() {
+        return
+                "SELECT \"OCCURRENCEID\", CAST(COALESCE(EXTRACT(EPOCH FROM CAST(\"MODIFIED\" AS TIMESTAMP))*1000,-1) AS BIGINT) AS version FROM \"OCCURRENCE\" ORDER BY version";
+    }
+
     public static Map<String, Long> getAllVersions(Shepherd myShepherd) {
         // note: some Occurrences do not have ids.  :(
-        String sql =
-            "SELECT \"OCCURRENCEID\", CAST(COALESCE(EXTRACT(EPOCH FROM CAST(\"MODIFIED\" AS TIMESTAMP))*1000,-1) AS BIGINT) AS version FROM \"ENCOUNTER\" ORDER BY version";
+        Occurrence occ = new Occurrence();
 
-        return getAllVersions(myShepherd, sql);
+        return getAllVersions(myShepherd, occ.getAllVersionsSql());
     }
 }

--- a/src/main/java/org/ecocean/Occurrence.java
+++ b/src/main/java/org/ecocean/Occurrence.java
@@ -1416,11 +1416,4 @@ public class Occurrence extends Base implements java.io.Serializable {
         return
                 "SELECT \"OCCURRENCEID\", CAST(COALESCE(EXTRACT(EPOCH FROM CAST(\"MODIFIED\" AS TIMESTAMP))*1000,-1) AS BIGINT) AS version FROM \"OCCURRENCE\" ORDER BY version";
     }
-
-    public static Map<String, Long> getAllVersions(Shepherd myShepherd) {
-        // note: some Occurrences do not have ids.  :(
-        Occurrence occ = new Occurrence();
-
-        return getAllVersions(myShepherd, occ.getAllVersionsSql());
-    }
 }

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -155,6 +155,8 @@ public class OpenSearch {
                         System.out.println("OpenSearch background indexing running...");
                         Base.opensearchSyncIndex(myShepherd, Encounter.class,
                         BACKGROUND_SLICE_SIZE);
+                        Base.opensearchSyncIndex(myShepherd, Annotation.class,
+                        BACKGROUND_SLICE_SIZE);
                         System.out.println("OpenSearch background indexing finished.");
                         myShepherd.rollbackAndClose();
                     } catch (Exception ex) {

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -61,7 +61,9 @@ public class OpenSearch {
         "10m");
     public static String SEARCH_PIT_TIME = (String)getConfigurationValue("searchPitTime", "10m");
     public static String INDEX_TIMESTAMP_PREFIX = "OpenSearch_index_timestamp_";
-    public static String[] VALID_INDICES = { "encounter", "individual", "occurrence" };
+    public static String[] VALID_INDICES = {
+        "encounter", "individual", "occurrence", "annotation"
+    };
     public static int BACKGROUND_DELAY_MINUTES = (Integer)getConfigurationValue(
         "backgroundDelayMinutes", 20);
     public static int BACKGROUND_SLICE_SIZE = (Integer)getConfigurationValue("backgroundSliceSize",

--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -153,7 +153,8 @@ public class OpenSearch {
                     try {
                         myShepherd.beginDBTransaction();
                         System.out.println("OpenSearch background indexing running...");
-                        Encounter.opensearchSyncIndex(myShepherd, BACKGROUND_SLICE_SIZE);
+                        Base.opensearchSyncIndex(myShepherd, Encounter.class,
+                        BACKGROUND_SLICE_SIZE);
                         System.out.println("OpenSearch background indexing finished.");
                         myShepherd.rollbackAndClose();
                     } catch (Exception ex) {

--- a/src/main/java/org/ecocean/Shepherd.java
+++ b/src/main/java/org/ecocean/Shepherd.java
@@ -1933,7 +1933,6 @@ public class Shepherd {
      * @return an Iterator of shark encounters that have yet to be assigned shark status or assigned to an existing shark in the database
      * @see encounter, java.util.Iterator
      */
-
     public List<MediaAsset> getMediaAssetsFromStore(int assetStoreId) {
         String filter =
             "SELECT FROM org.ecocean.media.MediaAsset WHERE this.assetStore == as && as.id == " +
@@ -2062,6 +2061,18 @@ public class Shepherd {
             npe.printStackTrace();
             return null;
         }
+    }
+
+    public Iterator<Encounter> getAllAnnotations(String order) {
+        Extent extClass = pm.getExtent(Annotation.class, true);
+        Query q = pm.newQuery(extClass);
+
+        q.setOrdering(order);
+        Collection c = (Collection)(q.execute());
+        ArrayList list = new ArrayList(c);
+        Iterator it = list.iterator();
+        q.closeAll();
+        return it;
     }
 
     public Iterator getAllMediaAssets() {
@@ -2679,7 +2690,6 @@ public class Shepherd {
                 }
             }
         }
-
         ArrayList<Map.Entry> as = new ArrayList<Map.Entry>(hmap.entrySet());
         if (as.size() > 0) {
             IndividualOccurrenceNumComparator cmp = new IndividualOccurrenceNumComparator();
@@ -3864,7 +3874,6 @@ public class Shepherd {
             ShepherdPMF.setShepherdState(action + "_" + shepherdID, "begin");
 
             pm.addInstanceLifecycleListener(new WildbookLifecycleListener(), null);
-
         } catch (JDOUserException jdoe) {
             jdoe.printStackTrace();
         } catch (NullPointerException npe) {
@@ -4283,8 +4292,8 @@ public class Shepherd {
                                     Keyword word = getKeyword(keywords[n]);
                                     if ((images.get(i).getKeywords() != null) &&
                                         images.get(i).getKeywords().contains(word)) {
-                                            hasKeyword = true;
-                                        }
+                                        hasKeyword = true;
+                                    }
                                 } else {
                                     hasKeyword = true;
                                 }
@@ -4358,7 +4367,7 @@ public class Shepherd {
                                         Keyword word = getKeyword(keywords[n]);
                                         if ((images.get(i).getKeywords() != null) &&
                                             images.get(i).getKeywords().contains(word)) {
-                                                hasKeyword = true;
+                                            hasKeyword = true;
                                         }
                                     } else {
                                         hasKeyword = true;
@@ -4437,9 +4446,8 @@ public class Shepherd {
                         }
                     }
                 }
-                if (hasKeyword && isAcceptableVideoFile(imageName)) {
-                } else if (hasKeyword && isAcceptableImageFile(imageName)) {
-                } else {
+                if (hasKeyword && isAcceptableVideoFile(imageName)) {} else if (hasKeyword &&
+                    isAcceptableImageFile(imageName)) {} else {
                     count--;
                 }
             }

--- a/src/main/resources/org/ecocean/package.jdo
+++ b/src/main/resources/org/ecocean/package.jdo
@@ -551,6 +551,11 @@
 			<index name="ANNOTATION_VIEWPOINT_IDX" />
 		</field>
 
+		<field jdbc-type="BIGINT" name="version" allows-null="false" >
+			<column default-value="-1" />
+			<index name="ANNOTATION_VERSION_IDX" />
+		</field>
+
             	<field name="features" persistence-modifier="persistent" default-fetch-group="false" recursion-depth="2" mapped-by="annotation" >
                 	<collection element-type="org.ecocean.media.Feature" dependent-element="true" />
                 	<join />

--- a/src/main/webapp/appadmin/opensearchInfo.jsp
+++ b/src/main/webapp/appadmin/opensearchInfo.jsp
@@ -20,6 +20,13 @@ private String wrap(final String input, int len) {
 }
 
 %>
+<style>
+h2 {
+    margin-top: 2em;
+    padding: 20px;
+    background-color: #AAA;
+}
+</style>
 
 <%
 
@@ -47,11 +54,12 @@ out.println(wrap(rtn, 123));
 </textarea>
 <%
 
-
-req = new Request("GET", "encounter/_mappings");
-JSONObject res = new JSONObject(os.getRestResponse(req));
+for (String indexName : OpenSearch.VALID_INDICES) {
+    out.println("<h2>" + indexName + "</h2>");
+    req = new Request("GET", indexName + "/_mappings");
+    JSONObject res = new JSONObject(os.getRestResponse(req));
 %>
-<h3>Encounter mapping</h3>
+<h3><%=indexName%> mapping</h3>
 <textarea style="height: 30em; width: 100em;">
 <%
 out.println(res.toString(4));
@@ -59,9 +67,9 @@ out.println(res.toString(4));
 </textarea>
 <%
 
-res = os.getSettings("encounter");
+res = os.getSettings(indexName);
 %>
-<h3>Encounter settings</h3>
+<h3><%=indexName%> settings</h3>
 <textarea style="height: 30em; width: 100em;">
 <%
 out.println(res.toString(4));
@@ -70,16 +78,18 @@ out.println(res.toString(4));
 <%
 
 
-req = new Request("GET", "encounter/_search?pretty=true&q=*:*&size=1");
+req = new Request("GET", indexName + "/_search?pretty=true&q=*:*&size=1");
 res = new JSONObject(os.getRestResponse(req));
 %>
-<h3>Encounter example</h3>
+<h3><%=indexName%> doc example</h3>
 <textarea style="height: 30em; width: 100em;">
 <%
 out.println(res.toString(4));
 %>
 </textarea>
 <%
+
+}
 
 
 


### PR DESCRIPTION
Indexing on Annotations

PR fixes #873 

**Changes**
- Annotation now inherits from Base
- add `version` to Annotation
- Annotation index mapping and serializer
- some changes to Base.java to allow generalized `opensearchSync()`, e.g. `getById()` and `getAllVersionsSql()`
- `opensearchSync()` pulled out of Encounter.java and put into Base.java, see above
- corresponding changes to MarkedIndividual and Occurrence due to Base changes (for future indexing of these classes)
- OpenSearch `backgroundStartup()` now includes Annotations in background indexing
- `opensearchInfo.jsp` now genericized to show all valid indices
- `opensearchSync.jsp` utility now genericized to support both Encounter and Annotation indices