### PR TITLE
Regression: users.jsp should be accessible to orgAdmins

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -79,7 +79,7 @@
 			  /appadmin/dataValuesCheck.jsp = authc
 
                 /appadmin/scanTaskAdmin.jsp = authc, roles[researcher]
-				/appadmin/users.jsp = authc, roles[admin]
+				/appadmin/users.jsp = authc, roles[orgAdmin]
 				/appadmin/automatedUserReconciliation.jsp = authc, roles[admin]
 				/appadmin/iaSpeciesDiff.jsp = authcBasicWildbook,roles[rest]
 
@@ -180,7 +180,7 @@
 		        # /SinglePhotoVideoAddKeyword = authc, roles[researcher]
 		         /EncounterSearchExportGeneGISFormat = authc, roles[researcher]
 		         /EncounterSearchExportKML = authc, roles[researcher]
-		         /UserCreate = authc, roles[admin]
+		         /UserCreate = authc, roles[orgAdmin]
 						 /UserCheck = authc
 				 /UserDelete = authc, roles[admin]
 				/ResetCommonConfiguration = authc, roles[admin]


### PR DESCRIPTION
Investigating why users.jsp went from orgAdmin-level access requirement to admin. This simple change restores expected behavior.

