### PR TITLE
Add MarkedIndividual.getDisplayName() to individual capture history record comment ba…

### DIFF
--- a/src/main/java/org/ecocean/servlet/export/SimpleCMROutput.java
+++ b/src/main/java/org/ecocean/servlet/export/SimpleCMROutput.java
@@ -182,8 +182,9 @@ public class SimpleCMROutput extends HttpServlet {
             }
             String includeID = "";
             if (request.getParameter("includeIndividualID") != null) {
-                includeID = "     /* " + indie.getIndividualID() + " */";
+                includeID = "     /* " +indie.getDisplayName()+" "+ indie.getIndividualID() + " */";
             }
+            //this if drops individuals never sighted and only prints individuals with at least one capture
             if (thisRecord.indexOf("1") != -1) {
                 histories.append(thisRecord + " 1;" + includeID + "\r\n");
             }


### PR DESCRIPTION
…se don user feedback

Adds a human readable MarkedIndividual name to the existing UUID in the comments section of a capture history export file.

