### PR TITLE
Better Shepherd handling on setting Import Task Complete

### DIFF
--- a/src/main/webapp/iaResultsSetID.jsp
+++ b/src/main/webapp/iaResultsSetID.jsp
@@ -36,7 +36,7 @@ private static void setImportTaskComplete(Shepherd myShepherd, Encounter enc) {
 			System.out.println("setImportTaskComplete() setting true for annot " + ann.getId());
 	    }
 	    SystemValue.set(myShepherd, svKey, m);
-	    myShepherd.commitDBTransaction();
+	    myShepherd.updateDBTransaction();
 	}
 	catch(Exception e){e.printStackTrace();}
 }


### PR DESCRIPTION
The private method setImportTaskComplete can be called repetetively and should not be closing the shared Shepherd database connection it uses. This throws nonblocking but unnecessary and repetetive exceptions. This resolves this by calling the correct Shepherd.updateDBTransaction() method for this use case.
