### PR TITLE
Set initial Encounter.state same as EncounterForm.class

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -4519,6 +4519,9 @@ public class Encounter extends Base implements java.io.Serializable {
         enc.setDecimalLongitude(decimalLongitude);
         enc.setDateFromISO8601String(dateTime);
         enc.setTaxonomyFromString(txStr);
+        if (CommonConfiguration.getProperty("encounterState0", context) != null) {
+            enc.setState(CommonConfiguration.getProperty("encounterState0", context));
+        }
         enc.setComments(payload.optString("comments", null));
         if (user == null) {
             enc.setSubmitterID("public"); // this seems to be what EncounterForm servlet does so...


### PR DESCRIPTION
The new React submission form leaves Encounter.state null, differing from the behavior of the legacy EncounterForm servlet. This standardizes the behavior.

PR fixes #1018 

**Before you Submit!**
* Is all the text internationalized?
* If you made a change to the header, did you update the react, jsp, and html?
* Are all depedencies at a locked version?
* Did you adhere to [best practices](https://wildbook.docs.wildme.org/contribute/code-guide.html)?
* Is there a quick [unit test](https://wildbook.docs.wildme.org/contribute/tests.html) you can add?
