### PR TITLE
Ensure Encounter.verbatimEventDate is indexed as plain text and not date in OpenSearch

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -4445,6 +4445,7 @@ public class Encounter extends Base implements java.io.Serializable {
             "{\"type\": \"keyword\", \"normalizer\": \"wildbook_keyword_normalizer\"}");
         map.put("date", new org.json.JSONObject("{\"type\": \"date\"}"));
         map.put("dateSubmitted", new org.json.JSONObject("{\"type\": \"date\"}"));
+        map.put("verbatimEventDate", new org.json.JSONObject("{\"type\": \"text\"}"));
         map.put("individualTimeOfBirth", new org.json.JSONObject("{\"type\": \"date\"}"));
         map.put("individualTimeOfDeath", new org.json.JSONObject("{\"type\": \"date\"}"));
         map.put("locationGeoPoint", new org.json.JSONObject("{\"type\": \"geo_point\"}"));


### PR DESCRIPTION
Encounter.verbatimEventDate is being indexed as [date] in OpenSearch. The field is intended to be a freeform text field for non-specific dates. This PR forces OpenSearch to consider it text. previously, date-like entries in the field were causing OpenSearch to try to validate it as a [date] field. This change forces text validation.


