### PR TITLE
fix for opensearch-based matchingSet query when supporting parts

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -803,11 +803,10 @@ public class Annotation extends Base implements java.io.Serializable {
                 "usePartsForIdentification"))) {
                 String part = this.getPartIfPresent();
                 if (!Util.stringIsEmptyOrNull(part)) {
-                    // TODO really should check that iaClass ENDS WITH part
                     arg = new JSONObject();
-                    arg.put("iaClass", part);
+                    arg.put("iaClass", "*" + part);
                     wrapper = new JSONObject();
-                    wrapper.put("match", arg);
+                    wrapper.put("wildcard", arg);
                     query.getJSONObject("query").getJSONObject("bool").getJSONArray("filter").put(
                         wrapper);
                     usedPart = true;


### PR DESCRIPTION
bugfix: parts-based iaClass was not getting handled correctly in opensearch query for matching set.
now uses wildcard to match _trailing end of_ the `iaClass` field when there is a part present.
(this mimics the previous non-opensearch matchingSet logic)