### PR TITLE
fix(?) broken jdo query by swapping around clause order

### DIFF
--- a/src/main/java/org/ecocean/IndividualQueryProcessor.java
+++ b/src/main/java/org/ecocean/IndividualQueryProcessor.java
@@ -97,7 +97,7 @@ public class IndividualQueryProcessor extends QueryProcessor {
             Util.isUUID(request.getParameter("organizationId"))) {
             String orgId = request.getParameter("organizationId");
             filter =
-                "SELECT FROM org.ecocean.MarkedIndividual WHERE encounters.contains(enc) && user.username == enc.submitterID && org.members.contains(user) && org.id == '"
+                "SELECT FROM org.ecocean.MarkedIndividual WHERE user.username == enc.submitterID && encounters.contains(enc) && org.members.contains(user) && org.id == '"
                 + orgId + "'";
             String variables_statement =
                 " VARIABLES org.ecocean.Encounter enc; org.ecocean.User user; org.ecocean.Organization org";


### PR DESCRIPTION
fix exception being thrown for malformed sql from jdoql.

PR fixes #320 

after way too much sleuthing and trail-and-error, a comment about jdoql being "sensitive" to clause order, it seems that switching around the order of these leading 2 where clauses fixes the problem.

testing needed, for sure.