### PR TITLE
Extract ShepherdState from PMF to its own class

### DIFF
--- a/src/main/java/org/ecocean/servlet/LightRestServlet.java
+++ b/src/main/java/org/ecocean/servlet/LightRestServlet.java
@@ -26,6 +26,7 @@ import org.ecocean.CommonConfiguration;
 import org.ecocean.Encounter;
 import org.ecocean.security.Collaboration;
 import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.shepherd.utils.ShepherdState;
 import org.ecocean.Util;
 
 import javax.jdo.Query;
@@ -173,13 +174,13 @@ public class LightRestServlet extends HttpServlet {
                 String queryString = URLDecoder.decode(req.getQueryString(), "UTF-8");
                 // PersistenceManager pm = pmf.getPersistenceManager();
                 String servletID = Util.generateUUID();
-                // ShepherdPMF.setShepherdState("LightRestServlet.class"+"_"+servletID, "new");
+                // ShepherdState.setShepherdState("LightRestServlet.class"+"_"+servletID, "new");
 
                 System.out.println("        LIGHTREST: has queryString " + queryString);
 
                 try {
                     myShepherd.beginDBTransaction();
-                    // ShepherdPMF.setShepherdState("LightRestServlet.class"+"_"+servletID, "begin");
+                    // ShepherdState.setShepherdState("LightRestServlet.class"+"_"+servletID, "begin");
 
                     Query query = myShepherd.getPM().newQuery("JDOQL", queryString);
                     if (fetchParam != null) {

--- a/src/main/java/org/ecocean/servlet/RestServlet.java
+++ b/src/main/java/org/ecocean/servlet/RestServlet.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.StringTokenizer;
 
 import org.ecocean.shepherd.core.ShepherdPMF;
+import org.ecocean.shepherd.utils.ShepherdState;
 import org.ecocean.Util;
 
 import java.lang.reflect.Method;
@@ -181,7 +182,7 @@ public class RestServlet extends HttpServlet {
                     queryString = URLDecoder.decode(req.getQueryString(), "UTF-8");
                 }
                 PersistenceManager pm = pmf.getPersistenceManager();
-                ShepherdPMF.setShepherdState("RestServlet.class" + "_" + servletID, "new");
+                ShepherdState.setShepherdState("RestServlet.class" + "_" + servletID, "new");
                 if (fetchParams != null) {
                     int numParams = fetchParams.length;
                     for (int g = 0; g < numParams; g++) {
@@ -207,7 +208,7 @@ public class RestServlet extends HttpServlet {
                 }
                 try {
                     pm.currentTransaction().begin();
-                    ShepherdPMF.setShepherdState("RestServlet.class" + "_" + servletID, "begin");
+                    ShepherdState.setShepherdState("RestServlet.class" + "_" + servletID, "begin");
 
                     Query query = pm.newQuery("JDOQL", queryString);
                     if (fetchParams != null) {
@@ -237,15 +238,15 @@ public class RestServlet extends HttpServlet {
                     resp.setHeader("Content-Type", "application/json");
                     resp.setStatus(200);
                     pm.currentTransaction().commit();
-                    ShepherdPMF.setShepherdState("RestServlet.class" + "_" + servletID, "commit");
+                    ShepherdState.setShepherdState("RestServlet.class" + "_" + servletID, "commit");
                 } finally {
                     if (pm.currentTransaction().isActive()) {
                         pm.currentTransaction().rollback();
-                        ShepherdPMF.setShepherdState("RestServlet.class" + "_" + servletID,
+                        ShepherdState.setShepherdState("RestServlet.class" + "_" + servletID,
                             "rollback");
                     }
                     pm.close();
-                    ShepherdPMF.removeShepherdState("RestServlet.class" + "_" + servletID);
+                    ShepherdState.removeShepherdState("RestServlet.class" + "_" + servletID);
                 }
                 return;
             }
@@ -266,7 +267,7 @@ public class RestServlet extends HttpServlet {
                     resp.getWriter().write(error.toString());
                     resp.setStatus(404);
                     resp.setHeader("Content-Type", "application/json");
-                    ShepherdPMF.removeShepherdState("RestServlet.class" + "_" + servletID);
+                    ShepherdState.removeShepherdState("RestServlet.class" + "_" + servletID);
 
                     return;
                 }
@@ -295,7 +296,7 @@ public class RestServlet extends HttpServlet {
                             }
                             try {
                                 pm.currentTransaction().begin();
-                                ShepherdPMF.setShepherdState("RestServlet.class" + "_" + servletID,
+                                ShepherdState.setShepherdState("RestServlet.class" + "_" + servletID,
                                     "begin");
 
                                 Query query = pm.newQuery("JDOQL", queryString);
@@ -311,7 +312,7 @@ public class RestServlet extends HttpServlet {
                                     pm.currentTransaction().rollback();
                                 }
                                 pm.close();
-                                ShepherdPMF.removeShepherdState("RestServlet.class" + "_" +
+                                ShepherdState.removeShepherdState("RestServlet.class" + "_" +
                                     servletID);
                             }
                             return;
@@ -321,7 +322,7 @@ public class RestServlet extends HttpServlet {
                             resp.getWriter().write(error.toString());
                             resp.setStatus(400);
                             resp.setHeader("Content-Type", "application/json");
-                            ShepherdPMF.removeShepherdState("RestServlet.class" + "_" + servletID);
+                            ShepherdState.removeShepherdState("RestServlet.class" + "_" + servletID);
 
                             return;
                         } catch (NucleusException ex) {
@@ -330,7 +331,7 @@ public class RestServlet extends HttpServlet {
                             resp.getWriter().write(error.toString());
                             resp.setStatus(404);
                             resp.setHeader("Content-Type", "application/json");
-                            ShepherdPMF.removeShepherdState("RestServlet.class" + "_" + servletID);
+                            ShepherdState.removeShepherdState("RestServlet.class" + "_" + servletID);
                             return;
                         } catch (RuntimeException ex) {
                             // errors from the google appengine may be raised when running queries
@@ -339,7 +340,7 @@ public class RestServlet extends HttpServlet {
                             resp.getWriter().write(error.toString());
                             resp.setStatus(404);
                             resp.setHeader("Content-Type", "application/json");
-                            ShepherdPMF.removeShepherdState("RestServlet.class" + "_" + servletID);
+                            ShepherdState.removeShepherdState("RestServlet.class" + "_" + servletID);
                             return;
                         }
                     } else {
@@ -349,7 +350,7 @@ public class RestServlet extends HttpServlet {
                         resp.getWriter().write(error.toString());
                         resp.setStatus(400);
                         resp.setHeader("Content-Type", "application/json");
-                        ShepherdPMF.removeShepherdState("RestServlet.class" + "_" + servletID);
+                        ShepherdState.removeShepherdState("RestServlet.class" + "_" + servletID);
                         return;
                     }
                 }
@@ -367,7 +368,7 @@ public class RestServlet extends HttpServlet {
                 }
                 try {
                     pm.currentTransaction().begin();
-                    ShepherdPMF.setShepherdState("RestServlet.class" + "_" + servletID, "begin");
+                    ShepherdState.setShepherdState("RestServlet.class" + "_" + servletID, "begin");
                     Object result = filterResult(pm.getObjectById(id));
                     JSONObject jsonobj = convertToJson(req, result,
                         ((JDOPersistenceManager)pm).getExecutionContext());
@@ -391,7 +392,7 @@ public class RestServlet extends HttpServlet {
                         pm.currentTransaction().rollback();
                     }
                     pm.close();
-                    ShepherdPMF.removeShepherdState("RestServlet.class" + "_" + servletID);
+                    ShepherdState.removeShepherdState("RestServlet.class" + "_" + servletID);
                 }
             }
         } catch (JSONException e) {
@@ -817,7 +818,7 @@ public class RestServlet extends HttpServlet {
         String context = "context0";
 
         context = ServletUtilities.getContext(req);
-        ShepherdPMF.setShepherdState("RestServlet.class" + "_" + servletID, "new");
+        ShepherdState.setShepherdState("RestServlet.class" + "_" + servletID, "new");
         pmf = ShepherdPMF.getPMF(context);
         this.nucCtx = ((JDOPersistenceManagerFactory)pmf).getNucleusContext();
         thisRequest = req;

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -26,6 +26,7 @@ import org.ecocean.security.Collaboration;
 import org.ecocean.servlet.importer.ImportTask;
 import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.social.*;
+import org.ecocean.shepherd.utils.ShepherdState;
 
 import javax.jdo.*;
 import javax.servlet.http.HttpServletRequest;
@@ -73,7 +74,7 @@ public class Shepherd {
                 pm = ShepherdPMF.getPMF(localContext).getPersistenceManager();
                 this.shepherdID = Util.generateUUID();
 
-                ShepherdPMF.setShepherdState(action + "_" + shepherdID, "new");
+                ShepherdState.setShepherdState(action + "_" + shepherdID, "new");
             } catch (JDOUserException e) {
                 System.out.println(
                     "Hit an excpetion while trying to instantiate a PM. Not fatal I think.");
@@ -3536,7 +3537,7 @@ public class Shepherd {
             } else if (!pm.currentTransaction().isActive()) {
                 pm.currentTransaction().begin();
             }
-            ShepherdPMF.setShepherdState(action + "_" + shepherdID, "begin");
+            ShepherdState.setShepherdState(action + "_" + shepherdID, "begin");
 
             pm.addInstanceLifecycleListener(new WildbookLifecycleListener(), null);
         } catch (JDOUserException jdoe) {
@@ -3569,7 +3570,7 @@ public class Shepherd {
                 System.out.println("You are trying to commit an inactive transaction.");
                 // return false;
             }
-            ShepherdPMF.setShepherdState(action + "_" + shepherdID, "commit");
+            ShepherdState.setShepherdState(action + "_" + shepherdID, "commit");
         } catch (JDOUserException jdoe) {
             jdoe.printStackTrace();
             System.out.println("I failed to commit a transaction." + "\n" + jdoe.getStackTrace());
@@ -3614,8 +3615,8 @@ public class Shepherd {
             if ((pm != null) && (!pm.isClosed())) {
                 pm.close();
             }
-            // ShepherdPMF.setShepherdState(action+"_"+shepherdID, "close");
-            ShepherdPMF.removeShepherdState(action + "_" + shepherdID);
+            // ShepherdState.setShepherdState(action+"_"+shepherdID, "close");
+            ShepherdState.removeShepherdState(action + "_" + shepherdID);
 
             // logger.info("A PersistenceManager has been successfully closed.");
         } catch (JDOUserException jdoe) {
@@ -3641,7 +3642,7 @@ public class Shepherd {
             } else {
                 // System.out.println("You are trying to rollback an inactive transaction.");
             }
-            ShepherdPMF.setShepherdState(action + "_" + shepherdID, "rollback");
+            ShepherdState.setShepherdState(action + "_" + shepherdID, "rollback");
         } catch (JDOUserException jdoe) {
             jdoe.printStackTrace();
         } catch (JDOFatalUserException fdoe) {
@@ -4965,12 +4966,12 @@ public class Shepherd {
     public void setAction(String newAction) {
         String state = "";
 
-        if (ShepherdPMF.getShepherdState(action + "_" + shepherdID) != null) {
-            state = ShepherdPMF.getShepherdState(action + "_" + shepherdID);
-            ShepherdPMF.removeShepherdState(action + "_" + shepherdID);
+        if (ShepherdState.getShepherdState(action + "_" + shepherdID) != null) {
+            state = ShepherdState.getShepherdState(action + "_" + shepherdID);
+            ShepherdState.removeShepherdState(action + "_" + shepherdID);
         }
         this.action = newAction;
-        ShepherdPMF.setShepherdState(action + "_" + shepherdID, state);
+        ShepherdState.setShepherdState(action + "_" + shepherdID, state);
     }
 
     public String getAction() { return action; }

--- a/src/main/java/org/ecocean/shepherd/core/ShepherdPMF.java
+++ b/src/main/java/org/ecocean/shepherd/core/ShepherdPMF.java
@@ -25,9 +25,6 @@ public class ShepherdPMF {
     private static TreeMap<String, PersistenceManagerFactory> pmfs = new TreeMap<String,
         PersistenceManagerFactory>();
 
-    private static ConcurrentHashMap<String, String> shepherds = new ConcurrentHashMap<String,
-        String>();
-
     public synchronized static PersistenceManagerFactory getPMF(String context) {
         // public static PersistenceManagerFactory getPMF(String dbLocation) {
         if (pmfs == null) { pmfs = new TreeMap<String, PersistenceManagerFactory>(); }
@@ -406,25 +403,5 @@ public class ShepherdPMF {
             }
         }
         return myProps;
-    }
-
-    public static void setShepherdState(String shepherdID, String state) {
-        if (shepherds == null) shepherds = new ConcurrentHashMap<String, String>();
-        shepherds.put(shepherdID, state);
-    }
-
-    public static void removeShepherdState(String shepherdID) {
-        if (shepherds == null) shepherds = new ConcurrentHashMap<String, String>();
-        shepherds.remove(shepherdID);
-    }
-
-    public static String getShepherdState(String shepherdID) {
-        if (shepherds == null) shepherds = new ConcurrentHashMap<String, String>();
-        return shepherds.get(shepherdID);
-    }
-
-    public static ConcurrentHashMap<String, String> getAllShepherdStates() {
-        if (shepherds == null) shepherds = new ConcurrentHashMap<String, String>();
-        return shepherds;
     }
 }

--- a/src/main/java/org/ecocean/shepherd/utils/ShepherdState.java
+++ b/src/main/java/org/ecocean/shepherd/utils/ShepherdState.java
@@ -3,30 +3,26 @@ package org.ecocean.shepherd.utils;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class ShepherdState {
+
+    private static final ConcurrentHashMap<String, String> shepherds = new ConcurrentHashMap<>();
+
     private ShepherdState() {
         // Prevent instantiation
     }
 
-    private static ConcurrentHashMap<String, String> shepherds = new ConcurrentHashMap<String,
-            String>();
-
     public static void setShepherdState(String shepherdID, String state) {
-        shepherds = new ConcurrentHashMap<String, String>();
         shepherds.put(shepherdID, state);
     }
 
     public static void removeShepherdState(String shepherdID) {
-        shepherds = new ConcurrentHashMap<String, String>();
         shepherds.remove(shepherdID);
     }
 
     public static String getShepherdState(String shepherdID) {
-        shepherds = new ConcurrentHashMap<String, String>();
         return shepherds.get(shepherdID);
     }
 
     public static ConcurrentHashMap<String, String> getAllShepherdStates() {
-        shepherds = new ConcurrentHashMap<String, String>();
         return shepherds;
     }
 }

--- a/src/main/java/org/ecocean/shepherd/utils/ShepherdState.java
+++ b/src/main/java/org/ecocean/shepherd/utils/ShepherdState.java
@@ -2,28 +2,31 @@ package org.ecocean.shepherd.utils;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-public class ShepherdState {
+public final class ShepherdState {
+    private ShepherdState() {
+        // Prevent instantiation
+    }
 
     private static ConcurrentHashMap<String, String> shepherds = new ConcurrentHashMap<String,
             String>();
 
     public static void setShepherdState(String shepherdID, String state) {
-        if (shepherds == null) shepherds = new ConcurrentHashMap<String, String>();
+        shepherds = new ConcurrentHashMap<String, String>();
         shepherds.put(shepherdID, state);
     }
 
     public static void removeShepherdState(String shepherdID) {
-        if (shepherds == null) shepherds = new ConcurrentHashMap<String, String>();
+        shepherds = new ConcurrentHashMap<String, String>();
         shepherds.remove(shepherdID);
     }
 
     public static String getShepherdState(String shepherdID) {
-        if (shepherds == null) shepherds = new ConcurrentHashMap<String, String>();
+        shepherds = new ConcurrentHashMap<String, String>();
         return shepherds.get(shepherdID);
     }
 
     public static ConcurrentHashMap<String, String> getAllShepherdStates() {
-        if (shepherds == null) shepherds = new ConcurrentHashMap<String, String>();
+        shepherds = new ConcurrentHashMap<String, String>();
         return shepherds;
     }
 }

--- a/src/main/java/org/ecocean/shepherd/utils/ShepherdState.java
+++ b/src/main/java/org/ecocean/shepherd/utils/ShepherdState.java
@@ -2,8 +2,17 @@ package org.ecocean.shepherd.utils;
 
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * ShepherdState provides static utility methods to track the state and use of shepherd instances (database access).
+ *
+ * See, e.g., Shepherd transaction handlers, Shepherd.setAction(...), RestServlet.doGet(...), etc.
+ * A state dump can be accessed via dbconnections.jsp
+ *
+ * <p><strong>Note:</strong> This class is not intended to be instantiated.</p>
+ */
 public final class ShepherdState {
 
+    // Internal thread-safe static map to store the state.
     private static final ConcurrentHashMap<String, String> shepherds = new ConcurrentHashMap<>();
 
     private ShepherdState() {

--- a/src/main/java/org/ecocean/shepherd/utils/ShepherdState.java
+++ b/src/main/java/org/ecocean/shepherd/utils/ShepherdState.java
@@ -1,0 +1,29 @@
+package org.ecocean.shepherd.utils;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ShepherdState {
+
+    private static ConcurrentHashMap<String, String> shepherds = new ConcurrentHashMap<String,
+            String>();
+
+    public static void setShepherdState(String shepherdID, String state) {
+        if (shepherds == null) shepherds = new ConcurrentHashMap<String, String>();
+        shepherds.put(shepherdID, state);
+    }
+
+    public static void removeShepherdState(String shepherdID) {
+        if (shepherds == null) shepherds = new ConcurrentHashMap<String, String>();
+        shepherds.remove(shepherdID);
+    }
+
+    public static String getShepherdState(String shepherdID) {
+        if (shepherds == null) shepherds = new ConcurrentHashMap<String, String>();
+        return shepherds.get(shepherdID);
+    }
+
+    public static ConcurrentHashMap<String, String> getAllShepherdStates() {
+        if (shepherds == null) shepherds = new ConcurrentHashMap<String, String>();
+        return shepherds;
+    }
+}

--- a/src/main/java/org/ecocean/shepherd/utils/ShepherdState.java
+++ b/src/main/java/org/ecocean/shepherd/utils/ShepherdState.java
@@ -8,6 +8,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * See, e.g., Shepherd transaction handlers, Shepherd.setAction(...), RestServlet.doGet(...), etc.
  * A state dump can be accessed via dbconnections.jsp
  *
+ * todo:  consider rewriting this as an event-driven service where shepherds publish events
+ *   that are handled centrally instead of manual set/remove ... more scalable, less likely to leak, better scope control ...
  * <p><strong>Note:</strong> This class is not intended to be instantiated.</p>
  */
 public final class ShepherdState {

--- a/src/main/webapp/dbconnections.jsp
+++ b/src/main/webapp/dbconnections.jsp
@@ -5,7 +5,7 @@ org.joda.time.format.DateTimeFormatter,
 org.joda.time.format.ISODateTimeFormat,java.net.*,
 org.ecocean.grid.*,java.util.concurrent.*,
 java.io.*,java.util.*, java.io.FileInputStream, java.io.File, java.io.FileNotFoundException, org.ecocean.*,org.ecocean.servlet.*,javax.jdo.*, java.lang.StringBuffer, java.util.Vector, java.util.Iterator, java.lang.NumberFormatException"%>
-<%@ page import="org.ecocean.shepherd.core.ShepherdPMF" %>
+<%@ page import="org.ecocean.shepherd.utils.ShepherdState" %>
 
 <%
 
@@ -28,11 +28,11 @@ context=ServletUtilities.getContext(request);
 <h1>Database Connections</h1>
 <ol>
 <%
-ConcurrentHashMap<String,String> map= ShepherdPMF.getAllShepherdStates();
+ConcurrentHashMap<String,String> map=ShepherdState.getAllShepherdStates();
 Enumeration<String> keys=map.keys();
 while(keys.hasMoreElements()){
 	String key=keys.nextElement();
-	String status=ShepherdPMF.getShepherdState(key);
+	String status=ShepherdState.getShepherdState(key);
 	//display any non-closes
 	//if(status.indexOf("close")==-1){
 	%>

--- a/src/test/java/org/ecocean/extensions/StaticFieldClearExtension.java
+++ b/src/test/java/org/ecocean/extensions/StaticFieldClearExtension.java
@@ -1,0 +1,56 @@
+package org.ecocean.extensions;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * JUnit 5 extension that clears the contents of static fields before each test.
+ * <p>
+ * Supports Maps, Collections, and any custom types that implement clear().
+ * </p>
+ */
+public class StaticFieldClearExtension implements BeforeEachCallback {
+
+    private final Class<?> targetClass;
+    private final String fieldName;
+
+    public StaticFieldClearExtension(Class<?> targetClass, String fieldName) {
+        this.targetClass = targetClass;
+        this.fieldName = fieldName;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        Field field = targetClass.getDeclaredField(fieldName);
+        field.setAccessible(true);
+
+        if (!java.lang.reflect.Modifier.isStatic(field.getModifiers())) {
+            throw new IllegalStateException("Field '" + fieldName + "' must be static.");
+        }
+
+        Object value = field.get(null); // static fields => pass 'null' for instance
+
+        if (value == null) {
+            // Nothing to clear if null
+            return;
+        }
+
+        if (value instanceof Map) {
+            ((Map<?, ?>) value).clear();
+        } else if (value instanceof Collection) {
+            ((Collection<?>) value).clear();
+        } else {
+            try {
+                // Try to find a 'clear' method by reflection
+                value.getClass().getMethod("clear").invoke(value);
+            } catch (NoSuchMethodException e) {
+                throw new IllegalStateException("Unsupported static field type: "
+                        + field.getType().getName() + ". Only Map, Collection, or classes with a clear() method are supported.");
+            }
+        }
+    }
+}

--- a/src/test/java/org/ecocean/shepherd/utils/ShepherdStateTest.java
+++ b/src/test/java/org/ecocean/shepherd/utils/ShepherdStateTest.java
@@ -2,22 +2,22 @@ package org.ecocean.shepherd.utils;
 
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.ecocean.extensions.StaticFieldClearExtension;
+
 class ShepherdStateTest {
 
-    @AfterEach
-    void tearDown() {
-        // Clear state after each test to avoid pollution
-        ShepherdState.getAllShepherdStates().clear();
-    }
+    @RegisterExtension
+    static StaticFieldClearExtension clearExtension =
+            new StaticFieldClearExtension(ShepherdState.class, "shepherds");
 
     @Test
     void testSetAndGetShepherdState() {
         ShepherdState.setShepherdState("shepherd1", "active");
-        String state = ShepherdState.getShepherdState("shepherd1");
-        assertEquals("active", state);
+        assertEquals("active", ShepherdState.getShepherdState("shepherd1"));
     }
 
     @Test
@@ -39,8 +39,7 @@ class ShepherdStateTest {
     void testOverwriteShepherdState() {
         ShepherdState.setShepherdState("shepherd4", "idle");
         ShepherdState.setShepherdState("shepherd4", "working");
-        String state = ShepherdState.getShepherdState("shepherd4");
-        assertEquals("working", state);
+        assertEquals("working", ShepherdState.getShepherdState("shepherd4"));
     }
 
     @Test

--- a/src/test/java/org/ecocean/shepherd/utils/ShepherdStateTest.java
+++ b/src/test/java/org/ecocean/shepherd/utils/ShepherdStateTest.java
@@ -1,0 +1,50 @@
+package org.ecocean.shepherd.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.*;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+class ShepherdStateTest {
+
+    @AfterEach
+    void tearDown() {
+        // Clear state after each test to avoid pollution
+        ShepherdState.getAllShepherdStates().clear();
+    }
+
+    @Test
+    void testSetAndGetShepherdState() {
+        ShepherdState.setShepherdState("shepherd1", "active");
+        String state = ShepherdState.getShepherdState("shepherd1");
+        assertEquals("active", state);
+    }
+
+    @Test
+    void testRemoveShepherdState() {
+        ShepherdState.setShepherdState("shepherd2", "inactive");
+        ShepherdState.removeShepherdState("shepherd2");
+        assertNull(ShepherdState.getShepherdState("shepherd2"));
+    }
+
+    @Test
+    void testGetAllShepherdStates() {
+        ShepherdState.setShepherdState("shepherd3", "busy");
+        ConcurrentHashMap<String, String> allStates = ShepherdState.getAllShepherdStates();
+        assertEquals(1, allStates.size());
+        assertEquals("busy", allStates.get("shepherd3"));
+    }
+
+    @Test
+    void testOverwriteShepherdState() {
+        ShepherdState.setShepherdState("shepherd4", "idle");
+        ShepherdState.setShepherdState("shepherd4", "working");
+        String state = ShepherdState.getShepherdState("shepherd4");
+        assertEquals("working", state);
+    }
+
+    @Test
+    void testGetStateForUnknownShepherd() {
+        assertNull(ShepherdState.getShepherdState("unknown"));
+    }
+}


### PR DESCRIPTION
The ShepherdState functionality which keeps an eye on db transaction begins and commits and is exposed in dbconnections was part of the ShepherdPMF file ... this pr pulls it out into its own file for clarity and adds some tests.  
