### PR TITLE
special wildcard match on taxonomy when encounter has "sp" for specificEpithet

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -764,8 +764,13 @@ public class Annotation extends Base implements java.io.Serializable {
         String txStr = enc.getTaxonomyString();
         if (txStr != null) {
             useClauses = true;
-            arg.put("encounterTaxonomy", txStr);
-            wrapper.put("match", arg);
+            if (txStr.endsWith(" sp")) {
+                arg.put("encounterTaxonomy", txStr.substring(0, txStr.length() - 2) + "*");
+                wrapper.put("wildcard", arg);
+            } else {
+                arg.put("encounterTaxonomy", txStr);
+                wrapper.put("match", arg);
+            }
             query.getJSONObject("query").getJSONObject("bool").getJSONArray("filter").put(wrapper);
         } else if (!Util.booleanNotFalse(IA.getProperty(myShepherd.getContext(),
             "allowIdentificationWithoutTaxonomy"))) {


### PR DESCRIPTION
When an Encounter has the property `specificEpithet` containing the value `sp`, the annotation matchingSet will be found by matching _any_ taxonomy that starts with the `genus` value only, using this wildcard OpenSearch query clause:
```
          "wildcard": {
              "encounterTaxonomy": "Genusvalue *"
          }
```

PR has no related issue.