### PR TITLE
messed-up status/state term

### DIFF
--- a/frontend/src/pages/SearchPages/getAllSearchParamsAndParse.js
+++ b/frontend/src/pages/SearchPages/getAllSearchParamsAndParse.js
@@ -27,7 +27,7 @@ const helperFunction = (
         "filter",
         {
           term: {
-            status: params.state,
+            state: params.state,
           },
         },
         "Encounter State",
@@ -35,8 +35,8 @@ const helperFunction = (
     }
     if (key === "searchQueryId") {
       store.formFilters = JSON.parse(sessionStorage.getItem("formData")) || [];
-      setTempFormFilters([...store.formFilters]);
     }
+    setTempFormFilters([...store.formFilters]);
   });
   setFilterPanel(false);
 };


### PR DESCRIPTION
fix an issue found in 10.6: When a user clicks on My Data > My Encounters > My unapproved animals they get 0 results. But if the same user starts an encounter search and searches for their own unapproved encounters (Metadata > Encounter state is unapproved > Assigned user is username) then the search results actually load a list of their unapproved encounters.

1. search term should be "state" not "status"
2. update formFilters when user search from "my encounter" in nav, so that sidebar can reflect filters from "my encounters" as well

PR does not fix numbered issue