### PR TITLE
fix my encounters search selection does not show up in encounter filters issue

### DIFF
--- a/frontend/src/pages/SearchPages/getAllSearchParamsAndParse.js
+++ b/frontend/src/pages/SearchPages/getAllSearchParamsAndParse.js
@@ -14,8 +14,8 @@ const helperFunction = (
         "assignedUsername",
         "filter",
         {
-          term: {
-            assignedUsername: params.username,
+          terms: {
+            assignedUsername: [params.username],
           },
         },
         "Assigned User",
@@ -26,8 +26,8 @@ const helperFunction = (
         "state",
         "filter",
         {
-          term: {
-            state: params.state,
+          terms: {
+            state: [params.state],
           },
         },
         "Encounter State",


### PR DESCRIPTION
fix an issue found by kirk:
I had verified that the search filters for assigned user and encounter state show up in the "Applied Filters" sidebar but I just noticed that the selections don't end up selected in the Metadata filter controls after you click "Edit" in  "Applied Filters".

root cause:
search filters for assigned user and encounter state from "my encounters" are single-select, while selection for those two fields "assignedUsername" and "state" are multi-select, so "term" does not match "terms", thus selected value will be empty array, no option will be selected

fix:
update "term" to "terms" and make the value of "assignedUsername" and "state" to be array