### PR TITLE
support all direction drawing

### DIFF
--- a/frontend/src/components/AddAnnotationModal.jsx
+++ b/frontend/src/components/AddAnnotationModal.jsx
@@ -11,8 +11,6 @@ export default function AddAnnotationModal({
 }) {
   const intl = useIntl();
 
-  console.log("error",error)
-
   return (
     <Modal show={showModal} onHide={() => setShowModal(false)}>
       <Modal.Header closeButton>

--- a/frontend/src/models/encounters/useCreateAnnotation.js
+++ b/frontend/src/models/encounters/useCreateAnnotation.js
@@ -23,8 +23,6 @@ export default function useCreateAnnotation() {
     setLoading(true);
     setError(null);
 
-    console.log("rotation", rotation);
-
     try {
       const response = await axios.request({
         method: "post",

--- a/frontend/src/pages/ManualAnnotation.jsx
+++ b/frontend/src/pages/ManualAnnotation.jsx
@@ -33,8 +33,6 @@ export default function ManualAnnotation() {
   const { createAnnotation, loading, error, submissionDone, responseData } =
     useCreateAnnotation();
 
-  console.log("error", error);
-
   const [showModal, setShowModal] = useState(false);
   const [scaleFactor, setScaleFactor] = useState({ x: 1, y: 1 });
   const [ia, setIa] = useState(null);
@@ -131,21 +129,6 @@ export default function ManualAnnotation() {
             scaledRect.height,
           );
 
-          // context.strokeStyle = "blue";
-          // context.lineWidth = 1;
-          // context.beginPath();
-          // context.moveTo(-scaledRect.width / 2, -scaledRect.height / 2); // Top-left corner
-          // context.lineTo(scaledRect.width / 2, -scaledRect.height / 2);  // Top-right corner
-          // context.stroke();
-
-          // // Draw the other borders in yellow
-          // context.strokeStyle = "yellow";
-          // context.lineWidth = 1;
-          // context.beginPath();
-          // context.moveTo(-scaledRect.width / 2, -scaledRect.height / 2);
-          // context.lineTo(-scaledRect.width / 2, scaledRect.height / 2);
-          // context.lineTo(scaledRect.width / 2, scaledRect.height / 2);
-          // context.lineTo(scaledRect.width / 2, -scaledRect.height / 2);
           context.restore();
         }
       }
@@ -228,6 +211,22 @@ export default function ManualAnnotation() {
 
   const handleMouseUp = () => {
     if (!imgRef.current || drawStatus === "DELETE") return;
+    function normalizeRectOnDraw(rect) {
+      let { x, y, width, height } = rect;
+
+      if (width < 0) {
+        x = x + width;
+        width = -width;
+      }
+      if (height < 0) {
+        y = y + height;
+        height = -height;
+      }
+
+      return { x, y, width, height };
+    }
+
+    setRect((prev) => normalizeRectOnDraw(prev));
     setIsDrawing(false);
   };
 


### PR DESCRIPTION
support all-directon drawing on react manual annotation page
(x,y) should always be the top-left corner, width and height should always be positive numbers
 
top to bottom
bottom to top
left to right
right to left

PR fixes #1096 