### PR TITLE
Set React default name to Wildbook

### DIFF
--- a/frontend/maven-build.sh
+++ b/frontend/maven-build.sh
@@ -3,7 +3,7 @@
 # it seems like we dont need a full/absolute url here
 #export PUBLIC_URL=https://example.com/react/
 export PUBLIC_URL=/react/
-export SITE_NAME="Test Site Name"
+export SITE_NAME="Wildbook"
 
 npm install react-app-rewired
 


### PR DESCRIPTION
Sets the default name in the React header to "Wildbook" from "Test Site Name". 
