### PR TITLE
Restore encounter visibility security checks to ensure they occur bef…

### DIFF
--- a/src/main/webapp/encounters/encounter.jsp
+++ b/src/main/webapp/encounters/encounter.jsp
@@ -558,7 +558,21 @@ var encounterNumber = '<%=num%>';
       			Encounter enc = myShepherd.getEncounter(num);
             	//System.out.println("Got encounter "+enc+" with dataSource "+enc.getDataSource()+" and submittedDate "+enc.getDWCDateAdded());
             	String encNum = enc.getCatalogNumber();
-				boolean visible = enc.canUserAccess(request);
+            	
+            	
+				//let's see if this user has ownership and can make edits
+      			boolean isOwner = ServletUtilities.isUserAuthorizedForEncounter(enc, request,myShepherd);
+            	boolean encounterIsPublic = ServletUtilities.isEncounterOwnedByPublic(enc);
+            	boolean encounterCanBeEditedByAnyLoggedInUser = encounterIsPublic && request.getUserPrincipal() != null;
+            	pageContext.setAttribute("editable", (isOwner || encounterCanBeEditedByAnyLoggedInUser) && CommonConfiguration.isCatalogEditable(context));
+      			boolean loggedIn = false;
+      			try{
+      				if(request.getUserPrincipal()!=null){loggedIn=true;}
+      			}
+      			catch(NullPointerException nullLogged){}
+            	
+            	
+				boolean visible = isOwner || encounterIsPublic || encounterCanBeEditedByAnyLoggedInUser || enc.canUserAccess(request);
 				System.out.println("visible: "+visible);
 				//if (!visible) visible = checkAccessKey(request, enc);
 				if (!visible) {
@@ -615,16 +629,7 @@ var encounterNumber = '<%=num%>';
 					System.out.println("============ out ==============");
 				}
 
-				//let's see if this user has ownership and can make edits
-      			boolean isOwner = ServletUtilities.isUserAuthorizedForEncounter(enc, request,myShepherd);
-            boolean encounterIsPublic = ServletUtilities.isEncounterOwnedByPublic(enc);
-            boolean encounterCanBeEditedByAnyLoggedInUser = encounterIsPublic && request.getUserPrincipal() != null;
-            pageContext.setAttribute("editable", (isOwner || encounterCanBeEditedByAnyLoggedInUser) && CommonConfiguration.isCatalogEditable(context));
-      			boolean loggedIn = false;
-      			try{
-      				if(request.getUserPrincipal()!=null){loggedIn=true;}
-      			}
-      			catch(NullPointerException nullLogged){}
+
 
       			String headerBGColor="FFFFFC";
       			//if(CommonConfiguration.getProperty(()){}


### PR DESCRIPTION
…ore collaboration checks

This PR moves security checks for Encounter access to occur before the Collaboration security check, ensuring they are used in deciding whether a user can access an Encounter page.

PR fixes #1123 

