### PR TITLE
Social unit fixes on individuals.jsp

### DIFF
--- a/src/main/java/org/ecocean/servlet/MembershipCreate.java
+++ b/src/main/java/org/ecocean/servlet/MembershipCreate.java
@@ -103,14 +103,16 @@ public class MembershipCreate extends HttpServlet {
                     DateTime startDT = DateTime.parse(startDate, formatter);
                     System.out.println("StartDate parsed: " + startDT.toString());
                     Long startLong = startDT.getMillis();
-                    membership.setStartDate(startLong.longValue());
+                    membership.setStartDate(startLong);
                 }
+                else if(startDate == null) {membership.setStartDate(null);}
                 if (endDate != null && !"".equals(endDate)) {
                     DateTime endDT = DateTime.parse(endDate, formatter);
                     System.out.println("EndDate parsed: " + endDT.toString());
                     Long endLong = endDT.getMillis();
-                    membership.setEndDate(endLong.longValue());
+                    membership.setEndDate(endLong);
                 }
+                else if(endDate == null) {membership.setEndDate(null);}
                 if (roleName != null) {
                     if (roleName.trim().equals("")) {
                         membership.setRole(null);

--- a/src/main/java/org/ecocean/social/Membership.java
+++ b/src/main/java/org/ecocean/social/Membership.java
@@ -103,13 +103,15 @@ public class Membership implements java.io.Serializable {
             this.role = null;
         } else { this.role = role; }
     }
-
-    public void setStartDate(long startDate) {
-        this.startDate = startDate;
+    
+    public void setStartDate(Long startDate) {
+    	if(startDate==null) {this.startDate=null;}
+    	else{this.startDate = startDate;}
     }
 
-    public void setEndDate(long endDate) {
-        this.endDate = endDate;
+    public void setEndDate(Long endDate) {
+    	if(endDate==null) {this.endDate=null;}
+    	else{this.endDate = endDate;}
     }
 
     public String getId() {

--- a/src/main/webapp/individuals.jsp
+++ b/src/main/webapp/individuals.jsp
@@ -1284,13 +1284,17 @@ if (sharky.getNames() != null) {
     <br/>
     <%
       List<SocialUnit> units = myShepherd.getAllSocialUnitsForMarkedIndividual(sharky);
-      String unitName = "";
-      String role = "";
-      String startDate = "";
-      String endDate = "";
+
       if (isOwner&&CommonConfiguration.isCatalogEditable(context)) {
         if (units!=null) {
             for (SocialUnit unit : units) {
+            	
+                String unitName = "";
+                String role = "";
+                String startDate = "";
+                String endDate = "";	
+            	
+            
                 Membership membership = unit.getMembershipForMarkedIndividual(sharky);
                 if (unit.getSocialUnitName()!=null) {unitName=unit.getSocialUnitName();}
                 if (membership.getRole()!=null) {role=membership.getRole();}
@@ -1316,7 +1320,7 @@ if (sharky.getNames() != null) {
 
             <div class="col-xs-3 col-sm-2">
               <label><strong><%=props.getProperty("socialGroupMembershipStart") %></strong></label>
-              <p class="socialGroupMembershipStart"><%=startDate%></p>
+              <p id="<%=membership.getStartDateLong() %>" class="socialGroupMembershipStart"><%=startDate%></p>
             </div>
 
             <div class="col-xs-3 col-sm-2">
@@ -1347,6 +1351,12 @@ if (sharky.getNames() != null) {
               <select id="socialGroupNameSelect" name="socialGroupNameSelect" onchange="socialGroupNameSelectChanged(this)">
                 <option value="new" selected>CREATE NEW</option>
                 <%
+                
+                String unitName = "";
+                String role = "";
+                String startDate = "";
+                String endDate = "";
+                
                 System.out.println("How many social unit??? "+units.size());
                 if (units!=null&&units.size()>0) {
                   for (SocialUnit formUnit : units) {


### PR DESCRIPTION
Display fixes for Social Units as rendered on individuals.jsp.

1. Fix display of wrong start and end dates for social unit membership due to variable scoping
2. Allow for setting start and end date to null

PR fixes #1135 


