### PR TITLE
Standardize and minimize JSP maincontent div margin padding

### DIFF
--- a/src/main/webapp/cust/mantamatcher/styles/_custom.less
+++ b/src/main/webapp/cust/mantamatcher/styles/_custom.less
@@ -50,7 +50,7 @@ h5 { text-decoration: underline; }
 	}
 
 @media (min-width: @screen-md) { 
-	.maincontent { margin-top: 100px; }
+	.maincontent { margin-top: 25px; }
 }
 
 .img-container img {

--- a/src/main/webapp/cust/mantamatcher/styles/_custom.less
+++ b/src/main/webapp/cust/mantamatcher/styles/_custom.less
@@ -45,7 +45,7 @@ h5 { text-decoration: underline; }
 .page-content a { text-decoration: underline; }
 
 .maincontent { 
-	margin-top: 70px; 
+	margin-top: 25px; 
 	margin-bottom: 80px;
 	}
 


### PR DESCRIPTION
Standardizes JSP div.maincontent top margin to 25px to remove wasted space.

Before:
![image](https://github.com/user-attachments/assets/cc423d86-b722-445b-b596-ddc335caa05d)

After:
![image](https://github.com/user-attachments/assets/26aa567b-049e-4338-a177-7dffdb717796)


