### PR TITLE
Set smtp as default email config

### DIFF
--- a/src/main/resources/bundles/commonConfiguration.properties
+++ b/src/main/resources/bundles/commonConfiguration.properties
@@ -27,7 +27,7 @@ GlobalUniqueIdentifierPrefix=MyGroup:MyStudy:
 sendEmailNotifications=true
 autoEmailAddress=info@wildme.org
 newSubmissionEmail=donotreply@wildme.org
-mailHost=localhost
+mailHost=smtp
 removeEmailString=Do you want to REMOVE your email address from this database? Click the link below to remove it. You will no longer receive updates on your encounters.
 
 #HTML metadata for each page


### PR DESCRIPTION
Sets smtp as the default email configuration mailhost.
