### PR TITLE
remove second close statement already covered in finally{} and throwi…

### DIFF
--- a/src/main/java/org/ecocean/OpenSearch.java
+++ b/src/main/java/org/ecocean/OpenSearch.java
@@ -156,7 +156,6 @@ public class OpenSearch {
                         Base.opensearchSyncIndex(myShepherd, MediaAsset.class,
                         BACKGROUND_SLICE_SIZE);
                         System.out.println("OpenSearch background indexing finished.");
-                        myShepherd.rollbackAndClose();
                     } catch (Exception ex) {
                         ex.printStackTrace();
                     } finally {


### PR DESCRIPTION
…ng trivial exception in logs

Removes a Shepherd close inside a {try} and relies on the finally{} to do it
