### PR TITLE
Add @URL_LOCATION@ to TagMap to allow email header

### DIFF
--- a/src/main/java/org/ecocean/servlet/UserResetPasswordSendEmail.java
+++ b/src/main/java/org/ecocean/servlet/UserResetPasswordSendEmail.java
@@ -93,6 +93,8 @@ public class UserResetPasswordSendEmail extends HttpServlet {
                     Map<String, String> tagMap = new HashMap<String, String>() {{
                         put("@RESET_LINK@", npLink);
                     }};
+                    tagMap.put("@URL_LOCATION@",String.format("https://%s", CommonConfiguration.getURLLocation(request)));
+
                     String mailTo = myUser.getEmailAddress();
                     NotificationMailer mailer = new NotificationMailer(context, null, mailTo,
                         "passwordReset", tagMap, true);                                                                // override user.receiveEmails


### PR DESCRIPTION
CXL graphic header is missing from password reset emails. This adds the @URL_LOCATION@ tag entry to ensure the proper URL gets set for the email header graphic.


