### PR TITLE
one part, one body allowance

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -1576,6 +1576,16 @@ public class Annotation extends Base implements java.io.Serializable {
         System.out.println("areContiguous() has nonTrivial=" + nonTrivial);
         if (nonTrivial.size() < 1) return false;
         if (nonTrivial.size() == 1) return true;
+        //if they're a body and a part, consider them contiguous
+        if (nonTrivial.size() == 2) {
+        	String iaClass0=nonTrivial.get(0).getIAClass();
+        	String iaClass1=nonTrivial.get(1).getIAClass();
+        	if(iaClass0!=null && iaClass1!=null) {
+        		if(iaClass0.indexOf("+")>-1&&iaClass1.indexOf("+")==-1) return true;
+        		if(iaClass1.indexOf("+")>-1&&iaClass0.indexOf("+")==-1) return true;
+        	}
+        	
+        }
         Annotation first = nonTrivial.remove(0);
         return (first.intersectsAtLeastOne(nonTrivial) && areContiguous(nonTrivial)); // yay recursion!
     }


### PR DESCRIPTION
Compelx logic goes into body and part association. This logic ensures that in the case where one body and one part annotation are present, they will always be contained in the same encounter. Previously, there were edge-cases where these two would be cloned to separate encounters.
