### PR TITLE
quick search can find individuals using encounter ids

### DIFF
--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -2602,7 +2602,7 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
             other.getIndividualID() + "'";
         Query q = myShepherd.getPM().newQuery(filter);
         Collection cTemp = (Collection)q.execute();
-        ArrayList<ScheduledIndividualMerge> c = new ArrayList<ScheduledIndividualMerge>(cTemp); 
+        ArrayList<ScheduledIndividualMerge> c = new ArrayList<ScheduledIndividualMerge>(cTemp);
         q.closeAll();
         ArrayList<ScheduledIndividualMerge> merges = new ArrayList<ScheduledIndividualMerge>(c);
         // throw out any scheduled merge related to this individual as it is now being merged.
@@ -2660,6 +2660,7 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
         map.put("sex", keywordType);
         map.put("taxonomy", keywordType);
         map.put("users", keywordType);
+        map.put("encounterIds", keywordType);
         map.put("cooccurrenceIndividualIds", keywordType);
 
         // all case-insensitive keyword-ish types
@@ -2760,6 +2761,7 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
         jgen.writeEndArray();
         if (this.getNumEncounters() > 0) {
             Set<String> users = new HashSet<String>();
+            Set<String> encIds = new HashSet<String>();
             jgen.writeNumberField("numberEncounters", this.getNumEncounters());
             Set<String> occIds = new HashSet<String>();
             List<Double> dlats = new ArrayList<Double>();
@@ -2767,6 +2769,7 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
             Map<MarkedIndividual, Integer> coMap = new HashMap<MarkedIndividual, Integer>();
             int numMAs = 0;
             for (Encounter enc : this.encounters) {
+                encIds.add(enc.getId());
                 numMAs += enc.numAnnotations();
                 users.addAll(enc.getAllSubmitterIds(myShepherd));
                 Occurrence occ = enc.getOccurrence(myShepherd);
@@ -2814,6 +2817,11 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
             jgen.writeArrayFieldStart("users");
             for (String uid : users) {
                 jgen.writeString(uid);
+            }
+            jgen.writeEndArray();
+            jgen.writeArrayFieldStart("encounterIds");
+            for (String eid : encIds) {
+                jgen.writeString(eid);
             }
             jgen.writeEndArray();
         } else {


### PR DESCRIPTION
PR fixes #1106 

- `encounterIds` list added to MarkedIndividual OpenSearch document and mapping
- frontend quicksearch query modified to add above