### PR TITLE
Fix @SENDER-EMAIL@ tag name in collaboration emails

### DIFF
--- a/src/main/resources/emails/en/collaborationInvite.html
+++ b/src/main/resources/emails/en/collaborationInvite.html
@@ -110,7 +110,7 @@
                                                 @CONTEXT_NAME@ from @SENDER@.</p>
 
                                               <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">
-                                                @SENDER_EMAIL@
+                                                @SENDER-EMAIL@
                                               </p>
 
                                               <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">Please


### PR DESCRIPTION
A single character fix to set the correct tag name for replacement in automated collaboration request emails.
