### PR TITLE
Ensures method does not return empty ACM IDs

### DIFF
--- a/src/main/java/org/ecocean/identity/IBEISIA.java
+++ b/src/main/java/org/ecocean/identity/IBEISIA.java
@@ -413,7 +413,7 @@ public class IBEISIA {
         JSONArray uuidList = new JSONArray();
 
         for (MediaAsset ma : mas) {
-            uuidList.put(toFancyUUID(ma.getAcmId()));
+        	if(ma.getAcmId()!=null)uuidList.put(toFancyUUID(ma.getAcmId()));
         }
         return uuidList;
     }


### PR DESCRIPTION
Detection jobs can fail when a MediaAsset sent by Wildbook does not have an ACM ID due to local corruption. There are likely other times this may block bulk detection as well. Tracing the issue back to this method, it returns an empty entry for a MediaAsset that does not have an ACM ID. These empty entries then get included in the detection request and result in a 500 error from WBIA.

This modification just ensures that only non-null ACM ID entries are returned from the method, preventing a WBIA 500 response through referencing an unknown image to WBIA.
