### PR TITLE
fix(email): correct legal statement in encounter submission mail (#1209)

### DIFF
--- a/src/main/resources/emails/en/individualAddEncounter.html
+++ b/src/main/resources/emails/en/individualAddEncounter.html
@@ -341,25 +341,10 @@
      
                                                               <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">LEGAL
                                                                 STATEMENT</p>
-                                                              <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">Wildbook
-                                                                is copyrighted
-                                                                2025 by Conservation X Labs.
-                                                                Individual
-                                                                contributors to
-                                                                Wildbook retain
-                                                                copyrights for
-                                                                submitted
-                                                                images. No
-                                                                reproduction or
-                                                                usage of
-                                                                material in this
-                                                                library is
-                                                                permitted
-                                                                without the
-                                                                express
-                                                                permission of
-                                                                the copyright
-                                                                holders.</p>
+                                                              <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">
+																  &copy; 2025 Conservation X Labs. Individual contributors to Wildbook retain copyrights for submitted images.
+																  No reproduction or usage of material in this library is permitted without the express permission of the copyright holders. </p>
+
                                                               <table class="spacer"
                                                               
                                                                 style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
@@ -371,11 +356,10 @@
                                                                   </tr>
                                                                 </tbody>
                                                               </table>
-                                                              <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">Do not reply to this email. For questions and comments, go to [
+                                                              <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">Do not reply to this email. For questions and comments, go to 
                                                                   <a href="@WILDBOOK_COMMUNITY_URL@"
                                                                   
-                                                                  style="Margin:0;color:#2199e8;font-family:Helvetica,Arial,sans-serif;font-weight:400;line-height:1.3;margin:0;padding:0;text-align:left;text-decoration:none">community.wildme.org</a>
-                                                              ].                                                         
+                                                                  style="Margin:0;color:#2199e8;font-family:Helvetica,Arial,sans-serif;font-weight:400;line-height:1.3;margin:0;padding:0;text-align:left;text-decoration:none">community.wildme.org</a>.                                                         
                                                               </p>
                                                               <table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%"
 


### PR DESCRIPTION
**Problem**
The encounter submission confirmation email showed the legal statement with outdated formatting and included square brackets around the community link.

**Fix**
Updated `src/main/resources/emails/en/individualAddEncounter.html`:
- Standardized the footer to “© 2025 Conservation X Labs. Individual contributors to Wildbook retain copyrights for submitted images. No reproduction or usage of material in this library is permitted without the express permission of the copyright holders.”
- Removed the `[...]` around the `@WILDBOOK_COMMUNITY_URL@` link so it renders as a normal anchor.

**Verification**
Manually inspected the template; the footer now shows the corrected legal statement and a clean `community.wildme.org` link. Unsubscribe token `[[UNSUB_LINK_EN]]` unchanged.
