### PR TITLE
Store and search subspecies more consistently

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -2150,7 +2150,7 @@ public class Encounter extends Base implements java.io.Serializable {
     }
 
     public void setSpeciesOnly(String species) {
-        this.specificEpithet = species;
+        setSpecificEpithet(species);
         this.refreshAnnotationLiteTaxonomy();
     }
 
@@ -2159,7 +2159,7 @@ public class Encounter extends Base implements java.io.Serializable {
     }
 
     public void setSpecificEpithet(String newEpithet) {
-        if (newEpithet != null) { specificEpithet = newEpithet; } else { specificEpithet = null; }
+        if (newEpithet != null) { specificEpithet = newEpithet.replaceAll("_"," "); } else { specificEpithet = null; }
         this.refreshAnnotationLiteTaxonomy();
     }
 
@@ -2187,7 +2187,7 @@ public class Encounter extends Base implements java.io.Serializable {
             this.specificEpithet = null;
         } else {
             this.genus = gs[0];
-            this.specificEpithet = gs[1];
+            this.specificEpithet = gs[1].replaceAll("_"," ");
         }
         this.refreshAnnotationLiteTaxonomy();
     }
@@ -2201,7 +2201,7 @@ public class Encounter extends Base implements java.io.Serializable {
             this.specificEpithet = null;
         } else {
             this.genus = gs[0];
-            this.specificEpithet = gs[1];
+            this.specificEpithet = gs[1].replaceAll("_"," ");
         }
         this.refreshAnnotationLiteTaxonomy();
     }

--- a/src/main/java/org/ecocean/EncounterQueryProcessor.java
+++ b/src/main/java/org/ecocean/EncounterQueryProcessor.java
@@ -1340,9 +1340,12 @@ public class EncounterQueryProcessor extends QueryProcessor {
 
                 // now we have to break apart genus species
                 StringTokenizer tokenizer = new StringTokenizer(genusSpecies, " ");
-                if (tokenizer.countTokens() == 2) {
+                if (tokenizer.countTokens() >1) {
                     genus = tokenizer.nextToken();
-                    specificEpithet = tokenizer.nextToken();
+                    while(tokenizer.hasMoreTokens()) {
+                    	specificEpithet+=tokenizer.nextToken()+" ";
+                    }
+                    specificEpithet=specificEpithet.trim();
                     if (filter.equals(SELECT_FROM_ORG_ECOCEAN_ENCOUNTER_WHERE)) {
                         filter += "genus == '" + genus + "' ";
                     } else { filter += " && genus == '" + genus + "' "; }

--- a/src/main/java/org/ecocean/IndividualQueryProcessor.java
+++ b/src/main/java/org/ecocean/IndividualQueryProcessor.java
@@ -974,7 +974,10 @@ public class IndividualQueryProcessor extends QueryProcessor {
             StringTokenizer tokenizer = new StringTokenizer(genusSpecies, " ");
             if (tokenizer.countTokens() == 2) {
                 genus = tokenizer.nextToken();
-                specificEpithet = tokenizer.nextToken();
+                while(tokenizer.hasMoreTokens()) {
+                	specificEpithet+=tokenizer.nextToken()+" ";
+                }
+                specificEpithet=specificEpithet.trim();
 
                 filter = filterWithCondition(filter, " enc.genus == '" + genus + "' ");
                 filter = filterWithCondition(filter,


### PR DESCRIPTION
Allows for normal subspecies definition without the need for an underscore in the genusSpeciesX definition in commonConfiguration.properties.

old way:
genusSpecies0 = Giraffa camelopardalis_camelopardalis

new way:
genusSpecies0 = Giraffa camelopardalis camelopardalis