### PR TITLE
Fix #1126: Enable autocomplete for 2-character Individual IDs

### DIFF
--- a/src/main/webapp/encounters/encounter.jsp
+++ b/src/main/webapp/encounters/encounter.jsp
@@ -401,6 +401,7 @@ var lastIndivAutoData = {};
 function setIndivAutocomplete(el) {
     if (!el || !el.length) return;
     var args = {
+        minLength: 2,
         resMap: function(data) {
             var taxString = $('#displayTax').text();
 

--- a/src/main/webapp/javascript/core.js
+++ b/src/main/webapp/javascript/core.js
@@ -245,6 +245,7 @@ var wildbook = {
     */
     makeAutocomplete: function(el, args) {
         if (typeof args != 'object') args = {};
+        var minLen = (args && args.minLength != null) ? args.minLength : 3;
 
         //this is "default behavior"
         //  item has:  item.species, item.label, item.type, item.value
@@ -274,7 +275,8 @@ var wildbook = {
                 }
             });
         };
-
+        
+        args.minLength = minLen;
         $(el).autocomplete(args);
     }
 };


### PR DESCRIPTION
Fixes the issue where the "Add to existing individual" field did not display the autocomplete suggestions for individual IDs less than 3 characters.

The changes I made:

- Updated makeAutocomplete() in src/main/webapp/javascript/core.js to accept a configurable minLength parameter.
- Updated setIndivAutocomplete() in src/main/webapp/encounters/encounter.jsp to pass a minLength of 2 for the Individual ID field.

PR fixes #1126