### PR TITLE
Fix Reference keyword export: use correct keyword variable and case-insensitive match

### DIFF
--- a/src/main/java/org/ecocean/servlet/export/EncounterAnnotationExportExcelFile.java
+++ b/src/main/java/org/ecocean/servlet/export/EncounterAnnotationExportExcelFile.java
@@ -415,8 +415,8 @@ public class EncounterAnnotationExportExcelFile extends HttpServlet {
                         for (MediaAsset ma : mas) {
                             for (Keyword kw : ma.getKeywordsStrict()) {
                                 if (kw != null && kw.getReadableName().equalsIgnoreCase(REFERENCE_KEYWORD)) {
-                                    exportCol.writeLabel(kw, row, sheet);
-                                    keywordFound = true;
+                                   exportCol.writeLabel(kw, row, sheet);;
+                                   keywordFound = true;
                                     break;
                                 }
                             }

--- a/src/main/java/org/ecocean/servlet/export/EncounterAnnotationExportExcelFile.java
+++ b/src/main/java/org/ecocean/servlet/export/EncounterAnnotationExportExcelFile.java
@@ -414,7 +414,7 @@ public class EncounterAnnotationExportExcelFile extends HttpServlet {
                         boolean keywordFound = false;
                         for (MediaAsset ma : mas) {
                             for (Keyword kw : ma.getKeywordsStrict()) {
-                                if (kw != null && kw.getReadableName().equals(REFERENCE_KEYWORD)) {
+                                if (kw != null && kw.getReadableName().equalsIgnoreCase(REFERENCE_KEYWORD)) {
                                     exportCol.writeLabel(kw, row, sheet);
                                     keywordFound = true;
                                     break;

--- a/src/main/resources/emails/en/individualAddEncounter.html
+++ b/src/main/resources/emails/en/individualAddEncounter.html
@@ -341,25 +341,10 @@
      
                                                               <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">LEGAL
                                                                 STATEMENT</p>
-                                                              <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">Wildbook
-                                                                is copyrighted
-                                                                2025 by Conservation X Labs.
-                                                                Individual
-                                                                contributors to
-                                                                Wildbook retain
-                                                                copyrights for
-                                                                submitted
-                                                                images. No
-                                                                reproduction or
-                                                                usage of
-                                                                material in this
-                                                                library is
-                                                                permitted
-                                                                without the
-                                                                express
-                                                                permission of
-                                                                the copyright
-                                                                holders.</p>
+                                                              <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">
+																  &copy; 2025 Conservation X Labs. Individual contributors to Wildbook retain copyrights for submitted images.
+																  No reproduction or usage of material in this library is permitted without the express permission of the copyright holders. </p>
+
                                                               <table class="spacer"
                                                               
                                                                 style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
@@ -371,11 +356,10 @@
                                                                   </tr>
                                                                 </tbody>
                                                               </table>
-                                                              <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">Do not reply to this email. For questions and comments, go to [
+                                                              <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">Do not reply to this email. For questions and comments, go to 
                                                                   <a href="@WILDBOOK_COMMUNITY_URL@"
                                                                   
-                                                                  style="Margin:0;color:#2199e8;font-family:Helvetica,Arial,sans-serif;font-weight:400;line-height:1.3;margin:0;padding:0;text-align:left;text-decoration:none">community.wildme.org</a>
-                                                              ].                                                         
+                                                                  style="Margin:0;color:#2199e8;font-family:Helvetica,Arial,sans-serif;font-weight:400;line-height:1.3;margin:0;padding:0;text-align:left;text-decoration:none">community.wildme.org</a>.                                                         
                                                               </p>
                                                               <table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%"
 


### PR DESCRIPTION
This pull request addresses the bug described in Wildbook issue #1210 (Reference keywords not appearing in the annotation export). 

### Changes
- The `EncounterAnnotationExportExcelFile` now writes the correct `Keyword` object to the "Reference" column instead of using the previous `LabelledKeyword`, ensuring that reference keywords populate in the export.
- The check for the "Reference" keyword is now case-insensitive (`equalsIgnoreCase`) so that different capitalizations are handled.
- The export loop now breaks as soon as the reference keyword is found to avoid redundant processing.

### Issue link
Fixes Wildbook/Wildbook#1210

Please let me know if any additional changes or tests are needed.