### PR TITLE
Link match-results "This Encounter" label to the query encounter

### DIFF
--- a/frontend/src/__tests__/pages/MatchResults/MatchProspectTable.test.jsx
+++ b/frontend/src/__tests__/pages/MatchResults/MatchProspectTable.test.jsx
@@ -1,0 +1,157 @@
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import MatchProspectTable from "../../../pages/MatchResultsPage/components/MatchProspectTable";
+
+jest.mock("../../../components/AnnotationOverlay", () => {
+  const React = require("react");
+  const InteractiveAnnotationOverlay = React.forwardRef(
+    function InteractiveAnnotationOverlay(props, ref) {
+      return React.createElement("div", {
+        "data-testid": "annotation-overlay-mock",
+      });
+    },
+  );
+  return InteractiveAnnotationOverlay;
+});
+
+jest.mock("../../../pages/MatchResultsPage/components/InspectorModal", () => {
+  const React = require("react");
+  function InspectorModal() {
+    return null;
+  }
+  InspectorModal.displayName = "InspectorModal";
+  return InspectorModal;
+});
+
+jest.mock("../../../api/client", () => ({
+  client: { post: jest.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+
+const themeColor = {
+  primaryColors: {
+    primary50: "#E5F6FF",
+    primary500: "#00ACCE",
+    primary700: "#007A93",
+  },
+  wildMeColors: {
+    teal100: "#CCF0F5",
+    teal800: "#00505F",
+  },
+};
+
+const messages = {
+  THIS_ENCOUNTER: "This Encounter",
+  POSSIBLE_MATCH: "Possible Match",
+  MATCHED_BASED_ON: "Matched based on",
+  NO_MATCH_RESULT: "No match results available.",
+  NO_MATCH_PROSPECTS: "No match prospects",
+};
+
+const renderTable = (props = {}) =>
+  render(
+    <IntlProvider locale="en" messages={messages} onError={() => {}}>
+      <MatchProspectTable
+        sectionId="individual-t1"
+        columns={[]}
+        themeColor={themeColor}
+        {...props}
+      />
+    </IntlProvider>,
+  );
+
+describe("MatchProspectTable — This Encounter label link", () => {
+  test("renders a link to the query encounter when thisEncounterId is provided", () => {
+    renderTable({ thisEncounterId: "enc-123" });
+
+    const link = screen.getByTestId(
+      "match-prospect-left-label-link-individual-t1",
+    );
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute(
+      "href",
+      "/react/encounter?number=enc-123",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    // setupTests.js mocks FormattedMessage to render the raw message id
+    expect(link).toHaveTextContent("THIS_ENCOUNTER");
+  });
+
+  test("URL-encodes the encounter id in the link href", () => {
+    renderTable({ thisEncounterId: "enc/we ird" });
+
+    const link = screen.getByTestId(
+      "match-prospect-left-label-link-individual-t1",
+    );
+    expect(link).toHaveAttribute(
+      "href",
+      `/react/encounter?number=${encodeURIComponent("enc/we ird")}`,
+    );
+  });
+
+  test("renders plain label text without a link when thisEncounterId is absent", () => {
+    renderTable();
+
+    const label = screen.getByTestId("match-prospect-left-label-individual-t1");
+    expect(label).toHaveTextContent("THIS_ENCOUNTER");
+    expect(within(label).queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  test("still links while the task is running with no prospects yet", () => {
+    renderTable({
+      thisEncounterId: "enc-123",
+      taskStatusOverall: "running",
+    });
+
+    expect(
+      screen.getByTestId("match-prospect-left-label-link-individual-t1"),
+    ).toHaveAttribute("href", "/react/encounter?number=enc-123");
+  });
+
+  const makeCandidate = () => ({
+    annotation: {
+      id: "ann-1",
+      asset: { url: "http://img.test/cand.jpg", width: 100, height: 80 },
+    },
+    score: 0.9,
+    displayIndex: 1,
+  });
+
+  test("fullscreen modal label links to the query encounter", () => {
+    renderTable({
+      thisEncounterId: "enc-123",
+      thisEncounterImageUrl: "http://img.test/query.jpg",
+      columns: [[makeCandidate()]],
+    });
+
+    fireEvent.click(
+      screen.getByTestId("match-prospect-fullscreen-open-individual-t1"),
+    );
+
+    const link = screen.getByTestId(
+      "match-prospect-fullscreen-left-label-link-individual-t1",
+    );
+    expect(link).toHaveAttribute("href", "/react/encounter?number=enc-123");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  test("fullscreen modal label has no link when thisEncounterId is absent", () => {
+    renderTable({
+      thisEncounterImageUrl: "http://img.test/query.jpg",
+      columns: [[makeCandidate()]],
+    });
+
+    fireEvent.click(
+      screen.getByTestId("match-prospect-fullscreen-open-individual-t1"),
+    );
+
+    const label = screen.getByTestId(
+      "match-prospect-fullscreen-left-label-individual-t1",
+    );
+    expect(label).toHaveTextContent("THIS_ENCOUNTER");
+    expect(within(label).queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/MatchResults/MatchResults.test.jsx
+++ b/frontend/src/__tests__/pages/MatchResults/MatchResults.test.jsx
@@ -37,10 +37,18 @@ jest.mock(
   "../../../pages/MatchResultsPage/components/MatchProspectTable",
   () => {
     const React = require("react");
-    function MatchProspectTable({ taskId, columns, onToggleSelected }) {
+    function MatchProspectTable({
+      taskId,
+      columns,
+      onToggleSelected,
+      thisEncounterId,
+    }) {
       return React.createElement(
         "div",
-        { "data-testid": "prospect-table-" + taskId },
+        {
+          "data-testid": "prospect-table-" + taskId,
+          "data-this-encounter-id": thisEncounterId || "",
+        },
         (columns || []).flat().map(function (col, i) {
           return React.createElement(
             "button",
@@ -227,6 +235,13 @@ describe("MatchResults component", () => {
     expect(
       await screen.findByTestId("prospect-table-task-1"),
     ).toBeInTheDocument();
+  });
+
+  test("passes the query encounter id to MatchProspectTable", async () => {
+    axios.get.mockResolvedValueOnce({ data: makeApiResponse() });
+    renderComponent();
+    const table = await screen.findByTestId("prospect-table-task-1");
+    expect(table).toHaveAttribute("data-this-encounter-id", "enc-query");
   });
 
   test("renders bottom bar when results are available", async () => {

--- a/frontend/src/__tests__/pages/MatchResults/matchResultsStore.test.js
+++ b/frontend/src/__tests__/pages/MatchResults/matchResultsStore.test.js
@@ -260,6 +260,36 @@ describe("MatchResultsStore — loadData", () => {
     );
   });
 
+  test("sets queryEncounterId in metadata for both view modes", () => {
+    store.loadData(makeApiResponse());
+    expect(store.processedIndivs[0].metadata.queryEncounterId).toBe(
+      "enc-query",
+    );
+    expect(store.processedAnnots[0].metadata.queryEncounterId).toBe(
+      "enc-query",
+    );
+  });
+
+  test("a two-child task tree yields per-section queryEncounterIds", () => {
+    const childA = makeProspect({ id: "task-a" });
+    childA.matchResults.queryAnnotation.encounter = { id: "enc-a" };
+    const childB = makeProspect({ id: "task-b" });
+    childB.matchResults.queryAnnotation.encounter = { id: "enc-b" };
+    const root = makeProspect({
+      id: "task-root",
+      matchResults: null,
+      children: [childA, childB],
+    });
+    store.loadData({ matchResultsRoot: root });
+
+    for (const sections of [store.processedIndivs, store.processedAnnots]) {
+      const a = sections.find((s) => s.taskId === "task-a");
+      const b = sections.find((s) => s.taskId === "task-b");
+      expect(a.metadata.queryEncounterId).toBe("enc-a");
+      expect(b.metadata.queryEncounterId).toBe("enc-b");
+    }
+  });
+
   test("clears selectedMatch after loading (resetSelectionToQuery called)", () => {
     store._selectedMatch = [{ key: "k1", encounterId: "e1" }];
     store.loadData(makeApiResponse());
@@ -390,6 +420,7 @@ describe("MatchResultsStore — _processData", () => {
         date: "2024-07-04",
         methodName: "mymeth",
         methodDescription: "desc",
+        queryEncounterId: "enc-t1-query",
         queryEncounterImageAsset: { url: "http://asset.test/img.jpg" },
         queryEncounterImageUrl: "http://asset.test/img.jpg",
         queryEncounterAnnotation: { x: 1 },
@@ -405,6 +436,73 @@ describe("MatchResultsStore — _processData", () => {
     expect(meta.methodName).toBe("mymeth");
     expect(meta.algorithm).toBe("mymeth");
     expect(meta.queryImageUrl).toBe("http://asset.test/img.jpg");
+    expect(meta.queryEncounterId).toBe("enc-t1-query");
+  });
+
+  test("each task section carries its own queryEncounterId", () => {
+    const base = {
+      numberCandidates: 1,
+      date: "d",
+      methodName: "m",
+      methodDescription: "d",
+      queryEncounterImageAsset: null,
+      queryEncounterImageUrl: null,
+      queryEncounterAnnotation: {},
+      taskStatus: "done",
+      taskStatusOverall: "done",
+      algorithm: "m",
+    };
+    const items = [
+      { ...base, taskId: "t1", score: 0.9, queryEncounterId: "enc-t1" },
+      { ...base, taskId: "t2", score: 0.8, queryEncounterId: "enc-t2" },
+    ];
+    const sections = store._processData(items);
+    const t1 = sections.find((s) => s.taskId === "t1");
+    const t2 = sections.find((s) => s.taskId === "t2");
+    expect(t1.metadata.queryEncounterId).toBe("enc-t1");
+    expect(t2.metadata.queryEncounterId).toBe("enc-t2");
+  });
+
+  test("placeholder section for a running task keeps its queryEncounterId", () => {
+    const items = [
+      {
+        taskId: "t-running",
+        numberCandidates: 3,
+        date: "d",
+        methodName: "m",
+        methodDescription: "d",
+        queryEncounterId: "enc-running",
+        queryEncounterImageAsset: null,
+        queryEncounterImageUrl: null,
+        queryEncounterAnnotation: {},
+        taskStatus: "running",
+        taskStatusOverall: "running",
+        algorithm: "m",
+        hasResults: false,
+      },
+    ];
+    const sections = store._processData(items);
+    expect(sections[0].metadata.queryEncounterId).toBe("enc-running");
+  });
+
+  test("section metadata queryEncounterId is null when items lack it", () => {
+    const items = [
+      {
+        taskId: "t1",
+        numberCandidates: 0,
+        date: "d",
+        methodName: "m",
+        methodDescription: "d",
+        queryEncounterImageAsset: null,
+        queryEncounterImageUrl: null,
+        queryEncounterAnnotation: {},
+        taskStatus: null,
+        taskStatusOverall: null,
+        algorithm: "m",
+      },
+    ];
+    const sections = store._processData(items);
+    expect(sections[0].metadata.queryEncounterId).toBeNull();
   });
 
   test("items without taskId are grouped under 'unknown-task'", () => {

--- a/frontend/src/pages/MatchResultsPage/MatchResults.jsx
+++ b/frontend/src/pages/MatchResultsPage/MatchResults.jsx
@@ -394,6 +394,7 @@ const MatchResults = observer(() => {
                     algorithm={metadata?.algorithm}
                     numCandidates={metadata?.numCandidates}
                     date={metadata?.date}
+                    thisEncounterId={metadata?.queryEncounterId}
                     thisEncounterImageUrl={metadata?.queryImageUrl}
                     thisEncounterAnnotations={[
                       metadata?.queryEncounterAnnotation,

--- a/frontend/src/pages/MatchResultsPage/components/MatchProspectTable.jsx
+++ b/frontend/src/pages/MatchResultsPage/components/MatchProspectTable.jsx
@@ -178,6 +178,7 @@ const MatchProspectTable = ({
   date,
   selectedMatch,
   onToggleSelected,
+  thisEncounterId,
   thisEncounterImageUrl,
   thisEncounterAnnotations,
   thisEncounterImageAsset,
@@ -377,6 +378,25 @@ const MatchProspectTable = ({
     taskStatusOverall !== "error";
 
   const isError = taskStatusOverall === "error";
+
+  // Label linking back to the query annotation's encounter; falls back to
+  // plain text when the match result carried no encounter id.
+  const renderThisEncounterLabel = (labelLinkId) =>
+    thisEncounterId ? (
+      <a
+        href={`/react/encounter?number=${encodeURIComponent(thisEncounterId)}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-decoration-underline"
+        style={{ color: "inherit" }}
+        id={labelLinkId}
+        data-testid={labelLinkId}
+      >
+        <FormattedMessage id="THIS_ENCOUNTER" />
+      </a>
+    ) : (
+      <FormattedMessage id="THIS_ENCOUNTER" />
+    );
 
   return (
     <div
@@ -677,7 +697,9 @@ const MatchProspectTable = ({
               style={styles.cornerLabel(themeColor)}
               data-testid={`match-prospect-left-label-${sectionId}`}
             >
-              <FormattedMessage id="THIS_ENCOUNTER" />
+              {renderThisEncounterLabel(
+                `match-prospect-left-label-link-${sectionId}`,
+              )}
             </div>
             <div
               style={styles.imageContainer}
@@ -945,7 +967,9 @@ const MatchProspectTable = ({
                     style={styles.fullscreenLabel}
                     data-testid={`match-prospect-fullscreen-left-label-${sectionId}`}
                   >
-                    <FormattedMessage id="THIS_ENCOUNTER" />
+                    {renderThisEncounterLabel(
+                      `match-prospect-fullscreen-left-label-link-${sectionId}`,
+                    )}
                   </div>
 
                   <div

--- a/frontend/src/pages/MatchResultsPage/stores/matchResultsStore.js
+++ b/frontend/src/pages/MatchResultsPage/stores/matchResultsStore.js
@@ -225,6 +225,7 @@ export default class MatchResultsStore {
         metadata: {
           numCandidates: first.numberCandidates ?? "-",
           date: first.date,
+          queryEncounterId: first.queryEncounterId ?? null,
           queryImageUrl:
             first.queryEncounterImageAsset?.url || first.queryEncounterImageUrl,
           queryEncounterImageAsset: first.queryEncounterImageAsset,


### PR DESCRIPTION
## What this does

On `/react/match-results`, the **"This Encounter"** label overlaying the query image (and its counterpart in the fullscreen compare modal) is now a link to the encounter the query annotation belongs to (`/react/encounter?number=<id>`, opens in a new tab). When the match result carries no encounter id, the label stays plain text.

## How

- `matchResultsStore._processData()` now includes `queryEncounterId` in each task section's metadata (sourced from `matchResults.queryAnnotation.encounter.id`, which `helperFunctions.collectProspects()` already put on every row). Per-section rather than the page-global `_encounterId`, so in multi-algorithm result pages each section links to its own query encounter — always consistent with the query image displayed in that section, since both come from the same representative row.
- `MatchResults.jsx` passes it to `MatchProspectTable` as `thisEncounterId`.
- `MatchProspectTable` renders both label spots via a shared helper: an `<a target="_blank" rel="noopener noreferrer">` when the id is present, plain `<FormattedMessage>` otherwise. Underline + inherited pill color for link affordance on the teal corner pill (deliberate exception to the `text-decoration-none` style used for links on plain backgrounds).

No new user-visible strings — `THIS_ENCOUNTER` is already localized in all five languages.

## Tests

- New `MatchProspectTable.test.jsx`: link href/target/rel, URL-encoding of the id, plain-text fallback without id, link while a task is still running, and the fullscreen-modal label link.
- `matchResultsStore.test.js`: `queryEncounterId` in section metadata (single task, per-section values in a two-child task tree, both view modes, running-placeholder rows, null fallback).
- `MatchResults.test.jsx`: asserts the page passes the per-section id into `MatchProspectTable`.

All 10 suites in `src/__tests__/pages/MatchResults` pass except `CreateNewIndividualModal.test.jsx`, which fails identically on `main` (pre-existing missing-`fetch` jest environment issue, unrelated to this change).

Plan and implementation were both reviewed by Codex (2 rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
