### PR TITLE
fix(ia): honor empty _id_conf so part classes are not force-matched

### DIFF
--- a/src/main/java/org/ecocean/ia/IA.java
+++ b/src/main/java/org/ecocean/ia/IA.java
@@ -416,6 +416,19 @@ public class IA {
         List<List<Annotation> > annotsByIaClass = binAnnotsByIaClass(anns);
         for (List<Annotation> annsOneIAClass : annotsByIaClass) {
             List<JSONObject> opts = iaConfig.identOpts(myShepherd, annsOneIAClass.get(0));
+            // No identification options means this iaClass cannot be identified. Empty is an
+            // explicit opt-out: IA.json declares the class with `"_id_conf": []`, which
+            // getIdentConfig returns as-is rather than falling back to `_default`. Null means
+            // neither the class nor the taxonomy's `_default` yielded any config at all.
+            //
+            // Bail here, BEFORE the matchingAlgorithms swap below. That swap replaces the opts
+            // list wholesale without consulting this iaClass, so it would otherwise manufacture
+            // an option for a class that declined one. Part classes are the common case: a
+            // `wild_dog+tail_*` annotation rides along with the body annotation detected beside
+            // it on the same image, and would get its own doomed identification task whenever
+            // the user picked an algorithm. A class that legitimately inherits a populated
+            // `_default._id_conf` has non-empty opts here and is unaffected.
+            if ((opts == null) || (opts.size() < 1)) continue; // no ID for this iaClass.
             // now we remove ones with default=false (they may get added in below via matchingAlgorithms param (via newOpts)
             if (opts != null) {
                 Iterator<JSONObject> itr = opts.iterator();

--- a/src/test/java/org/ecocean/ia/IdentificationTest.java
+++ b/src/test/java/org/ecocean/ia/IdentificationTest.java
@@ -15,6 +15,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import static org.junit.Assert.*;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -67,6 +69,117 @@ class IdentificationTest {
                 }
             }
         }
+    }
+
+    // An iaClass configured with `"_id_conf": []` has opted out of identification.
+    // A user-selected algorithm (taskParameters.matchingAlgorithms) must not
+    // manufacture an option for it -- otherwise part classes like
+    // `wild_dog+tail_*` get a doomed identification task whenever someone picks
+    // an algorithm on a sibling annotation of the same image.
+    private static Shepherd runIntakeWithOpts(List<JSONObject> identOpts,
+        JSONArray matchingAlgorithms) {
+        Annotation ann = new Annotation();
+
+        ann.setIAClass("wild_dog+tail_general");
+        ann.setId("tail-ann-1");
+        List<Annotation> anns = new ArrayList<Annotation>();
+        anns.add(ann);
+
+        PersistenceManager mockPM = mock(PersistenceManager.class);
+        when(mockPM.makePersistent(any(Object.class))).thenReturn(null);
+        Shepherd myShepherd = mock(Shepherd.class);
+        when(myShepherd.getPM()).thenReturn(mockPM);
+
+        Encounter enc = new Encounter();
+        enc.setTaxonomyFromString("Lycaon pictus");
+
+        IAJsonProperties mockIAConfig = mock(IAJsonProperties.class);
+        when(mockIAConfig.identOpts(any(Shepherd.class),
+            any(Annotation.class))).thenReturn(identOpts);
+
+        Task parentTask = new Task();
+        if (matchingAlgorithms != null) {
+            JSONObject params = new JSONObject();
+            params.put("matchingAlgorithms", matchingAlgorithms);
+            parentTask.setParameters(params);
+        }
+        try (MockedStatic<CommonConfiguration> mockConfig = mockStatic(CommonConfiguration.class)) {
+            mockConfig.when(() -> CommonConfiguration.getServerURL(any(String.class))).thenReturn(
+                "/fake/url");
+            try (MockedStatic<IAJsonProperties> mockJP = mockStatic(IAJsonProperties.class)) {
+                mockJP.when(() -> IAJsonProperties.iaConfig()).thenReturn(mockIAConfig);
+                try (MockedStatic<Encounter> mockEnc = mockStatic(Encounter.class,
+                        org.mockito.Answers.CALLS_REAL_METHODS)) {
+                    mockEnc.when(() -> Encounter.findByAnnotation(any(Annotation.class),
+                        any(Shepherd.class))).thenReturn(enc);
+                    IA.intakeAnnotations(myShepherd, anns, parentTask, false);
+                }
+            }
+        }
+        return myShepherd;
+    }
+
+    private static JSONArray hotspotterAlgorithmChoice() {
+        JSONArray algos = new JSONArray();
+
+        algos.put(new JSONObject(
+            "{\"query_config_dict\": {\"sv_on\": false}, \"description\": \"HotSpotter pattern-matcher\", \"default\": false}"));
+        return algos;
+    }
+
+    @Test void emptyIdentConfigIsNotOverriddenByMatchingAlgorithms() {
+        Shepherd myShepherd = runIntakeWithOpts(new ArrayList<JSONObject>(),
+            hotspotterAlgorithmChoice());
+
+        verify(myShepherd, never()).storeNewTask(any(Task.class));
+    }
+
+    @Test void nullIdentConfigIsNotOverriddenByMatchingAlgorithms() {
+        Shepherd myShepherd = runIntakeWithOpts(null, hotspotterAlgorithmChoice());
+
+        verify(myShepherd, never()).storeNewTask(any(Task.class));
+    }
+
+    @Test void configuredIaClassStillHonorsMatchingAlgorithms() {
+        List<JSONObject> configured = new ArrayList<JSONObject>();
+
+        // deliberately has no "description", so the assertion below can only pass if the
+        // user-selected option really did replace it
+        configured.add(new JSONObject(
+            "{\"pipeline_root\": \"vector\", \"method\": \"miewid\", \"default\": true}"));
+        Shepherd myShepherd = runIntakeWithOpts(configured, hotspotterAlgorithmChoice());
+
+        ArgumentCaptor<Task> stored = ArgumentCaptor.forClass(Task.class);
+        verify(myShepherd).storeNewTask(stored.capture());
+        JSONObject chosen = stored.getValue().getParameters().optJSONObject(
+            "ibeis.identification");
+        assertNotNull("the stored task must record the option it will run", chosen);
+        assertEquals("the user-selected option must override the configured default",
+            "HotSpotter pattern-matcher", chosen.optString("description", null));
+    }
+
+    // Characterization test for the IA.json contract the guard above relies on. This locks in
+    // existing IAJsonProperties behavior (it passes without the guard change): an explicit
+    // `"_id_conf": []` is an opt-out and must NOT inherit `_default`, while a class that is not
+    // declared at all must inherit it. If that ever flipped, the guard would start skipping
+    // classes that should be matched.
+    @Test void emptyIdentConfigOptsOutWhileUndeclaredClassInheritsDefault()
+    throws Exception {
+        IAJsonProperties conf = new IAJsonProperties();
+
+        conf.setJson(new JSONObject("{\"Lycaon\": {\"pictus\": {"
+            + "\"_default\": {\"_id_conf\": [{\"description\": \"MiewID\", \"default\": true}]},"
+            + "\"wild_dog\": {\"_id_conf\": [{\"description\": \"MiewID\", \"default\": true}]},"
+            + "\"wild_dog+tail_general\": {\"_id_conf\": [], \"_save_keyword\": \"TailGeneral\"}"
+            + "}}}"));
+        Taxonomy taxy = new Taxonomy("Lycaon pictus");
+
+        assertEquals("explicit [] must stay empty, not fall back to _default",
+            0, conf.identOpts(taxy, "wild_dog+tail_general").size());
+        assertEquals("a declared class keeps its own options",
+            1, conf.identOpts(taxy, "wild_dog").size());
+        assertEquals("an undeclared class must inherit _default and stay matchable",
+            1, conf.identOpts(taxy, "wild_dog+scar").size());
     }
 
     @Test void miscMethodTest() {


### PR DESCRIPTION
## Problem

An iaClass configured with `"_id_conf": []` in IA.json has opted out of identification. On the African Carnivore Wildbook that covers all nine `wild_dog+tail_*` part classes — tails feed the `wd_v0` assigner and the tail-pattern keywords, they are not something we match on.

They were being matched anyway. Reported symptom: starting a HotSpotter match from a wild dog **body** annotation produced a second, permanently-failing panel on the match results page attributed to the **tail** — a tail the user never selected — reading `Match results processing failed.` followed by a long run of `Unknown error`.

## Root cause

`IA.intakeAnnotations` bins annotations by iaClass and has a guard that skips a bin with no identification options. That guard ran *after* `taskParameters.matchingAlgorithms` replaced the options list:

```java
List<JSONObject> opts = iaConfig.identOpts(myShepherd, annsOneIAClass.get(0));  // [] for a tail
...
if (newOpts.size() > 0) { opts = newOpts; }        // <-- replaces the empty list
...
if ((opts == null) || (opts.size() < 1)) continue; // <-- too late to help
```

`matchingAlgorithms` is chosen once per request from the encounter's **taxonomy** and then substituted into **every** bin without consulting that bin's own config. So picking any algorithm in the New Match dialog manufactured an option for a class that had explicitly declined one, and `"_id_conf": []` — the only way IA.json can say "never identify this class" — was silently discarded.

Two things compound it. The React dialog submits every annotation on the selected image rather than the one you clicked, so a part annotation always rides along with its body. And the resulting task can never succeed: the class has no configured algorithm and no trained model, so no `MatchResult` is ever built, `Task.matchResultsJson` re-runs `generateMatchResults` on every poll, and each attempt appends another entry to `statusDetails.errors` — which has no de-duplication and no cap. That is why the error list grows.

## Fix

Move the existing guard ahead of the swap, so an empty options list is honored before anything can overwrite it. Purely additive — no deletions.

The later guard stays: it still catches a list emptied by the `default=false` strip (an iaClass whose every option is non-default, with no `matchingAlgorithms` supplied).

Classes that inherit a populated `_default._id_conf` are unaffected. `getIdentConfig` falls back to `_default` only when the class-specific key is **absent**, never when it is an explicit `[]`, so an inheriting class arrives here with non-empty options and flows through the normal override path.

This is not ACW-specific — giraffe and lion have the same part-class structure (`lion+head`, `lion_general+head`).

## Tests

Four new cases in `IdentificationTest`, three of them driving the real `IA.intakeAnnotations`:

- empty `identOpts` + `matchingAlgorithms` supplied → no task created
- null `identOpts` + `matchingAlgorithms` supplied → no task created
- **configured** iaClass + `matchingAlgorithms` supplied → task created *and* its `ibeis.identification` is the user-selected option (guards the feature)
- a characterization test driving real `IAJsonProperties`, pinning the contract the guard depends on: explicit `[]` does not inherit `_default`, an undeclared class does

Both negative tests fail on `main` for the right reason — `storeNewTask` is invoked with `ibeis.identification` set to the HotSpotter option on an annotation whose class has no ident config. The positive-control assertion was verified to discriminate by temporarily disabling the swap and confirming it fails.

The characterization test passes without the production change; it is a regression guard on existing `IAJsonProperties` behavior, not a proof of the fix.

## Verification

`mvn -o test -Dtest=IdentificationTest` → 6 tests, 0 failures, 0 errors.

## Deliberately not addressed

Three adjacent problems found while diagnosing this, each worth its own issue:

1. **Error reporting is unreadable.** The UI renders only `err.code` and drops `err.message`, and only 4 of ~18 backend error codes have locale keys, so most failures display as "Unknown error". `MATCH_RESULTS_ERROR_UNKNOWN` is itself the string "Unknown error", making a real code indistinguishable from an untranslated one. Errors also accumulate without de-duplication, and `statusDetails` is serialized only for leaf tasks, so anything stamped on a parent never reaches the client.
2. **`NewMatchStore.annotationIds` submits every annotation on the selected image**, not the one the user clicked. Filtering it client-side was attempted here and reverted: site settings only tags *declared* iaClasses in `_iaClasses`, so a positive allow-list would wrongly drop annotations whose class legitimately inherits `_default`. Doing this safely needs an explicit opt-out contract from the backend rather than an inferred one. The backend guard is authoritative in the meantime.
3. **`isHotspotterQueryConfig` is `optBoolean("sv_on", false)`**, so a config written as `{"sv_on": false}` is not recognized as HotSpotter. ACW's IA.json uses exactly that form for all 29 of its HotSpotter entries, which makes `IA.annotationHasHotspotterOpt()` false across that install.

Reviewed by Codex over two rounds; the frontend filter above was removed in response to a Major finding, and the positive-control assertion strengthened in response to a Minor one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
