### PR TITLE
Scope manual-annotation trivial cleanup to the target encounter

### DIFF
--- a/src/main/java/org/ecocean/Annotation.java
+++ b/src/main/java/org/ecocean/Annotation.java
@@ -1575,6 +1575,26 @@ public class Annotation extends Base implements java.io.Serializable {
         return ann;
     }
 
+    // Find the trivial placeholder annotation that manual-annotation creation
+    // should consume. A MediaAsset shared by multiple encounters (e.g. one
+    // image imported on several bulk-import rows) carries one trivial
+    // placeholder per encounter, so the search must be scoped to the target
+    // encounter's annotations on this asset: detaching another encounter's
+    // placeholder deletes its feature while enc.removeAnnotation() silently
+    // no-ops, stranding a featureless annotation on that encounter and
+    // dropping the image from it. With no encounter given, falls back to the
+    // historical asset-wide search. Package-visible for testing.
+    static Annotation findTrivialPlaceholder(Encounter enc, MediaAsset ma) {
+        if (ma == null) return null;
+        List<Annotation> candidates = (enc == null) ? ma.getAnnotations() : enc.getAnnotations(ma);
+        if (candidates == null) return null;
+        Annotation foundTrivial = null;
+        for (Annotation a : candidates) {
+            if (a.isTrivial()) foundTrivial = a;
+        }
+        return foundTrivial;
+    }
+
     public static Base createFromApi(JSONObject payload, List<File> files, Shepherd myShepherd)
     throws ApiException {
         if (payload == null) throw new ApiException("empty payload");
@@ -1772,10 +1792,7 @@ public class Annotation extends Base implements java.io.Serializable {
             }
         }
         // NOTE: manualAnnotation.jsp allowed 'removeTrivial' (boolean) to be set via url, but was default true
-        Annotation foundTrivial = null; // note this will only remove (at most) ONE (but "should never" have > 1 anyway)
-        for (Annotation a : ma.getAnnotations()) {
-            if (a.isTrivial()) foundTrivial = a;
-        }
+        Annotation foundTrivial = findTrivialPlaceholder(enc, ma); // note this will only remove (at most) ONE (but "should never" have > 1 anyway)
         if (foundTrivial == null) {
             System.out.println(
                 "Annotation.createFromApi(): no trivial annotation found to remove from " + ma);

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -2911,6 +2911,7 @@ public class Encounter extends Base implements java.io.Serializable {
     public List<Annotation> getAnnotations(MediaAsset ma) {
         List<Annotation> anns = new ArrayList<Annotation>();
 
+        if (getAnnotations() == null) return anns;
         for (Annotation ann : getAnnotations()) {
             if (ann.getMediaAsset() == ma) anns.add(ann);
         }

--- a/src/test/java/org/ecocean/AnnotationTest.java
+++ b/src/test/java/org/ecocean/AnnotationTest.java
@@ -107,4 +107,56 @@ class AnnotationTest {
         long v2 = ann.getVersion();
         assertTrue("incrementWbiaRegisterAttempts should bump version", v2 > v1);
     }
+
+    // A MediaAsset shared by multiple encounters (e.g. one image imported on
+    // several bulk-import rows) carries one trivial placeholder per encounter.
+    // The manual-annotation cleanup must only ever consume the placeholder
+    // belonging to the encounter being annotated -- picking another
+    // encounter's placeholder deletes its feature while leaving it attached,
+    // stranding a featureless annotation there and dropping the image from
+    // that encounter.
+    @Test void findTrivialPlaceholderScopedToEncounter() {
+        AssetStore store = null;
+        MediaAsset ma = new MediaAsset(store, null);
+        Annotation trivialA = new Annotation("species", ma);
+        Annotation trivialB = new Annotation("species", ma);
+        // in-memory only: set the feature->annotation back-references that JDO
+        // maintains for persistent objects, so an (incorrect) asset-wide
+        // search would see both trivials and this test can catch it
+        trivialA.getFeatures().get(0).setAnnotation(trivialA);
+        trivialB.getFeatures().get(0).setAnnotation(trivialB);
+        Encounter encA = new Encounter();
+        encA.addAnnotation(trivialA);
+        Encounter encB = new Encounter();
+        encB.addAnnotation(trivialB);
+
+        assertEquals(trivialA, Annotation.findTrivialPlaceholder(encA, ma));
+        assertEquals(trivialB, Annotation.findTrivialPlaceholder(encB, ma));
+    }
+
+    @Test void findTrivialPlaceholderNoneOnEncounter() {
+        AssetStore store = null;
+        MediaAsset ma = new MediaAsset(store, null);
+        Annotation otherEncsTrivial = new Annotation("species", ma);
+        otherEncsTrivial.getFeatures().get(0).setAnnotation(otherEncsTrivial);
+        Encounter owner = new Encounter();
+        owner.addAnnotation(otherEncsTrivial);
+        Encounter encWithoutTrivial = new Encounter();
+
+        // must NOT fall back to another encounter's placeholder
+        assertNull(Annotation.findTrivialPlaceholder(encWithoutTrivial, ma));
+    }
+
+    @Test void findTrivialPlaceholderNullEncounterSearchesAsset() {
+        AssetStore store = null;
+        MediaAsset ma = new MediaAsset(store, null);
+        Annotation trivial = new Annotation("species", ma);
+
+        // in-memory only: set the feature->annotation back-reference that JDO
+        // maintains for persistent objects (MediaAsset.getAnnotations() walks it)
+        trivial.getFeatures().get(0).setAnnotation(trivial);
+
+        assertEquals(trivial, Annotation.findTrivialPlaceholder(null, ma));
+        assertNull(Annotation.findTrivialPlaceholder(null, new MediaAsset(store, null)));
+    }
 }

--- a/src/test/java/org/ecocean/AnnotationTest.java
+++ b/src/test/java/org/ecocean/AnnotationTest.java
@@ -147,6 +147,23 @@ class AnnotationTest {
         assertNull(Annotation.findTrivialPlaceholder(encWithoutTrivial, ma));
     }
 
+    // multiple placeholders on one encounter is malformed data, but lock in
+    // the intentional selection rule (last one wins, matching the historical
+    // asset-wide scan)
+    @Test void findTrivialPlaceholderKeepsLastOfMultiple() {
+        AssetStore store = null;
+        MediaAsset ma = new MediaAsset(store, null);
+        Annotation first = new Annotation("species", ma);
+        Annotation second = new Annotation("species", ma);
+        first.getFeatures().get(0).setAnnotation(first);
+        second.getFeatures().get(0).setAnnotation(second);
+        Encounter enc = new Encounter();
+        enc.addAnnotation(first);
+        enc.addAnnotation(second);
+
+        assertEquals(second, Annotation.findTrivialPlaceholder(enc, ma));
+    }
+
     @Test void findTrivialPlaceholderNullEncounterSearchesAsset() {
         AssetStore store = null;
         MediaAsset ma = new MediaAsset(store, null);


### PR DESCRIPTION
## What this fixes

`Annotation.createFromApi()` (manual annotation via API v3) removes the trivial placeholder annotation by scanning **every annotation on the MediaAsset** and taking the last trivial one. A MediaAsset shared by multiple encounters — e.g. one image imported on several bulk-import rows — carries one trivial placeholder **per encounter**, so the scan can select a *different encounter's* placeholder. When that happens:

- `detachFromMediaAsset()` deletes the placeholder's unity feature (forever), but
- `enc.removeAnnotation(foundTrivial)` silently no-ops because the placeholder belongs to another encounter.

The result is a stranded, featureless, `matchAgainst=false` annotation on the other encounter. Consequences:

1. **Bulk imports never reach 100%.** `ImportTask.iaSummaryJson()` counts every non-trivial annotation in the identification denominator; a stranded placeholder (no features → not trivial by `isTrivial()`, and never eligible for an identification task) is counted as "pending" forever.
2. **The affected encounter silently loses the shared image** (encounter media is reachable only via annotation → feature → asset).

Observed in production on GiraffeSpotter: bulk import `fdc7908f-bc4c-437e-970a-abab047c2eeb` stuck at 98% (253/258), with 5 stranded placeholders on encounters whose shared images had been manually annotated from a sibling encounter. (Production data has been repaired directly; this PR prevents recurrence.)

## The fix

- Extract the placeholder selection into `Annotation.findTrivialPlaceholder(Encounter, MediaAsset)`, scoped to the **target encounter's** annotations on the asset (`enc.getAnnotations(ma)`); the legacy `enc == null` case keeps the historical asset-wide search.
- Make `Encounter.getAnnotations(MediaAsset)` null-safe for encounters with no annotation list.

## Tests

Three new unit tests in `AnnotationTest`:
- two encounters sharing one asset each get their own placeholder back;
- an encounter with no placeholder on the asset must NOT consume another encounter's;
- `enc == null` fallback still searches the asset.

The first two were verified to **fail** against the previous asset-wide scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Adversarially reviewed with [Codex](https://developers.openai.com/codex/cli) to convergence; see the review-provenance comment for the adjacent defects it surfaced that are deliberately out of scope here.
