### PR TITLE
fix(queue): consumer loop survives transient failures; only STOP/SHUTDOWN halts it

### DIFF
--- a/src/main/java/org/ecocean/queue/FileQueue.java
+++ b/src/main/java/org/ecocean/queue/FileQueue.java
@@ -2,7 +2,6 @@ package org.ecocean.queue;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
 import org.ecocean.CommonConfiguration;
 import org.ecocean.Util;
 
@@ -82,6 +81,14 @@ public class FileQueue extends Queue {
         System.out.println("[INFO] FileQueue.init(" + context + ") complete");
     }
 
+    // TEST-ONLY seam: point the static base dir at an isolated temp dir so tests do not
+    // permanently claim the production spool location for the whole JVM (pass null to restore
+    // the lazy property-based init). Package-private on purpose; production code must go
+    // through init()/setQueueDir().
+    static synchronized void overrideQueueBaseDirForTesting(File dir) {
+        queueBaseDir = dir;
+    }
+
     public static synchronized File setQueueDir(String context)
     throws IOException {
         if (queueBaseDir != null) return queueBaseDir; // hey we have one already!
@@ -103,10 +110,17 @@ public class FileQueue extends Queue {
             throw new IOException("FileQueue.publish() failed, queueDir is not set");
         String qid = Util.generateUUID();
         File tmpFile = new File(queueDir, "addToQueue-" + qid + ".tmp"); // write to tmp file first so it doesnt (yet) get picked up by queue til done
-        PrintWriter qout = new PrintWriter(tmpFile);
-        qout.print(msg);
-        qout.close();
-        tmpFile.renameTo(new File(queueDir, qid));
+        // Files.write/Files.move throw on failure. The previous PrintWriter+renameTo version
+        // swallowed write errors and ignored the rename result, so a failed publish logged
+        // success while the job silently never entered the queue.
+        Files.write(tmpFile.toPath(),
+            msg.getBytes(java.nio.charset.Charset.defaultCharset()));
+        try {
+            Files.move(tmpFile.toPath(), new File(queueDir, qid).toPath());
+        } catch (IOException ex) {
+            tmpFile.delete(); // best-effort: don't leave orphaned .tmp litter
+            throw ex;
+        }
         System.out.println("INFO: FileQueue.publish() added " + queueDir + " -> " + qid);
     }
 
@@ -229,7 +243,7 @@ public class FileQueue extends Queue {
             return null;
         }
         if (this.isConsumerShutdownMessage(fcontents))
-            throw new IOException("SHUTDOWN message received");
+            throw new QueueStopException(this.toString() + " SHUTDOWN message received");
         return fcontents;
     }
 
@@ -261,7 +275,7 @@ public class FileQueue extends Queue {
 // System.out.println("queueDir file=" + f);
             // this always wins... so we can just grind everything to a halt
             if (isStopFile(f))
-                throw new IOException(this.toString() + " FileQueue STOP FILE found");
+                throw new QueueStopException(this.toString() + " FileQueue STOP FILE found");
             if (f.isDirectory() || !Util.isUUID(f.getName())) continue; // ignore!
             BasicFileAttributes attr = null;
             try {

--- a/src/main/java/org/ecocean/queue/QueueStopException.java
+++ b/src/main/java/org/ecocean/queue/QueueStopException.java
@@ -1,0 +1,19 @@
+package org.ecocean.queue;
+
+import java.io.IOException;
+
+/**
+ * Signals an INTENTIONAL consumer stop from {@link Queue#getNext()} — the operator STOP file or a
+ * SHUTDOWN queue message. This is the ONLY condition that shuts a consumer executor down.
+ *
+ * <p>Transient failures (unreadable spool file, disk hiccup) must NOT use this type: the poll loop
+ * logs those and retries on the next tick. Before this distinction existed, ANY exception from
+ * getNext() permanently killed every consumer on the queue — a single transient I/O error silently
+ * stopped detection/IA processing until the next Tomcat restart (observed as a 2-day production
+ * outage on GiraffeSpotter, 2026-08).</p>
+ */
+public class QueueStopException extends IOException {
+    public QueueStopException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/ecocean/queue/QueueUtil.java
+++ b/src/main/java/org/ecocean/queue/QueueUtil.java
@@ -55,52 +55,66 @@ public class QueueUtil {
             runningSF.add(schedFuture);
         }
         runningSES.add(schedExec);
-
-        System.out.println("---- about to awaitTermination() (" + n + " worker(s)) ----");
-        try {
-            schedExec.awaitTermination(5000, TimeUnit.MILLISECONDS);
-        } catch (java.lang.InterruptedException ex) {
-            System.out.println("WARNING: queue interrupted! " + ex.toString());
-        }
-        System.out.println("==== schedExec.shutdown() called, apparently");
+        System.out.println("---- " + queue.toString() + " started " + n + " consumer worker(s) ----");
     }
 
     // One consumer poll loop. Each call returns a fresh Runnable with its own `count`, so multiple
-    // workers on the same queue do not share mutable state. Logic is unchanged from the original
-    // single-consumer implementation.
+    // workers on the same queue do not share mutable state.
+    //
+    // Resilience contract: this runs via scheduleWithFixedDelay, whose spec SILENTLY CANCELS the
+    // periodic task if any execution throws — so nothing may escape run() (short of a
+    // VirtualMachineError, where the JVM is unrecoverable and hiding it would be worse). Only an
+    // intentional stop (QueueStopException: operator STOP file, SHUTDOWN message) shuts the
+    // executor down; any other failure costs one tick or one message, never the consumer.
     private static Runnable newConsumerRunnable(final Queue queue,
         final ScheduledExecutorService schedExec) {
         return new Runnable() {
             int count = 0;
             public void run() {
-                ++count;
-                String message = null;
-                boolean cont = true;
                 try {
-                    message = queue.getNext();
-                } catch (Exception ex) {
-                    System.out.println(queue.toString() + " getNext() got an exception; halting: " +
-                    ex.toString());
-                    cont = false;
-                }
-                if (count % 100 == 1)
-                    System.out.println("==== " + queue.toString() + " run [count " + count +
-                    "]; queue=" + queue.toString() + "; continue = " + cont + " ====");
-                boolean ok = true;
-                // note message == null means it was read, but there is nothign to handle
-                if (cont && (message != null)) {
+                    ++count;
+                    if (count % 100 == 1)
+                        System.out.println("==== " + queue.toString() + " run [count " + count +
+                        "] ====");
+                    String message = null;
                     try {
-                        ok = queue.messageHandler.handler(message);
-                    } catch (IOException ioex) {
-                        System.out.println("WARNING: swallowed IOException from message handler: " +
-                        ioex.toString());
+                        message = queue.getNext();
+                    } catch (QueueStopException stop) {
+                        // the ONLY path that stops the consumer; keep the legacy log line —
+                        // operators (and runbooks) grep for it
+                        System.out.println(":::: " + queue.toString() +
+                            " intentional stop: " + stop.getMessage() + " ::::");
+                        System.out.println(":::: " + queue.toString() +
+                            " shutdown via discontinue signal ::::");
+                        schedExec.shutdown();
+                        return;
+                    } catch (Exception ex) {
+                        // transient poll failure (disk hiccup, unreadable spool file): log and
+                        // retry next tick; the fixed delay is the backoff
+                        System.out.println("WARNING: " + queue.toString() +
+                            " getNext() failed (will retry next tick): " + ex.toString());
+                        ex.printStackTrace();
+                        return;
                     }
-                }
-// System.out.println("count=" + count + "; handled-ok=" + ok + "; cont=" + cont + "; msg=" + message);
-                if (!cont) {
-                    System.out.println(":::: " + queue.toString() +
-                    " shutdown via discontinue signal ::::");
-                    schedExec.shutdown();
+                    // note message == null means it was read, but there is nothing to handle
+                    if (message == null) return;
+                    try {
+                        queue.messageHandler.handler(message);
+                    } catch (Throwable t) {
+                        if (t instanceof VirtualMachineError) throw (VirtualMachineError)t;
+                        System.out.println("ERROR: " + queue.toString() +
+                            " message handler threw; message dropped: " + t.toString());
+                        t.printStackTrace();
+                    }
+                } catch (Throwable t) {
+                    if (t instanceof VirtualMachineError) throw (VirtualMachineError)t;
+                    // best-effort logging: toString()/printStackTrace() on arbitrary objects can
+                    // themselves throw, and a throw from HERE silently cancels the periodic task
+                    try {
+                        System.out.println("ERROR: " + queue.toString() +
+                            " consumer tick threw unexpectedly; continuing: " + t.toString());
+                        t.printStackTrace();
+                    } catch (Throwable ignored) {}
                 }
             }
         };

--- a/src/main/java/org/ecocean/servlet/IAGateway.java
+++ b/src/main/java/org/ecocean/servlet/IAGateway.java
@@ -863,9 +863,9 @@ public class IAGateway extends HttpServlet {
         // previous code's "logged before sleeping" timing for any
         // operators tailing for this string.
         System.out.println("requeueJob(): backgrounding taskId=" + taskId);
-        scheduleRequeuePublish(jobj, context, taskId, initialDelayMillis);
-
-        return true;
+        // false when the executor rejected the schedule (webapp undeploy): the retry is
+        // permanently lost and the caller must not believe it was requeued
+        return scheduleRequeuePublish(jobj, context, taskId, initialDelayMillis);
     }
 
     // Schedules a single attempt to publish jobj onto the appropriate
@@ -873,7 +873,22 @@ public class IAGateway extends HttpServlet {
     // with a 30s backoff — preserving the original code's "retry
     // forever on addToQueue/addToDetectionQueue failure" semantics
     // without an unbounded busy loop on a dedicated thread.
-    private static void scheduleRequeuePublish(final JSONObject jobj, final String context,
+    private static boolean scheduleRequeuePublish(final JSONObject jobj, final String context,
+        final String taskId, long delayMillis) {
+        try {
+            scheduleRequeuePublishUnguarded(jobj, context, taskId, delayMillis);
+            return true;
+        } catch (java.util.concurrent.RejectedExecutionException rex) {
+            // REQUEUE_EXEC was shut down (webapp undeploy/reload). The job was never written to
+            // the persistent spool, so this retry is genuinely lost — say so loudly rather than
+            // letting the exception propagate into whatever thread asked for the requeue.
+            System.out.println("ERROR: scheduleRequeuePublish() rejected (executor shut down?); " +
+                "requeue LOST for taskId=" + taskId + ": " + rex.toString());
+            return false;
+        }
+    }
+
+    private static void scheduleRequeuePublishUnguarded(final JSONObject jobj, final String context,
         final String taskId, long delayMillis) {
         REQUEUE_EXEC.schedule(new Runnable() {
             public void run() {

--- a/src/test/java/org/ecocean/queue/QueueConsumerResilienceTest.java
+++ b/src/test/java/org/ecocean/queue/QueueConsumerResilienceTest.java
@@ -1,0 +1,172 @@
+package org.ecocean.queue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for consumer-loop resilience. The poll loop runs via
+ * ScheduledExecutorService.scheduleWithFixedDelay, whose contract silently cancels the periodic
+ * task if any execution throws — so every failure mode here previously killed the consumer until
+ * the next Tomcat restart (2-day silent production outage, GiraffeSpotter 2026-08):
+ *
+ * - any Exception from getNext() halted the executor by design ("halting" + shutdown), so one
+ *   transient I/O error permanently stopped the queue;
+ * - a RuntimeException escaping the message handler wasn't caught at all and suppressed the
+ *   periodic task with ZERO log output.
+ *
+ * Only an intentional stop ({@link QueueStopException}: operator STOP file, SHUTDOWN message) may
+ * shut a consumer down. No containers required.
+ *
+ * State hygiene: FileQueue's base dir is a JVM-wide static; each test points it at an isolated
+ * {@code @TempDir} and restores the lazy init afterwards. QueueUtil.cleanup() is global (it stops
+ * ALL tracked consumer executors) — acceptable here because Surefire runs tests sequentially and
+ * no other live consumers exist during this class.
+ */
+public class QueueConsumerResilienceTest {
+    @TempDir Path tempDir;
+
+    @BeforeEach void isolateQueueBaseDir() {
+        FileQueue.overrideQueueBaseDirForTesting(tempDir.toFile());
+    }
+
+    @AfterEach void cleanupExecutorsAndState() {
+        QueueUtil.cleanup();
+        FileQueue.overrideQueueBaseDirForTesting(null);
+    }
+
+    /** Minimal in-memory Queue: getNext() behavior is driven by the test via call count. */
+    private abstract static class StubQueue extends Queue {
+        final AtomicInteger polls = new AtomicInteger(0);
+        StubQueue(String name, QueueMessageHandler handler) {
+            super(name);
+            this.type = "Stub";
+            this.messageHandler = handler;
+        }
+
+        @Override public void publish(String msg) {}
+
+        @Override public void consume(QueueMessageHandler msgHandler) {}
+
+        @Override public void shutdown() {}
+
+        @Override public long getQueueSize() {
+            return 0;
+        }
+    }
+
+    @Test void consumerSurvivesTransientGetNextFailure() throws Exception {
+        final CountDownLatch delivered = new CountDownLatch(1);
+        QueueMessageHandler handler = new QueueMessageHandler() {
+            @Override public boolean handler(String msg) {
+                delivered.countDown();
+                return true;
+            }
+        };
+        StubQueue q = new StubQueue("stub-transient-" + System.nanoTime(), handler) {
+            @Override public String getNext() throws IOException {
+                int n = polls.incrementAndGet();
+                if (n == 1) throw new IOException("transient disk hiccup");
+                if (n == 2) return "{\"m\":1}";
+                return null;
+            }
+        };
+
+        QueueUtil.backgroundWithWorkers(q, 1);
+        assertTrue(delivered.await(15, TimeUnit.SECONDS),
+            "a single transient getNext() failure must not kill the consumer; "
+            + "the next tick must still deliver the queued message");
+    }
+
+    @Test void consumerSurvivesHandlerRuntimeException() throws Exception {
+        final CountDownLatch delivered = new CountDownLatch(1);
+        QueueMessageHandler handler = new QueueMessageHandler() {
+            @Override public boolean handler(String msg) {
+                if (msg.contains("bad")) throw new RuntimeException("handler bug on this message");
+                delivered.countDown();
+                return true;
+            }
+        };
+        StubQueue q = new StubQueue("stub-handlerboom-" + System.nanoTime(), handler) {
+            @Override public String getNext() {
+                int n = polls.incrementAndGet();
+                if (n == 1) return "{\"m\":\"bad\"}";
+                if (n == 2) return "{\"m\":\"good\"}";
+                return null;
+            }
+        };
+
+        QueueUtil.backgroundWithWorkers(q, 1);
+        assertTrue(delivered.await(15, TimeUnit.SECONDS),
+            "a RuntimeException from the handler must cost that one message, not the consumer; "
+            + "the next message must still be delivered");
+    }
+
+    @Test void queueStopExceptionStopsAllWorkers() throws Exception {
+        final CountDownLatch stopSeen = new CountDownLatch(1);
+        QueueMessageHandler handler = new QueueMessageHandler() {
+            @Override public boolean handler(String msg) {
+                fail("handler must not run after an intentional stop");
+                return true;
+            }
+        };
+        StubQueue q = new StubQueue("stub-stop-" + System.nanoTime(), handler) {
+            @Override public String getNext() throws IOException {
+                polls.incrementAndGet();
+                stopSeen.countDown();
+                throw new QueueStopException("STOP requested by test");
+            }
+        };
+
+        // two workers share one executor: the intentional stop must halt BOTH
+        QueueUtil.backgroundWithWorkers(q, 2);
+        assertTrue(stopSeen.await(15, TimeUnit.SECONDS), "first poll should happen");
+        // shutdown() lets already-started invocations finish; wait for the count to stabilize,
+        // then require it to STAY stable — polls resuming means a worker survived the stop
+        Thread.sleep(2500);
+        int settled = q.polls.get();
+        Thread.sleep(2500);
+        assertEquals(settled, q.polls.get(),
+            "no worker may poll again after an intentional QueueStopException stop");
+    }
+
+    @Test void stopFileAndShutdownMessageSignalIntentionalStop() throws Exception {
+        FileQueue q = new FileQueue("test-stop-" + System.nanoTime());
+
+        // SHUTDOWN message -> QueueStopException (not a generic IOException)
+        q.publish("SHUTDOWN");
+        assertThrows(QueueStopException.class, () -> q.getNext(),
+            "a SHUTDOWN message must surface as the intentional-stop type");
+
+        // operator STOP file -> QueueStopException, and it wins over queued messages
+        q.publish("{\"m\":1}");
+        File stop = new File(q.getQueueDir(), "STOP");
+        Files.write(stop.toPath(), new byte[0]);
+        try {
+            assertThrows(QueueStopException.class, () -> q.getNext(),
+                "a STOP file must surface as the intentional-stop type");
+        } finally {
+            stop.delete();
+        }
+    }
+
+    @Test void publishFailureThrowsInsteadOfLoggingSuccess() throws Exception {
+        FileQueue q = new FileQueue("test-pubfail-" + System.nanoTime());
+
+        // deleting the spool dir makes the write fail; publish must THROW, not log success
+        assertTrue(q.getQueueDir().delete(), "empty spool dir should delete");
+        assertThrows(IOException.class, () -> q.publish("{\"m\":1}"),
+            "publish into a missing spool dir must throw");
+    }
+}


### PR DESCRIPTION
## What

Hardens the file-queue consumer loop so that a queue consumer can only be stopped **intentionally** (operator `STOP` file or `SHUTDOWN` message). Every other failure now costs one tick or one message — never the consumer.

## Why

The consumer poll loop runs via `scheduleWithFixedDelay`, whose contract **silently cancels the periodic task if any execution throws**. Two kill paths existed:

1. Any `Exception` from `getNext()` (a single transient disk hiccup) deliberately shut down the entire consumer executor ("halting" + "discontinue signal").
2. A `RuntimeException`/`Error` escaping the message handler wasn't caught at all — the periodic task was suppressed with **zero log output**.

Observed in production as a 2-day silent detection-queue outage on GiraffeSpotter (2026-08): jobs spooled to disk, nothing consumed, no log lines, until a container restart drained the backlog. All Wildbook installs share this code.

## Changes

- **New `QueueStopException`** marks the two intentional stops (STOP file, SHUTDOWN message) — now the only condition that shuts a consumer down. The legacy `shutdown via discontinue signal` log line is preserved for operators/runbooks that grep for it.
- **Throw-proof consumer tick**: transient `getNext()` failures log and retry next tick (the 1s fixed delay is the backoff); a handler `Throwable` drops that one message with a loud log; only `VirtualMachineError` propagates (rethrown *before* any logging, and the recovery logging itself is non-throwing).
- **`FileQueue.publish()` surfaces failures**: the old `PrintWriter` + ignored `renameTo()` could log success while the job silently never entered the queue. Now `Files.write` + `Files.move` throw on failure (tmp-then-move visibility semantics unchanged; no trailing newline added).
- **`IAGateway.scheduleRequeuePublish()`** catches `RejectedExecutionException` after executor shutdown (webapp undeploy) and logs the lost requeue; `requeueJob()` now returns `false` in that case instead of throwing into the caller's thread or falsely reporting success.
- **Removed the 5s `awaitTermination()` block at consumer startup** that delayed webapp init ~5s per queue while misleadingly logging that shutdown had been called.

## Tests

`QueueConsumerResilienceTest` (5 tests, no containers): consumer survives a transient `getNext()` failure; consumer survives a handler `RuntimeException`; `QueueStopException` stops **all** workers sharing the executor (2-worker stabilization test); STOP file and SHUTDOWN message surface as the intentional-stop type; `publish()` failure throws instead of logging success. The two resilience tests were verified to fail against the old implementation. Tests isolate the static `queueBaseDir` via a package-private test seam + `@TempDir`.

Codex adversarial review: 2 rounds, converged.

## Follow-ups (separate PRs)

- Terminal `error` status when detection/extraction retries are exhausted (currently strands assets in `processing-mlservice`).
- At-least-once delivery semantics (`.complete` is currently written *before* the handler runs, so a crash mid-handling loses the message).
- Queue depth/staleness metrics + alerting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)