### PR TITLE
fix(ia): terminal status on retry exhaustion; durable requeue handoff

### DIFF
--- a/src/main/java/org/ecocean/ia/DeferredMatchPublisher.java
+++ b/src/main/java/org/ecocean/ia/DeferredMatchPublisher.java
@@ -22,6 +22,11 @@ public interface DeferredMatchPublisher {
      * {@code deferredMatch: true}) and gate metadata (
      * {@code attempt}, {@code firstDeferredAt},
      * {@code lastGateReason}) into the payload before calling.
+     *
+     * @return true iff the payload was actually queued for re-fire;
+     *         false means the deferred match is LOST (e.g. the requeue
+     *         executor was shut down mid-undeploy) and the caller must
+     *         not report success for it.
      */
-    void publish(JSONObject payload);
+    boolean publish(JSONObject payload);
 }

--- a/src/main/java/org/ecocean/ia/IAGatewayDeferredMatchPublisher.java
+++ b/src/main/java/org/ecocean/ia/IAGatewayDeferredMatchPublisher.java
@@ -18,7 +18,7 @@ import org.json.JSONObject;
  */
 public final class IAGatewayDeferredMatchPublisher implements DeferredMatchPublisher {
     @Override
-    public void publish(JSONObject payload) {
-        IAGateway.requeueJob(payload, true);
+    public boolean publish(JSONObject payload) {
+        return IAGateway.requeueJob(payload, true);
     }
 }

--- a/src/main/java/org/ecocean/ia/MlServiceProcessor.java
+++ b/src/main/java/org/ecocean/ia/MlServiceProcessor.java
@@ -108,8 +108,7 @@ public class MlServiceProcessor {
             response = client.pipeline(det.apiEndpoint, det.imageUri, det.mlConfig);
         } catch (IAException ex) {
             if (ex.shouldRequeue()) {
-                IAGateway.requeueJob(jobData, ex.shouldIncrement());
-                return MlServiceJobOutcome.requeue();
+                return handleRetryableDetectionFailure(jobData, maId, taskId, ex);
             }
             markDetectionFailure(maId, taskId, ex.getCode(), ex.getMessage());
             return mapNonRetryableError(ex);
@@ -149,8 +148,7 @@ public class MlServiceProcessor {
                 ext.mlConfig);
         } catch (IAException ex) {
             if (ex.shouldRequeue()) {
-                IAGateway.requeueJob(jobData, ex.shouldIncrement());
-                return MlServiceJobOutcome.requeue();
+                return handleRetryableExtractionFailure(jobData, taskId, ex);
             }
             markTaskError(taskId, ex.getCode(), ex.getMessage());
             return mapNonRetryableError(ex);
@@ -662,8 +660,17 @@ public class MlServiceProcessor {
           case READY:
             return runMatchProspects(annotationIds, taskId, matchConfig);
           case DEFER:
-            enqueueDeferredMatch(annotationIds, taskId, matchConfig, gate);
-            return MlServiceJobOutcome.ok(annotationIds);
+            if (enqueueDeferredMatch(annotationIds, taskId, matchConfig, gate))
+                return MlServiceJobOutcome.ok(annotationIds);
+            // The deferred re-fire was NOT queued (requeue executor gone / publish failed).
+            // There is no passive backstop here: the parent task was already marked completed
+            // before the gate ran, so the inactivity watchdog ignores it, and a REQUEUE outcome
+            // is inert for deferred payloads. Run the match NOW against the currently visible
+            // corpus — same tradeoff as the gate's GIVE_UP arm (partial results are better than
+            // silently never creating a match task).
+            System.out.println("WARN: MlServiceProcessor deferred-match enqueue failed for task " +
+                taskId + "; running match against current visible corpus instead of dropping it");
+            return runMatchProspects(annotationIds, taskId, matchConfig);
           case GIVE_UP:
           default:
             System.out.println(
@@ -799,6 +806,58 @@ public class MlServiceProcessor {
         // when the inspector opens — see api/MatchInspection and the
         // lazy-fetch in MatchProspectTable.jsx.
         return MlServiceJobOutcome.ok(annotationIds);
+    }
+
+    // Package-private seam so tests can stub the requeue verdict without the static IAGateway
+    // machinery (mirrors the readSkipIdent test seam).
+    IAGateway.RequeueResult requeueJob(JSONObject jobData, boolean increment) {
+        return IAGateway.requeueJobResult(jobData, increment);
+    }
+
+    /**
+     * Handle a retryable failure from the detection HTTP call. Requeues while the retry budget
+     * allows. On PERMANENT policy exhaustion (retry cap / max queue time), land the MediaAsset +
+     * task terminal instead of stranding the asset in {@code processing-mlservice} forever —
+     * before this, exhaustion silently dropped the job and the asset stayed non-terminal,
+     * pinning bulk imports below 100% with nothing left to ever complete it. The {@code error}
+     * detection status counts as detection-complete in {@code ImportTask.iaSummaryJson}.
+     *
+     * <p>EXECUTOR_REJECTED (webapp undeploy in flight) is deliberately NOT terminal: the asset
+     * stays {@code processing-mlservice}, which is exactly the state the startup
+     * stale-mlservice reconciler recovers after redeploy.</p>
+     */
+    MlServiceJobOutcome handleRetryableDetectionFailure(JSONObject jobData, String maId,
+        String taskId, IAException ex) {
+        IAGateway.RequeueResult rq = requeueJob(jobData, ex.shouldIncrement());
+
+        if (rq == IAGateway.RequeueResult.QUEUED) return MlServiceJobOutcome.requeue();
+        if (!rq.isPolicyExhausted()) {
+            System.out.println("WARN: MlServiceProcessor detection retry for ma " + maId +
+                " (task " + taskId + ") not requeued (" + rq +
+                "); leaving asset recoverable for the startup reconciler");
+            return MlServiceJobOutcome.requeue();
+        }
+        String message = "retries exhausted (" + rq + "): " + ex.getMessage();
+        markDetectionFailure(maId, taskId, "RETRIES_EXHAUSTED", message);
+        return MlServiceJobOutcome.networkError("RETRIES_EXHAUSTED", message);
+    }
+
+    /** Extraction twin of {@link #handleRetryableDetectionFailure}: terminal task error on
+     * policy exhaustion instead of a silently dropped job; EXECUTOR_REJECTED stays
+     * non-terminal (the task's inactivity watchdog is the backstop). */
+    MlServiceJobOutcome handleRetryableExtractionFailure(JSONObject jobData, String taskId,
+        IAException ex) {
+        IAGateway.RequeueResult rq = requeueJob(jobData, ex.shouldIncrement());
+
+        if (rq == IAGateway.RequeueResult.QUEUED) return MlServiceJobOutcome.requeue();
+        if (!rq.isPolicyExhausted()) {
+            System.out.println("WARN: MlServiceProcessor extraction retry for task " + taskId +
+                " not requeued (" + rq + "); leaving task to the inactivity watchdog");
+            return MlServiceJobOutcome.requeue();
+        }
+        String message = "retries exhausted (" + rq + "): " + ex.getMessage();
+        markTaskError(taskId, "RETRIES_EXHAUSTED", message);
+        return MlServiceJobOutcome.networkError("RETRIES_EXHAUSTED", message);
     }
 
     static MlServiceJobOutcome mapNonRetryableError(IAException ex) {
@@ -1027,7 +1086,8 @@ public class MlServiceProcessor {
         return iac.convertIAClassForTaxonomy(rawIaClass, taxy);
     }
 
-    private void markTaskError(String taskId, String code, String message) {
+    // package-private (was private) so tests can override to observe terminal writes
+    void markTaskError(String taskId, String code, String message) {
         Shepherd shep = new Shepherd(context);
         shep.setAction(ACTION_PREFIX + "markTaskError");
         try {
@@ -1058,7 +1118,8 @@ public class MlServiceProcessor {
      * DB unavailable), the original failure outcome is preserved and
      * a WARN is logged — do NOT shadow the upstream error.</p>
      */
-    private void markDetectionFailure(String maId, String taskId, String code, String message) {
+    // package-private (was private) so tests can override to observe terminal writes
+    void markDetectionFailure(String maId, String taskId, String code, String message) {
         // Whole-helper try so that nothing in here can shadow the upstream
         // failure outcome — Shepherd construction, setAction, the
         // transaction body, AND the final rollbackAndClose are all guarded.
@@ -1182,7 +1243,8 @@ public class MlServiceProcessor {
      * DEFER, preserved across re-fires for elapsed-time age-out),
      * {@code lastGateReason} (Codex round-2 #6 diagnostic).</p>
      */
-    private void enqueueDeferredMatch(List<String> annotationIds, String parentTaskId,
+    // returns true iff the deferred payload was actually queued for re-fire
+    private boolean enqueueDeferredMatch(List<String> annotationIds, String parentTaskId,
         JSONObject matchConfig, MatchVisibilityGate.GateOutcome gate) {
         JSONObject payload = new JSONObject();
         // Routing flags — both required for the dispatcher to land
@@ -1207,12 +1269,13 @@ public class MlServiceProcessor {
         payload.put("firstDeferredAt", gate.firstDeferredAt);
         if (gate.reason != null) payload.put("lastGateReason", gate.reason);
         try {
-            deferredPublisher.publish(payload);
+            return deferredPublisher.publish(payload);
         } catch (Exception ex) {
             // requeueJob doesn't throw declared exceptions, but a future
             // publisher impl might. Don't let publish-failure leak past
             // the orchestrator.
             System.out.println("MlServiceProcessor.enqueueDeferredMatch failed: " + ex);
+            return false;
         }
     }
 

--- a/src/main/java/org/ecocean/servlet/IAGateway.java
+++ b/src/main/java/org/ecocean/servlet/IAGateway.java
@@ -101,6 +101,18 @@ public class IAGateway extends HttpServlet {
         } catch (Throwable t) {
             t.printStackTrace();
         }
+        // shutdownNow() cancels delayed publish runnables whose payloads were already reported
+        // as queued (requeueJob returned QUEUED). Flush them to the persistent spool NOW — a
+        // plain file write, safe mid-shutdown — so they survive the redeploy instead of being
+        // silently lost.
+        try {
+            int flushed = flushPendingRequeues();
+            if (flushed > 0)
+                System.out.println("IAGateway.destroy() flushed " + flushed +
+                    " pending requeue(s) to the spool");
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
         super.destroy();
     }
 
@@ -810,7 +822,31 @@ public class IAGateway extends HttpServlet {
         if (requeue) requeueJob(jobj, requeueIncrement);
     }
 
+    /**
+     * Typed verdict from {@link #requeueJobResult}. The distinction matters to callers deciding
+     * what to do with the underlying work item: {@code RETRY_CAP}/{@code TIME_CAP} are PERMANENT
+     * policy exhaustion (the job will never run again — mark the work terminal), while
+     * {@code EXECUTOR_REJECTED} means the requeue executor is gone (webapp undeploy in flight) —
+     * the job is lost from memory but the work item should be left in its recoverable state for
+     * post-redeploy reconciliation, NOT marked terminal.
+     */
+    public enum RequeueResult {
+        QUEUED, RETRY_CAP, TIME_CAP, EXECUTOR_REJECTED;
+        public boolean isPolicyExhausted() {
+            return this == RETRY_CAP || this == TIME_CAP;
+        }
+    }
+
     public static boolean requeueJob(JSONObject jobj, final boolean increment) {
+        return requeueJobResult(jobj, increment) == RequeueResult.QUEUED;
+    }
+
+    public static RequeueResult requeueJobResult(JSONObject jobj, final boolean increment) {
+        // NOTE: only PENALIZED retries (increment=true) grow the __queueRetries counter, so a
+        // purely non-incrementing chain (e.g. timeouts passing shouldIncrement()=false) is
+        // bounded by the wall-clock MAX_TIME_MILLIS cap, not MAX_RETRIES. Once the counter HAS
+        // accrued MAX_RETRIES penalized retries, though, the job is refused regardless of the
+        // current failure's increment flag — 30 penalized failures mark the job sick for good.
         int MAX_RETRIES = 30;
         long MAX_TIME_MILLIS = 2 * 24 * 60 * 60 * 1000;
         String context = jobj.optString("__context", "context0");
@@ -821,11 +857,17 @@ public class IAGateway extends HttpServlet {
 
         if (retries < 0) retries = 0;
         long elapsed = System.currentTimeMillis() - queueStart;
-        if (elapsed > MAX_TIME_MILLIS) retries = MAX_RETRIES + 1; // waiting around too long
-        if (retries > MAX_RETRIES) {
+        if (elapsed > MAX_TIME_MILLIS) { // waiting around too long
             System.out.println("requeueJob(): completely failed taskId=" + taskId + " after " +
-                MAX_RETRIES + " retries (or max time) in queue; giving up");
-            return false;
+                elapsed + "ms (max time) in queue; giving up");
+            return RequeueResult.TIME_CAP;
+        }
+        // >= so exactly MAX_RETRIES retries run: `retries` counts retries already scheduled, and
+        // the old `>` boundary scheduled a 31st retry before rejecting the 32nd call
+        if (retries >= MAX_RETRIES) {
+            System.out.println("requeueJob(): completely failed taskId=" + taskId + " after " +
+                MAX_RETRIES + " retries in queue; giving up");
+            return RequeueResult.RETRY_CAP;
         }
         System.out.println("requeueJob(): attempting to requeue taskId=" + taskId + " for retry " +
             retries + " out of " + MAX_RETRIES + " (actualRetries=" + actualRetries + "; start=" +
@@ -863,9 +905,10 @@ public class IAGateway extends HttpServlet {
         // previous code's "logged before sleeping" timing for any
         // operators tailing for this string.
         System.out.println("requeueJob(): backgrounding taskId=" + taskId);
-        // false when the executor rejected the schedule (webapp undeploy): the retry is
-        // permanently lost and the caller must not believe it was requeued
-        return scheduleRequeuePublish(jobj, context, taskId, initialDelayMillis);
+        // EXECUTOR_REJECTED when the schedule was refused (webapp undeploy): the retry is lost
+        // from memory and the caller must not believe it was requeued
+        return scheduleRequeuePublish(jobj, context, taskId, initialDelayMillis)
+                   ? RequeueResult.QUEUED : RequeueResult.EXECUTOR_REJECTED;
     }
 
     // Schedules a single attempt to publish jobj onto the appropriate
@@ -873,52 +916,147 @@ public class IAGateway extends HttpServlet {
     // with a 30s backoff — preserving the original code's "retry
     // forever on addToQueue/addToDetectionQueue failure" semantics
     // without an unbounded busy loop on a dedicated thread.
-    private static boolean scheduleRequeuePublish(final JSONObject jobj, final String context,
-        final String taskId, long delayMillis) {
-        try {
-            scheduleRequeuePublishUnguarded(jobj, context, taskId, delayMillis);
-            return true;
-        } catch (java.util.concurrent.RejectedExecutionException rex) {
-            // REQUEUE_EXEC was shut down (webapp undeploy/reload). The job was never written to
-            // the persistent spool, so this retry is genuinely lost — say so loudly rather than
-            // letting the exception propagate into whatever thread asked for the requeue.
-            System.out.println("ERROR: scheduleRequeuePublish() rejected (executor shut down?); " +
-                "requeue LOST for taskId=" + taskId + ": " + rex.toString());
-            return false;
+    // A payload whose delayed publish has been accepted but not yet written to the persistent
+    // spool. Tracked so a shutdown can flush it durably instead of losing it with the cancelled
+    // runnable. Exactly-once publish is enforced by publishPending(): the `published` flag makes
+    // re-publish a no-op and the `inFlight` CAS stops concurrent attempts; the entry leaves the
+    // set only AFTER a successful spool write, so a publisher interrupted mid-write leaves the
+    // payload visible to the shutdown flush.
+    private static final class PendingRequeue {
+        final JSONObject jobj;
+        final String context;
+        final String taskId;
+        final java.util.concurrent.atomic.AtomicBoolean inFlight =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
+        volatile boolean published = false;
+        PendingRequeue(JSONObject jobj, String context, String taskId) {
+            this.jobj = jobj;
+            this.context = context;
+            this.taskId = taskId;
+        }
+    }
+    private static final java.util.Set<PendingRequeue> PENDING_REQUEUES =
+        java.util.concurrent.ConcurrentHashMap.newKeySet();
+
+    // Route the payload onto its queue NOW (a plain spool-file write). mlServiceV2 retries must
+    // land on the detection queue, not the generic IA queue — without this, a retryable
+    // ml-service failure would never be re-dispatched to MlServiceProcessor.
+    private static void publishRequeueNow(JSONObject jobj, String context)
+    throws IOException {
+        if (jobj.optJSONObject("detect") != null ||
+            jobj.optBoolean("fastlane", false) ||
+            jobj.optBoolean("MLService", false) ||
+            jobj.optBoolean("mlServiceV2", false)) {
+            addToDetectionQueue(context, jobj.toString());
+        } else {
+            addToQueue(context, jobj.toString());
         }
     }
 
-    private static void scheduleRequeuePublishUnguarded(final JSONObject jobj, final String context,
-        final String taskId, long delayMillis) {
-        REQUEUE_EXEC.schedule(new Runnable() {
-            public void run() {
+    // The single publish path shared by the delayed runnable, the shutdown flush, and the
+    // schedule-rejection fallback. Returns true iff THIS call performed the durable spool write.
+    // Idempotent: an already-published or currently-in-flight entry is left alone. On write
+    // failure the entry STAYS in PENDING_REQUEUES so another actor can still recover it.
+    private static boolean publishPending(PendingRequeue pr) {
+        if (pr.published || !pr.inFlight.compareAndSet(false, true)) return false;
+        try {
+            publishRequeueNow(pr.jobj, pr.context);
+            pr.published = true;
+            PENDING_REQUEUES.remove(pr);
+            return true;
+        } catch (Throwable t) {
+            System.out.println(
+                ".....requeueJob() looping: failed to requeue addTo_Queue() taskId=" +
+                pr.taskId + " due to " + t.toString());
+            t.printStackTrace();
+            return false;
+        } finally {
+            pr.inFlight.set(false);
+        }
+    }
+
+    // "Last actor" publish: used where NOTHING later is guaranteed to retry (the shutdown flush,
+    // and the schedule-rejection fallback once the executor is gone). Waits briefly for any
+    // concurrent in-flight publisher to settle, then makes its own bounded write attempts.
+    //
+    // Verdict semantics at the deadline: if an owner is STILL in flight (a spool write blocking
+    // >2s during shutdown), we return pessimistic-false by design. The alternatives are both
+    // worse: waiting unboundedly lets a hung disk hang destroy(); reporting optimistic-true
+    // while the owner then fails re-opens the lost-payload hole. A false verdict makes callers
+    // err toward DUPLICATE work (recoverable state / run-match-now, both idempotent-tolerant) —
+    // never toward loss — and physical writes stay CAS+published-gated, so a duplicate verdict
+    // can never become a duplicate spool file.
+    private static boolean publishPendingFinal(PendingRequeue pr) {
+        long deadline = System.currentTimeMillis() + 2000;
+        int writeAttempts = 0;
+
+        while ((System.currentTimeMillis() < deadline) && (writeAttempts < 3)) {
+            if (pr.published) return true;
+            if (pr.inFlight.get()) { // let the current owner finish (it may succeed or fail)
                 try {
-                    if (jobj.optJSONObject("detect") != null ||
-                        jobj.optBoolean("fastlane", false) ||
-                        jobj.optBoolean("MLService", false) ||
-                        jobj.optBoolean("mlServiceV2", false)) {
-                        // mlServiceV2 retries must land on the
-                        // detection queue, not the generic IA queue.
-                        // Without this, a retryable ml-service failure
-                        // would never be re-dispatched to
-                        // MlServiceProcessor.
-                        addToDetectionQueue(context, jobj.toString());
-                    } else {
-                        addToQueue(context, jobj.toString());
-                    }
-                } catch (Throwable t) {
-                    System.out.println(
-                        ".....requeueJob() looping: failed to requeue addTo_Queue() taskId=" +
-                        taskId + " due to " + t.toString());
-                    t.printStackTrace();
-                    // Indefinite retry on publish failure, 30s backoff.
-                    // Catching Throwable (not Exception) ensures even
-                    // unexpected Errors during publish don't kill the
-                    // executor worker silently.
-                    scheduleRequeuePublish(jobj, context, taskId, 30000L);
+                    Thread.sleep(10);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
                 }
+                continue;
             }
-        }, delayMillis, java.util.concurrent.TimeUnit.MILLISECONDS);
+            writeAttempts++;
+            if (publishPending(pr)) return true;
+        }
+        return pr.published;
+    }
+
+    // Durably publish every payload still awaiting its (now cancelled) delayed runnable.
+    // Package-private for tests. Returns how many this call left published (by itself or a
+    // concurrent owner it waited out).
+    static int flushPendingRequeues() {
+        int flushed = 0;
+        for (PendingRequeue pr : PENDING_REQUEUES) {
+            if (pr.published) continue;
+            if (publishPendingFinal(pr)) flushed++;
+            else
+                System.out.println("ERROR: flushPendingRequeues() could not publish taskId=" +
+                    pr.taskId + "; requeue LOST (spool write failing at shutdown)");
+        }
+        return flushed;
+    }
+
+    private static boolean scheduleRequeuePublish(final JSONObject jobj, final String context,
+        final String taskId, long delayMillis) {
+        PendingRequeue pending = new PendingRequeue(jobj, context, taskId);
+        PENDING_REQUEUES.add(pending);
+        return schedulePending(pending, delayMillis);
+    }
+
+    // Schedule the delayed publish of an EXISTING pending entry; on executor rejection (webapp
+    // undeploy) skip the backoff — it only exists to throttle retries, moot when this JVM is
+    // exiting — and write the job durably to the spool right now (a plain file write, safe
+    // mid-shutdown; consumed after the redeploy).
+    private static boolean schedulePending(final PendingRequeue pending, long delayMillis) {
+        try {
+            REQUEUE_EXEC.schedule(new Runnable() {
+                public void run() {
+                    if (publishPending(pending) || pending.published) return;
+                    // publish failed (entry still recoverable in the set): indefinite retry
+                    // with a 30s backoff on the SAME entry — never a duplicate.
+                    schedulePending(pending, 30000L);
+                }
+            }, delayMillis, java.util.concurrent.TimeUnit.MILLISECONDS);
+            return true;
+        } catch (java.util.concurrent.RejectedExecutionException rex) {
+            // The executor is gone (undeploy), so no later actor is guaranteed: settle any
+            // concurrent publisher (e.g. the shutdown flush, which may yet fail) and make our
+            // own final write attempts. Only a genuine spool-write failure gets reported lost.
+            if (publishPendingFinal(pending)) {
+                System.out.println("schedulePending(): executor rejected (shutdown?); " +
+                    "published taskId=" + pending.taskId + " directly to the spool");
+                return true;
+            }
+            System.out.println("ERROR: schedulePending() rejected AND direct spool publish " +
+                "failed; requeue LOST for taskId=" + pending.taskId + ": " + rex.toString());
+            return false;
+        }
     }
 
     public static void processCallbackQueueMessage(String message) {

--- a/src/test/java/org/ecocean/ia/MlServiceProcessorGateTest.java
+++ b/src/test/java/org/ecocean/ia/MlServiceProcessorGateTest.java
@@ -30,8 +30,9 @@ class MlServiceProcessorGateTest {
     /** Records the payload(s) published by the processor under test. */
     private static final class RecordingPublisher implements DeferredMatchPublisher {
         final List<JSONObject> published = new ArrayList<JSONObject>();
-        @Override public void publish(JSONObject payload) {
+        @Override public boolean publish(JSONObject payload) {
             published.add(payload);
+            return true;
         }
     }
 
@@ -88,6 +89,37 @@ class MlServiceProcessorGateTest {
         assertEquals(MlServiceJobOutcome.Kind.OK, out.getKind());
         assertEquals(1, publisher.published.size(),
             "expected exactly one re-published payload");
+    }
+
+    @Test void failedDeferredPublishFallsBackToRunningTheMatch() {
+        // If the deferred payload was NOT queued (publisher returns false: requeue executor
+        // gone / publish failed), the DEFER arm must not report OK for a match that will never
+        // run. There is no passive backstop (the parent task is already completed, so the
+        // inactivity watchdog ignores it) — the processor must run the match immediately
+        // against the visible corpus, same tradeoff as the GIVE_UP arm.
+        long firstDeferred = System.currentTimeMillis();
+        DeferredMatchPublisher failingPublisher = new DeferredMatchPublisher() {
+            @Override public boolean publish(JSONObject payload) {
+                return false;
+            }
+        };
+        final List<String> matchedTaskIds = new ArrayList<String>();
+        MlServiceProcessor p = new MlServiceProcessor("context0", new MlServiceClient(),
+            new StubGate(MatchVisibilityGate.GateOutcome.defer(
+                2, firstDeferred, "sibling MA non-terminal")), failingPublisher) {
+            @Override boolean readSkipIdent(String taskId) { return false; }
+            @Override public MlServiceJobOutcome runMatchProspects(List<String> annotationIds,
+                String taskId, JSONObject matchConfig) {
+                matchedTaskIds.add(taskId);
+                return MlServiceJobOutcome.ok(new ArrayList<String>(annotationIds));
+            }
+        };
+        MlServiceJobOutcome out = p.runDeferredMatch(deferredJobPayload(2, firstDeferred));
+        assertEquals(1, matchedTaskIds.size(),
+            "a lost deferred re-fire must fall back to running the match now");
+        assertEquals("task-1", matchedTaskIds.get(0), "fallback match targets the same task");
+        assertEquals(MlServiceJobOutcome.Kind.OK, out.getKind(),
+            "outcome comes from the fallback match, not a fake OK for a dropped job");
     }
 
     @Test void publishedPayloadCarriesBothRoutingFlags() {

--- a/src/test/java/org/ecocean/ia/MlServiceProcessorRetryExhaustionTest.java
+++ b/src/test/java/org/ecocean/ia/MlServiceProcessorRetryExhaustionTest.java
@@ -1,0 +1,152 @@
+package org.ecocean.ia;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.ecocean.servlet.IAGateway;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for requeue-exhaustion handling. A retryable ml-service failure goes to
+ * IAGateway.requeueJobResult(), which permanently gives up after its retry/time cap. Previously
+ * that verdict was ignored: the job was silently dropped and the MediaAsset stayed in
+ * 'processing-mlservice' forever — non-terminal, so it pinned bulk-import detection below 100%
+ * with nothing left to ever complete it (GiraffeSpotter 2026-08). Policy exhaustion
+ * (RETRY_CAP/TIME_CAP) must land the asset/task in a terminal error state ('error' counts as
+ * detection-complete in ImportTask.iaSummaryJson). EXECUTOR_REJECTED (webapp undeploy) must NOT
+ * be terminal: the asset stays recoverable for the startup stale-mlservice reconciler. No
+ * containers or DB required — terminal writes are observed via the package-private marker seams.
+ */
+public class MlServiceProcessorRetryExhaustionTest {
+    private static final class NoopGate implements MatchVisibilityGate {
+        @Override public GateOutcome gateForBatch(Collection<String> callerAnnotationIds,
+            String childTaskId, JSONObject matchConfig, int attempt, Long firstDeferredAt) {
+            throw new UnsupportedOperationException("gate is not reached in these tests");
+        }
+    }
+
+    private static final class NoopPublisher implements DeferredMatchPublisher {
+        @Override public boolean publish(JSONObject payload) {
+            return true;
+        }
+    }
+
+    /** Stubs the requeue verdict and records terminal-state writes instead of touching the DB. */
+    private static final class RecordingProcessor extends MlServiceProcessor {
+        final IAGateway.RequeueResult requeueVerdict;
+        final List<Boolean> requeueIncrements = new ArrayList<Boolean>();
+        String detectionFailureMaId = null;
+        String detectionFailureCode = null;
+        String taskErrorTaskId = null;
+        String taskErrorCode = null;
+
+        RecordingProcessor(IAGateway.RequeueResult requeueVerdict) {
+            super("context0", new MlServiceClient(), new NoopGate(), new NoopPublisher());
+            this.requeueVerdict = requeueVerdict;
+        }
+
+        @Override IAGateway.RequeueResult requeueJob(JSONObject jobData, boolean increment) {
+            requeueIncrements.add(Boolean.valueOf(increment));
+            return requeueVerdict;
+        }
+
+        @Override void markDetectionFailure(String maId, String taskId, String code,
+            String message) {
+            this.detectionFailureMaId = maId;
+            this.detectionFailureCode = code;
+        }
+
+        @Override void markTaskError(String taskId, String code, String message) {
+            this.taskErrorTaskId = taskId;
+            this.taskErrorCode = code;
+        }
+    }
+
+    private static IAException retryable() {
+        return new IAException("SERVER_ERROR", "ml-service 500", true, true);
+    }
+
+    private static JSONObject job() {
+        JSONObject jo = new JSONObject();
+        jo.put("mlServiceV2", true);
+        jo.put("taskId", "task-1");
+        return jo;
+    }
+
+    @Test void detectionFailureRequeuesWhileBudgetAllows() {
+        RecordingProcessor p = new RecordingProcessor(IAGateway.RequeueResult.QUEUED);
+        MlServiceJobOutcome out = p.handleRetryableDetectionFailure(job(), "ma-1", "task-1",
+            retryable());
+
+        assertEquals(MlServiceJobOutcome.Kind.REQUEUE, out.getKind(), "budget left -> requeue");
+        assertEquals(1, p.requeueIncrements.size(), "exactly one requeue attempt");
+        assertTrue(p.requeueIncrements.get(0).booleanValue(),
+            "increment flag must come from the exception");
+        assertNull(p.detectionFailureCode, "no terminal write while the job can still retry");
+    }
+
+    @Test void detectionRetryExhaustionLandsTerminal() {
+        RecordingProcessor p = new RecordingProcessor(IAGateway.RequeueResult.RETRY_CAP);
+        MlServiceJobOutcome out = p.handleRetryableDetectionFailure(job(), "ma-1", "task-1",
+            retryable());
+
+        assertEquals(MlServiceJobOutcome.Kind.ERROR_NETWORK, out.getKind(),
+            "exhaustion is a terminal network-class error, not a silent drop");
+        assertEquals("RETRIES_EXHAUSTED", p.detectionFailureCode,
+            "the MediaAsset/task must be marked terminal on exhaustion");
+        assertEquals("ma-1", p.detectionFailureMaId, "terminal write targets the right asset");
+    }
+
+    @Test void detectionTimeCapAlsoLandsTerminal() {
+        RecordingProcessor p = new RecordingProcessor(IAGateway.RequeueResult.TIME_CAP);
+        p.handleRetryableDetectionFailure(job(), "ma-1", "task-1", retryable());
+
+        assertEquals("RETRIES_EXHAUSTED", p.detectionFailureCode,
+            "the 2-day queue-time cap is policy exhaustion too");
+    }
+
+    @Test void detectionExecutorRejectionStaysRecoverable() {
+        RecordingProcessor p = new RecordingProcessor(IAGateway.RequeueResult.EXECUTOR_REJECTED);
+        MlServiceJobOutcome out = p.handleRetryableDetectionFailure(job(), "ma-1", "task-1",
+            retryable());
+
+        assertEquals(MlServiceJobOutcome.Kind.REQUEUE, out.getKind(),
+            "undeploy-time rejection must not finalize the job");
+        assertNull(p.detectionFailureCode,
+            "no terminal write on executor rejection: the asset must stay "
+            + "processing-mlservice so the startup reconciler can recover it after redeploy");
+    }
+
+    @Test void extractionFailureRequeuesWhileBudgetAllows() {
+        RecordingProcessor p = new RecordingProcessor(IAGateway.RequeueResult.QUEUED);
+        MlServiceJobOutcome out = p.handleRetryableExtractionFailure(job(), "task-1", retryable());
+
+        assertEquals(MlServiceJobOutcome.Kind.REQUEUE, out.getKind(), "budget left -> requeue");
+        assertNull(p.taskErrorCode, "no terminal write while the job can still retry");
+    }
+
+    @Test void extractionRetryExhaustionLandsTerminal() {
+        RecordingProcessor p = new RecordingProcessor(IAGateway.RequeueResult.RETRY_CAP);
+        MlServiceJobOutcome out = p.handleRetryableExtractionFailure(job(), "task-1", retryable());
+
+        assertEquals(MlServiceJobOutcome.Kind.ERROR_NETWORK, out.getKind(),
+            "exhaustion is a terminal network-class error, not a silent drop");
+        assertEquals("RETRIES_EXHAUSTED", p.taskErrorCode,
+            "the task must be marked terminal on exhaustion");
+        assertEquals("task-1", p.taskErrorTaskId, "terminal write targets the right task");
+    }
+
+    @Test void extractionExecutorRejectionStaysRecoverable() {
+        RecordingProcessor p = new RecordingProcessor(IAGateway.RequeueResult.EXECUTOR_REJECTED);
+        MlServiceJobOutcome out = p.handleRetryableExtractionFailure(job(), "task-1", retryable());
+
+        assertEquals(MlServiceJobOutcome.Kind.REQUEUE, out.getKind(),
+            "undeploy-time rejection must not finalize the job");
+        assertNull(p.taskErrorCode,
+            "no terminal write on executor rejection: the inactivity watchdog is the backstop");
+    }
+}

--- a/src/test/java/org/ecocean/queue/FileQueueTestSupport.java
+++ b/src/test/java/org/ecocean/queue/FileQueueTestSupport.java
@@ -1,0 +1,15 @@
+package org.ecocean.queue;
+
+import java.io.File;
+
+/**
+ * Test-only bridge to FileQueue's package-private base-dir seam, for tests living outside the
+ * org.ecocean.queue package (e.g. servlet-layer tests that exercise queue publishes).
+ */
+public final class FileQueueTestSupport {
+    private FileQueueTestSupport() {}
+
+    public static void overrideBaseDir(File dir) {
+        FileQueue.overrideQueueBaseDirForTesting(dir);
+    }
+}

--- a/src/test/java/org/ecocean/servlet/IAGatewayRequeueBoundaryTest.java
+++ b/src/test/java/org/ecocean/servlet/IAGatewayRequeueBoundaryTest.java
@@ -1,0 +1,110 @@
+package org.ecocean.servlet;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.ecocean.queue.FileQueueTestSupport;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Retry-cap boundary + typed verdict for {@link IAGateway#requeueJobResult}. `__queueRetries`
+ * counts retries already scheduled, so the cap check must refuse at {@code >= MAX_RETRIES}
+ * (exactly 30 retries run). The old {@code >} boundary scheduled a 31st retry before refusing
+ * the 32nd call. The verdict type distinguishes permanent policy exhaustion (RETRY_CAP/TIME_CAP,
+ * caller marks the work terminal) from executor rejection (caller leaves the work recoverable).
+ *
+ * Note: QUEUED cases schedule a real delayed publish on the shared requeue executor — a benign
+ * side effect in the test JVM (the publish lands in the temp/fallback file-queue dir).
+ */
+public class IAGatewayRequeueBoundaryTest {
+    @TempDir Path tempDir;
+
+    @BeforeEach void isolateQueueBaseDir() {
+        FileQueueTestSupport.overrideBaseDir(tempDir.toFile());
+    }
+
+    @AfterEach void restoreQueueBaseDir() {
+        FileQueueTestSupport.overrideBaseDir(null);
+    }
+
+    private static JSONObject jobWithRetries(int retries) {
+        JSONObject jo = new JSONObject();
+        jo.put("taskId", "task-boundary");
+        jo.put("__queueStart", System.currentTimeMillis());
+        jo.put("__queueRetries", retries);
+        return jo;
+    }
+
+    @Test void allowsTheFinalRetryUnderTheCap() {
+        JSONObject jo = jobWithRetries(29);
+        assertEquals(IAGateway.RequeueResult.QUEUED, IAGateway.requeueJobResult(jo, true),
+            "retry #30 (the final one) is within budget");
+        assertEquals(30, jo.optInt("__queueRetries"), "increment stamps the next retry count");
+    }
+
+    @Test void refusesAtExactlyMaxRetries() {
+        assertEquals(IAGateway.RequeueResult.RETRY_CAP,
+            IAGateway.requeueJobResult(jobWithRetries(30), true),
+            "retry #31 must be refused: the cap is 30");
+        assertFalse(IAGateway.requeueJob(jobWithRetries(30), true),
+            "boolean contract: refused means false");
+    }
+
+    @Test void refusesBeyondMaxRetries() {
+        assertEquals(IAGateway.RequeueResult.RETRY_CAP,
+            IAGateway.requeueJobResult(jobWithRetries(31), true),
+            "beyond the cap must always be refused");
+    }
+
+    @Test void refusesWhenMaxQueueTimeExceeded() {
+        JSONObject jo = jobWithRetries(0);
+        jo.put("__queueStart", System.currentTimeMillis() - (3L * 24L * 60L * 60L * 1000L));
+        assertEquals(IAGateway.RequeueResult.TIME_CAP, IAGateway.requeueJobResult(jo, true),
+            "a job older than the 2-day queue-time cap must be refused regardless of count");
+    }
+
+    @Test void nonIncrementingRetriesRideTheTimeCapNotTheCounter() {
+        JSONObject jo = jobWithRetries(0);
+        assertEquals(IAGateway.RequeueResult.QUEUED, IAGateway.requeueJobResult(jo, false),
+            "non-penalized retry is within budget");
+        assertEquals(0, jo.optInt("__queueRetries"),
+            "increment=false must not grow the counter: such retries are bounded by the "
+            + "2-day wall clock, not MAX_RETRIES (deliberate asymmetry)");
+    }
+
+    @Test void accruedCapRefusesEvenNonIncrementingRetries() {
+        assertEquals(IAGateway.RequeueResult.RETRY_CAP,
+            IAGateway.requeueJobResult(jobWithRetries(30), false),
+            "once 30 penalized retries have accrued the job is refused regardless of the "
+            + "current failure's increment flag");
+    }
+
+    @Test void pendingRequeueSurvivesShutdownViaFlush() {
+        // requeueJob reports QUEUED once the DELAYED publish runnable is accepted — the durable
+        // spool write happens up to 30s later. destroy()'s shutdownNow() cancels those pending
+        // runnables, so it must flush them to the spool (what flushPendingRequeues does) or the
+        // already-reported-as-queued job is silently lost across a redeploy.
+        JSONObject jo = jobWithRetries(0);
+        jo.put("mlServiceV2", true); // routes to the detection spool
+        assertEquals(IAGateway.RequeueResult.QUEUED, IAGateway.requeueJobResult(jo, true),
+            "accepted for a 30s-delayed publish");
+
+        int flushed = IAGateway.flushPendingRequeues();
+        assertTrue(flushed >= 1, "the pending payload must be flushed durably, not lost");
+        File spool = new File(tempDir.toFile(), "detection");
+        File[] files = spool.isDirectory() ? spool.listFiles() : null;
+        assertTrue(files != null && files.length >= 1,
+            "the flushed payload must be a real file in the persistent detection spool");
+
+        // exactly-once: a second flush (or the delayed runnable firing later) must not publish
+        // the same payloads again
+        assertEquals(0, IAGateway.flushPendingRequeues(),
+            "already-published payloads must never be flushed twice");
+    }
+}


### PR DESCRIPTION
**Stacked on #1727** (base = `fix/filequeue-consumer-resilience`; retarget to `main` after #1727 merges). Second PR from the GiraffeSpotter queue-outage investigation.

## The bug

A retryable ml-service failure (e.g. a transient HTTP 500) goes to `IAGateway.requeueJob()`, which permanently gives up after its retry/time cap — but `MlServiceProcessor` **ignored that verdict**. On exhaustion the job was silently dropped and the MediaAsset stayed in `processing-mlservice` forever: non-terminal, so bulk-import detection was pinned below 100% with nothing left to ever complete it. Observed on GiraffeSpotter (2026-08); only a Tomcat restart + the startup reconciler could revive such assets.

## Changes

**Typed requeue verdict.** New `IAGateway.RequeueResult` (`QUEUED` / `RETRY_CAP` / `TIME_CAP` / `EXECUTOR_REJECTED`) via `requeueJobResult()`; the boolean `requeueJob()` delegates, preserving the legacy contract. The distinction matters: the caps are *permanent policy exhaustion*, while `EXECUTOR_REJECTED` means the requeue executor is gone mid-undeploy and the work must stay recoverable.

**Terminal status on exhaustion.** `processDetection`/`processExtraction` route retryable failures through new `handleRetryable*Failure` helpers: `QUEUED` → requeue; caps → `markDetectionFailure`/`markTaskError` (`RETRIES_EXHAUSTED`) + `ERROR_NETWORK` outcome (`error` counts as detection-complete in `ImportTask.iaSummaryJson`, so exhausted assets no longer strand imports); `EXECUTOR_REJECTED` → **no** terminal write — the asset stays `processing-mlservice` for the startup stale-mlservice reconciler.

**Durable requeue handoff (exactly-once).** Previously `requeueJob` reported success when the *delayed* publish runnable was accepted; `destroy()`'s `shutdownNow()` then cancelled pending runnables, silently losing jobs already reported as queued. Now: pending payloads are tracked with `published`-flag + `inFlight`-CAS exactly-once semantics; `destroy()` flushes survivors durably to the persistent spool; a rejected schedule falls back to an immediate synchronous spool write; the two last-actor paths settle any in-flight owner and retry before ever reporting a loss. At the 2s shutdown deadline the verdict is deliberately pessimistic-false (documented in-code): callers err toward duplicate work, never loss.

**Deferred-match honesty.** `DeferredMatchPublisher.publish` now returns whether the payload was actually queued; the DEFER arm no longer reports OK for a match that was never queued — it runs the match immediately against the visible corpus (same tradeoff as the gate's GIVE_UP arm), since the parent task is already completed and no watchdog would ever surface the loss.

**Retry-cap off-by-one.** `>` → `>=`: `__queueRetries` counts retries already scheduled, so the old boundary ran a 31st retry before refusing the 32nd call. Also documented that `MAX_RETRIES` caps only penalized (`increment=true`) retries — non-incrementing chains ride the 2-day wall clock by design — and that an accrued cap refuses regardless of the current increment flag.

## Tests

24 new/updated assertions across three classes, no DB or containers:
- `MlServiceProcessorRetryExhaustionTest` (7): requeue-while-budget, terminal on RETRY_CAP/TIME_CAP, recoverable on EXECUTOR_REJECTED — for both detection and extraction.
- `IAGatewayRequeueBoundaryTest` (7): 29→30 final-allowed boundary (verified to fail on the old `>` cap), refusal at/beyond 30, time-cap, non-incrementing contract, accrued-cap refusal, and pending-requeue shutdown-flush durability with an exactly-once double-flush assertion.
- `MlServiceProcessorGateTest` (+1): failed deferred publish falls back to running the match, outcome supplied by the real fallback.

Codex adversarial review: **8 rounds, converged** — including an exhaustive state-machine pass over the exactly-once publish mechanics and an adjudicated verdict-semantics tradeoff.

## Out of scope (noted for follow-ups)

- Legacy WBIA/`MLService` dispatcher paths still ignore the requeue verdict (pre-existing behavior; the earlier cap moves their silent drop one retry earlier).
- Ack-after-handle delivery semantics for the FileQueue itself (`.complete` written before the handler runs).
- Queue depth/staleness metrics + alerting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)