### PR TITLE
Report Modified Groth + I3S scan tasks in /metrics (per-algorithm gauges + identification aggregate)

### DIFF
--- a/src/main/java/org/ecocean/MetricsBot.java
+++ b/src/main/java/org/ecocean/MetricsBot.java
@@ -555,6 +555,20 @@ public class MetricsBot {
             "Number of ml-service v2 vector (MiewID) re-ID leaf tasks (one per matched annotation; a rare invalid-config match failure counts as one)",
             context));
 
+        // Modified Groth + I3S spot-pattern scans. These never touch org.ecocean.ia.Task:
+        // GrothScanRunnable writes one org.ecocean.grid.ScanRecord row per completed scan
+        // run, with a per-algorithm success flag for each (one run executes BOTH matchers).
+        // ScanTask rows cannot be counted instead — one reused row per encounter side.
+        // Counts start at 0 on deploy; historical scans left no per-run rows.
+        addLineIfNotNull(csvLines, buildGauge(
+            "SELECT count(this) FROM org.ecocean.grid.ScanRecord where grothSuccess == true",
+            "wildbook_tasks_modifiedGroth",
+            "Number of successful Modified Groth spot-pattern scan tasks", context));
+        addLineIfNotNull(csvLines, buildGauge(
+            "SELECT count(this) FROM org.ecocean.grid.ScanRecord where i3sSuccess == true",
+            "wildbook_tasks_i3s",
+            "Number of successful I3S spot-pattern scan tasks", context));
+
 
 
         // add queue information
@@ -587,8 +601,16 @@ public class MetricsBot {
             String idCompleteFilter =
                 "SELECT count(this) FROM org.ecocean.ia.Task where completionDateInMilliseconds > "
                 + (System.currentTimeMillis() - TwoFourHours);
+            // Successful Modified Groth / I3S spot scans contribute to the identification
+            // aggregate. A run that produced both algorithms' results counts ONCE here —
+            // it is one re-ID job; the per-algorithm gauges report them individually.
+            String spotScansCompleteFilter =
+                "SELECT count(this) FROM org.ecocean.grid.ScanRecord where endTime > "
+                + (System.currentTimeMillis() - TwoFourHours) +
+                " && (grothSuccess == true || i3sSuccess == true)";
             Query qD = null;
             Query qID = null;
+            Query qS = null;
             try {
                 Long detectValue = null;
                 Long idValue = null;
@@ -599,9 +621,21 @@ public class MetricsBot {
                 idValue = (Long)qID.execute();
                 if (idValue != null)
                     numIDCompletedLast24 = idValue.intValue() - detectValue.intValue();
+                // Own try/catch so a ScanRecord-side failure cannot suppress the two
+                // pre-existing completed metrics below.
+                try {
+                    qS = myShepherd.getPM().newQuery(spotScansCompleteFilter);
+                    Long spotScanValue = (Long)qS.execute();
+                    if (spotScanValue != null)
+                        numIDCompletedLast24 += spotScanValue.intValue();
+                } catch (Exception scanEx) {
+                    System.out.println(
+                        "MetricsBot: could not count ScanRecord spot scans for last24:");
+                    scanEx.printStackTrace();
+                }
                 csvLines.add("wildbook_identification_tasks_completed_last24, " +
                     numIDCompletedLast24 + "," + "gauge" + "," +
-                    "Number of child identification tasks completed last 24 hours");
+                    "Number of child identification tasks completed last 24 hours (includes successful Modified Groth / I3S spot-pattern scans)");
                 csvLines.add("wildbook_detection_tasks_completed_last24, " +
                     numDetectionCompletedLast24 + "," + "gauge" + "," +
                     "Number of detection tasks completed last 24 hours");
@@ -613,6 +647,7 @@ public class MetricsBot {
             } finally {
                 if (qD != null) qD.closeAll();
                 if (qID != null) qID.closeAll();
+                if (qS != null) qS.closeAll();
             }
             IAJsonProperties iaConfig = new IAJsonProperties();
             List<Taxonomy> taxes = iaConfig.getAllTaxonomies(myShepherd);

--- a/src/main/java/org/ecocean/grid/ScanRecord.java
+++ b/src/main/java/org/ecocean/grid/ScanRecord.java
@@ -1,0 +1,87 @@
+package org.ecocean.grid;
+
+import java.io.Serializable;
+
+/**
+ * One immutable row per completed Modified Groth (+ I3S) scan run, written by
+ * GrothScanRunnable at the end of each run so MetricsBot can report spot-pattern
+ * matching activity in /metrics (wildbook_tasks_modifiedGroth, wildbook_tasks_i3s,
+ * and the wildbook_identification_tasks_completed_last24 aggregate).
+ *
+ * ScanTask rows cannot serve this purpose: their id is scan{L|R}{encounterNumber},
+ * one reused row per encounter side, reset on every rerun — so they count distinct
+ * encounter sides ever scanned, not scan runs. ScanRecord is row-per-run.
+ *
+ * This is best-effort telemetry: the result XML files on disk and this row cannot
+ * be written atomically, so a JVM crash between the two can under- or over-count a
+ * single run. Failure to persist a record is logged and dropped — it must never
+ * block scan completion.
+ */
+public class ScanRecord implements Serializable {
+    static final long serialVersionUID = 1L;
+
+    private String id;
+    private String taskID;
+    private String encounterNumber;
+    private boolean rightSide;
+    private long startTime = -1;
+    private long endTime = -1;
+    private boolean grothSuccess = false;
+    private boolean i3sSuccess = false;
+
+    /**
+     * empty constructor required by the JDO enhancer. DO NOT USE.
+     */
+    public ScanRecord() {}
+
+    /**
+     * @param id           pre-generated UUID for this run — generated ONCE per run so
+     *                     retried inserts stay idempotent (the id is the primary key)
+     * @param taskID       the (reused) ScanTask id, e.g. scanL12345
+     * @param grothSuccess the Groth result XML was written successfully
+     * @param i3sSuccess   the I3S result XML was written successfully
+     */
+    public ScanRecord(String id, String taskID, String encounterNumber, boolean rightSide,
+        long startTime, long endTime, boolean grothSuccess, boolean i3sSuccess) {
+        this.id = id;
+        this.taskID = taskID;
+        this.encounterNumber = encounterNumber;
+        this.rightSide = rightSide;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.grothSuccess = grothSuccess;
+        this.i3sSuccess = i3sSuccess;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTaskID() {
+        return taskID;
+    }
+
+    public String getEncounterNumber() {
+        return encounterNumber;
+    }
+
+    public boolean isRightSide() {
+        return rightSide;
+    }
+
+    public long getStartTime() {
+        return startTime;
+    }
+
+    public long getEndTime() {
+        return endTime;
+    }
+
+    public boolean isGrothSuccess() {
+        return grothSuccess;
+    }
+
+    public boolean isI3sSuccess() {
+        return i3sSuccess;
+    }
+}

--- a/src/main/java/org/ecocean/servlet/GrothScanRunnable.java
+++ b/src/main/java/org/ecocean/servlet/GrothScanRunnable.java
@@ -27,6 +27,7 @@ import org.ecocean.grid.I3SMatchObject;
 import org.ecocean.grid.I3SResultWriter;
 import org.ecocean.grid.MatchComparator;
 import org.ecocean.grid.MatchObject;
+import org.ecocean.grid.ScanRecord;
 import org.ecocean.grid.ScanTask;
 import org.ecocean.grid.VertexPointMatch;
 import org.ecocean.shepherd.core.Shepherd;
@@ -55,6 +56,10 @@ public final class GrothScanRunnable implements Runnable {
     private final double epsilon, R, Sizelim, maxTriangleRotation, C;
     private final String encDate, encSex, encIndividualID, encSize, encLocation, encLocationID;
     private final File shepherdDataDir;
+    // Metrics run id, generated ONCE per run: it is the ScanRecord primary key, so
+    // retried inserts stay idempotent (see persistScanRecord). Never derive this from
+    // taskID — taskID is intentionally reused across reruns of the same encounter side.
+    private final String runId = org.ecocean.Util.generateUUID();
 
     public GrothScanRunnable(String context, String taskID, long token, String encNumber,
         boolean rightScan, SuperSpot[] queryArray, EncounterLite queryLite,
@@ -85,6 +90,10 @@ public final class GrothScanRunnable implements Runnable {
     @Override public void run() {
         GridManager gm = GridManagerFactory.getGridManager();
         long startTime = System.currentTimeMillis();
+        // Per-algorithm success for the metrics ScanRecord: one run executes BOTH the
+        // Modified Groth and I3S matchers, so each result write is tracked separately.
+        boolean grothSucceeded = false;
+        boolean i3sSucceeded = false;
 
         try {
             // Remove stale result files first so a failed or partial run can never display
@@ -163,8 +172,18 @@ public final class GrothScanRunnable implements Runnable {
             // the tx, then write files (no DB transaction held during file I/O).
             Document document = buildMatchDocument(matchArray);
             writeScanXml(document);
-            I3SResultWriter.write(matchArray, queryLite, scannedI3SLites, encNumber, encDate,
-                encSex, encIndividualID, encSize, rightScan, shepherdDataDir);
+            grothSucceeded = true;
+            // I3S write success is the writer's RETURN VALUE (it catches internally and
+            // returns false). Its own try/catch so an I3S-only failure cannot mark the
+            // whole run failed — the Groth result XML is already on disk and usable.
+            try {
+                i3sSucceeded = I3SResultWriter.write(matchArray, queryLite, scannedI3SLites,
+                    encNumber, encDate, encSex, encIndividualID, encSize, rightScan,
+                    shepherdDataDir);
+            } catch (Exception i3sWriteEx) {
+                log.severe("I3S result write failed for " + encNumber + " (task " + taskID +
+                    "): " + i3sWriteEx.getMessage());
+            }
         } catch (Exception e) {
             log.severe("Async Groth scan failed for " + encNumber + " (task " + taskID + "): " +
                 e.getMessage());
@@ -174,8 +193,10 @@ public final class GrothScanRunnable implements Runnable {
             // shows the "results could not be written" branch since the XML was deleted up
             // front). The owner check is defensive — with no stale-reclaim this run owns the
             // slot throughout — and endScan releases it atomically by token.
+            long finishedAt = System.currentTimeMillis();
             if (gm.isScanOwner(taskID, token)) {
-                markScanTaskFinished();
+                markScanTaskFinished(finishedAt);
+                persistScanRecord(startTime, finishedAt, grothSucceeded, i3sSucceeded);
                 gm.clearScanProgress(taskID);
             }
             gm.endScan(taskID, token);
@@ -327,7 +348,7 @@ public final class GrothScanRunnable implements Runnable {
      * and explicitly roll back a failed/uncommitted transaction (commitDBTransactionWithStatus
      * does not roll back on failure, and closeDBTransaction does not roll back an active tx).
      */
-    private void markScanTaskFinished() {
+    private void markScanTaskFinished(long finishedAt) {
         for (int attempt = 1; attempt <= 3; attempt++) {
             Shepherd sh = new Shepherd(context);
             sh.setAction("GrothScanRunnable.finish");
@@ -337,7 +358,7 @@ public final class GrothScanRunnable implements Runnable {
                 ScanTask st = sh.getScanTask(taskID);
                 if (st != null) {
                     st.setFinished(true);
-                    st.setEndTime(System.currentTimeMillis());
+                    st.setEndTime(finishedAt);
                 }
                 ok = sh.commitDBTransactionWithStatus();
             } catch (Exception e) {
@@ -354,5 +375,51 @@ public final class GrothScanRunnable implements Runnable {
         }
         log.severe("Failed to persist finished ScanTask " + taskID +
             " after retries; the progress page may keep polling.");
+    }
+
+    /**
+     * Best-effort metrics telemetry: insert one {@link ScanRecord} row for this run so
+     * MetricsBot can report Modified Groth / I3S scan counts in /metrics. Runs in its
+     * OWN transaction, after {@link #markScanTaskFinished(long)} — a telemetry failure
+     * must never block the finished flag the polling JSP depends on. Idempotent across
+     * retries: the pre-generated {@link #runId} is the primary key, and each attempt
+     * checks for an existing row first (a commit that failed on the client side but
+     * landed in the database would otherwise double-count on retry). After 3 failed
+     * attempts the record is dropped and logged (metrics undercount this run).
+     */
+    private void persistScanRecord(long startedAt, long finishedAt, boolean grothOk,
+        boolean i3sOk) {
+        for (int attempt = 1; attempt <= 3; attempt++) {
+            Shepherd sh = new Shepherd(context);
+            sh.setAction("GrothScanRunnable.persistScanRecord");
+            sh.beginDBTransaction();
+            boolean ok = false;
+            try {
+                boolean exists = true;
+                try {
+                    sh.getPM().getObjectById(
+                        sh.getPM().newObjectIdInstance(ScanRecord.class, runId), true);
+                } catch (Exception notFound) {
+                    exists = false;
+                }
+                if (!exists) {
+                    sh.getPM().makePersistent(new ScanRecord(runId, taskID, encNumber,
+                        rightScan, startedAt, finishedAt, grothOk, i3sOk));
+                }
+                ok = sh.commitDBTransactionWithStatus();
+            } catch (Exception e) {
+                log.severe("Error persisting ScanRecord " + runId + " for task " + taskID +
+                    " (attempt " + attempt + "): " + e.getMessage());
+                ok = false;
+            } finally {
+                if (!ok) {
+                    try { sh.rollbackDBTransaction(); } catch (Exception ignore) {}
+                }
+                sh.closeDBTransaction();
+            }
+            if (ok) return;
+        }
+        log.warning("Failed to persist ScanRecord " + runId + " for task " + taskID +
+            " after retries; scan metrics will undercount this run.");
     }
 }

--- a/src/main/resources/org/ecocean/grid/package.jdo
+++ b/src/main/resources/org/ecocean/grid/package.jdo
@@ -36,9 +36,24 @@
 			</field>
 
 			<fetch-group name="count"/>
-            
-            
+
+
         </class>
-        
+
+        <class name="ScanRecord" identity-type="application">
+            <field name="id" primary-key="true">
+                <column length="36"/>
+            </field>
+            <field name="taskID">
+                <column length="100"/>
+            </field>
+            <field name="encounterNumber">
+                <column length="100"/>
+            </field>
+            <field name="endTime">
+                <index name="SCANRECORD_ENDTIME_idx"/>
+            </field>
+        </class>
+
     </package>
 </jdo>

--- a/src/test/java/org/ecocean/grid/ScanRecordTest.java
+++ b/src/test/java/org/ecocean/grid/ScanRecordTest.java
@@ -1,0 +1,49 @@
+package org.ecocean.grid;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the field semantics of {@link ScanRecord}, the per-run metrics row written by
+ * GrothScanRunnable and counted by MetricsBot (wildbook_tasks_modifiedGroth,
+ * wildbook_tasks_i3s, and the identification_tasks_completed_last24 aggregate).
+ */
+class ScanRecordTest {
+    @Test
+    void constructorMapsAllFields() {
+        ScanRecord r = new ScanRecord("uuid-1", "scanR123", "123", true,
+            1000L, 2000L, true, false);
+        assertEquals("uuid-1", r.getId());
+        assertEquals("scanR123", r.getTaskID());
+        assertEquals("123", r.getEncounterNumber());
+        assertTrue(r.isRightSide(), "rightSide should map from constructor");
+        assertEquals(1000L, r.getStartTime());
+        assertEquals(2000L, r.getEndTime());
+        assertTrue(r.isGrothSuccess(), "grothSuccess should map from constructor");
+        assertFalse(r.isI3sSuccess(), "i3sSuccess should map from constructor");
+    }
+
+    @Test
+    void successFlagsAreIndependent() {
+        ScanRecord grothOnly = new ScanRecord("a", "scanL1", "1", false, 1L, 2L, true, false);
+        ScanRecord i3sOnly = new ScanRecord("b", "scanL1", "1", false, 1L, 2L, false, true);
+        ScanRecord failed = new ScanRecord("c", "scanL1", "1", false, 1L, 2L, false, false);
+        assertTrue(grothOnly.isGrothSuccess() && !grothOnly.isI3sSuccess(),
+            "groth-only run must not credit I3S");
+        assertTrue(!i3sOnly.isGrothSuccess() && i3sOnly.isI3sSuccess(),
+            "i3s-only run must not credit Groth");
+        assertFalse(failed.isGrothSuccess() || failed.isI3sSuccess(),
+            "failed run credits neither algorithm");
+    }
+
+    @Test
+    void jdoEnhancerNoArgConstructorExists() {
+        // The JDO enhancer requires a no-arg constructor; deleting it breaks
+        // persistence at runtime only, so pin it here at compile/test time.
+        assertNotNull(new ScanRecord());
+    }
+}


### PR DESCRIPTION
## What

`/metrics` (MetricsBot) counted re-ID jobs exclusively from `org.ecocean.ia.Task`, so Modified Groth and I3S spot-pattern scans — which run through `GrothMatchServlet`/`GrothScanRunnable` and `org.ecocean.grid.ScanTask` — were invisible: no per-algorithm gauge, and no contribution to `wildbook_identification_tasks_completed_last24`. Installs with heavy spot-matching usage (e.g. Sharkbook) undercount their re-ID activity.

This PR:

- adds `org.ecocean.grid.ScanRecord`: one immutable row per **completed scan run**, written by `GrothScanRunnable` at its terminal step, carrying per-algorithm success flags (one run executes BOTH matchers; each result-XML write is tracked separately)
- adds two cumulative gauges, parallel to the existing `wildbook_tasks_*` family:
  - `wildbook_tasks_modifiedGroth` — successful Modified Groth scan tasks
  - `wildbook_tasks_i3s` — successful I3S scan tasks
- makes successful spot scans contribute to `wildbook_identification_tasks_completed_last24` (a dual-algorithm run counts **once** in the aggregate — it is one re-ID job; the per-algorithm gauges report them individually)

## Why a new row-per-run class

`ScanTask` rows cannot be counted: the id is `scan{L|R}{encounterNumber}` — one row per encounter side, **reused and reset on every rerun** — so `count(ScanTask)` counts distinct encounter sides ever scanned, not scans run. `isFinished` also doesn't mean success (the runnable's `finally` marks the task finished even on failure so the polling JSP stops).

## Design notes

- **Success signals:** `grothSuccess` = the Groth result XML was written; `i3sSuccess` = `I3SResultWriter.write(...)`'s boolean return value (it catches internally and returns false — an exception-based flag would overcount). An I3S-only write failure no longer voids the already-written Groth result.
- **Never blocks scan completion:** the record persists in its own retry transaction after `markScanTaskFinished`; a telemetry failure is logged and dropped.
- **Idempotent inserts:** a run-scoped UUID (generated once per run) is the primary key; each retry attempt checks for an existing row before insert, so a commit that failed client-side but landed in PostgreSQL can't double-count.
- **Failed runs are recorded** (both flags false) for observability; all gauges filter on the success flags.
- Schema auto-creates via DataNucleus (`datanucleus.schema.autoCreateAll=true`); `endTime` is indexed for the hourly last-24h count.
- Gauges start at 0 on deploy — historical scans left no per-run rows; no backfill is possible.
- `wildbook_identification_tasks_added_last24` is deliberately unchanged: records exist only at completion, and scans complete in minutes.
- The dead async grid path (`WriteOutScanTask`) is intentionally not instrumented.

## Testing

- New `ScanRecordTest` (field mapping, independent success flags, JDO no-arg constructor).
- Existing `GrothMatchServletTest` (10 tests) passes; eligibility logic untouched.
- Design and implementation reviewed by Codex (converged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
