### PR TITLE
fix(social): relationship delete/edit broke on the datastore-identity persistenceID

### DIFF
--- a/src/main/java/org/ecocean/servlet/RelationshipCreate.java
+++ b/src/main/java/org/ecocean/servlet/RelationshipCreate.java
@@ -31,6 +31,7 @@ public class RelationshipCreate extends HttpServlet {
         response.setContentType("text/html");
         PrintWriter out = response.getWriter();
         boolean createThisRelationship = false;
+        boolean serverError = false;
 
         System.out.println("RelationshipCreate: " + request.getQueryString());
         if ((request.getParameter("markedIndividualName1") != null) &&
@@ -61,9 +62,16 @@ public class RelationshipCreate extends HttpServlet {
                         rel = myShepherd.getRelationship(request.getParameter("persistenceID"));
                         if (rel == null) {
                             myShepherd.rollbackDBTransaction();
-                            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-                            out.println(
-                                "<strong>Failure:</strong> The relationship to edit was not found. It may have been deleted.");
+                            if (Shepherd.parseRelationshipKey(request.getParameter(
+                                "persistenceID")) == null) {
+                                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                                out.println(
+                                    "<strong>Failure:</strong> That is not a valid relationship id.");
+                            } else {
+                                response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                                out.println(
+                                    "<strong>Failure:</strong> The relationship to edit was not found. It may have been deleted.");
+                            }
                             out.close();
                             return;
                         }
@@ -156,6 +164,7 @@ public class RelationshipCreate extends HttpServlet {
                 }
             } catch (Exception e) {
                 myShepherd.rollbackDBTransaction();
+                serverError = true;
                 e.printStackTrace();
             } finally {
                 myShepherd.closeDBTransaction();
@@ -172,7 +181,9 @@ public class RelationshipCreate extends HttpServlet {
             } else {
                 out.println(
                     "<strong>Failure:</strong>  I could not create the relationship. Have your administrator check the log files for you to understand the problem.");
-                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                // a datastore/transaction failure is a server error, not the caller's bad request
+                response.setStatus(serverError ? HttpServletResponse.SC_INTERNAL_SERVER_ERROR :
+                    HttpServletResponse.SC_BAD_REQUEST);
             }
             // out.println("<p><a href=\""+request.getScheme()+"://" + CommonConfiguration.getURLLocation(request) +
             // "/individuals.jsp?number="+request.getParameter("markedIndividualName1")+ "\">Return to Marked Individual

--- a/src/main/java/org/ecocean/servlet/RelationshipCreate.java
+++ b/src/main/java/org/ecocean/servlet/RelationshipCreate.java
@@ -172,7 +172,7 @@ public class RelationshipCreate extends HttpServlet {
             }
             // output success statement
             // out.println(ServletUtilities.getHeader(request));
-            if (createThisRelationship) {
+            if (createThisRelationship && !serverError) {
                 response.setStatus(HttpServletResponse.SC_OK);
                 out.println("<strong>Success:</strong> A relationship of type " +
                     request.getParameter("type") + " was created between " +

--- a/src/main/java/org/ecocean/servlet/RelationshipCreate.java
+++ b/src/main/java/org/ecocean/servlet/RelationshipCreate.java
@@ -42,7 +42,7 @@ public class RelationshipCreate extends HttpServlet {
             Shepherd myShepherd = new Shepherd(context);
             myShepherd.setAction("RelationshipCreate.class");
 
-            Relationship rel = new Relationship();
+            Relationship rel = null;
             SocialUnit comm = new SocialUnit();
 
             myShepherd.beginDBTransaction();
@@ -58,11 +58,15 @@ public class RelationshipCreate extends HttpServlet {
                         request.getParameter("markedIndividualName2"));
                     if ((request.getParameter("persistenceID") != null) &&
                         (!request.getParameter("persistenceID").equals(""))) {
-                        // Object identity = myShepherd.getPM().newObjectIdInstance(org.ecocean.social.Relationship.class,
-                        // request.getParameter("persistenceID"));
-                        // rel=(Relationship)myShepherd.getPM().getObjectById(identity);
-                        rel = (Relationship)myShepherd.getPM().getObjectById(Relationship.class,
-                            request.getParameter("persistenceID"));
+                        rel = myShepherd.getRelationship(request.getParameter("persistenceID"));
+                        if (rel == null) {
+                            myShepherd.rollbackDBTransaction();
+                            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                            out.println(
+                                "<strong>Failure:</strong> The relationship to edit was not found. It may have been deleted.");
+                            out.close();
+                            return;
+                        }
                     } else {
                         rel = new Relationship(request.getParameter("type"), individual1,
                             individual2);

--- a/src/main/java/org/ecocean/servlet/RelationshipDelete.java
+++ b/src/main/java/org/ecocean/servlet/RelationshipDelete.java
@@ -35,14 +35,9 @@ public class RelationshipDelete extends HttpServlet {
             Shepherd myShepherd = new Shepherd(context);
             myShepherd.setAction("RelationshipDelete.class");
 
-            Relationship rel = new Relationship();
-
             myShepherd.beginDBTransaction();
             try {
-                // rel=((Relationship) (myShepherd.getPM().getObjectById(myShepherd.getPM().newObjectIdInstance(Relationship.class,
-                // request.getParameter("persistenceID")), true)));
-
-                rel = (Relationship)myShepherd.getPM().getObjectById(Relationship.class,
+                Relationship rel = myShepherd.getRelationship(
                     request.getParameter("persistenceID"));
                 if (rel != null) {
                     myShepherd.getPM().deletePersistent(rel);
@@ -51,17 +46,22 @@ public class RelationshipDelete extends HttpServlet {
                         request.getParameter("type") + " between " +
                         request.getParameter("markedIndividualName1") + " and " +
                         request.getParameter("markedIndividualName2") + " was deleted.");
+                } else {
+                    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                    out.println(
+                        "<strong>Failure:</strong> The relationship to delete was not found. It may have already been deleted.");
                 }
             } catch (Exception e) {
+                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 out.println(
-                    "<strong>Failure:</strong> I did not have all of the information required.");
+                    "<strong>Failure:</strong> The relationship could not be deleted due to a server error. Have your administrator check the log files.");
                 e.printStackTrace();
             } finally {
                 myShepherd.rollbackAndClose();
                 out.close();
-                return;
             }
         } else {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             out.println(
                 "<strong>Failure:</strong> I did not have all of the information required.");
             out.close();

--- a/src/main/java/org/ecocean/servlet/RelationshipDelete.java
+++ b/src/main/java/org/ecocean/servlet/RelationshipDelete.java
@@ -46,6 +46,11 @@ public class RelationshipDelete extends HttpServlet {
                         request.getParameter("type") + " between " +
                         request.getParameter("markedIndividualName1") + " and " +
                         request.getParameter("markedIndividualName2") + " was deleted.");
+                } else if (Shepherd.parseRelationshipKey(request.getParameter("persistenceID")) ==
+                    null) {
+                    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    out.println(
+                        "<strong>Failure:</strong> That is not a valid relationship id.");
                 } else {
                     response.setStatus(HttpServletResponse.SC_NOT_FOUND);
                     out.println(

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -821,6 +821,25 @@ public class Shepherd {
         return filteredSpaces;
     }
 
+    // Relationship uses JDO datastore identity (a bigint surrogate key); the social UI submits
+    // the full identity string, e.g. "1011[OID]org.ecocean.social.Relationship". Accepts that
+    // form or a bare numeric key; returns null (never throws) for anything else or a missing row.
+    public Relationship getRelationship(String persistenceID) {
+        if (persistenceID == null) return null;
+        String key = persistenceID.trim();
+        String oidSuffix = "[OID]" + Relationship.class.getName();
+        if (key.endsWith(oidSuffix)) key = key.substring(0, key.length() - oidSuffix.length());
+        if (!key.matches("\\d+")) return null;
+        try {
+            return (Relationship)pm.getObjectById(pm.newObjectIdInstance(Relationship.class,
+                Long.valueOf(key)), true);
+        } catch (Exception e) {
+            System.out.println("Shepherd.getRelationship(" + persistenceID + ") found nothing: " +
+                e);
+            return null;
+        }
+    }
+
     public Relationship getRelationship(String type, String indie1, String indie2) {
         Relationship tempRel = null;
         String filter = "this.type == \"" + type + "\" && ((this.markedIndividualName1 == \"" +

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -823,17 +823,31 @@ public class Shepherd {
 
     // Relationship uses JDO datastore identity (a bigint surrogate key); the social UI submits
     // the full identity string, e.g. "1011[OID]org.ecocean.social.Relationship". Accepts that
-    // form or a bare numeric key; returns null (never throws) for anything else or a missing row.
-    public Relationship getRelationship(String persistenceID) {
+    // form or a bare numeric key; returns null for anything else, so callers can answer 400 for
+    // malformed input before ever touching the datastore.
+    public static Long parseRelationshipKey(String persistenceID) {
         if (persistenceID == null) return null;
         String key = persistenceID.trim();
         String oidSuffix = "[OID]" + Relationship.class.getName();
         if (key.endsWith(oidSuffix)) key = key.substring(0, key.length() - oidSuffix.length());
         if (!key.matches("\\d+")) return null;
         try {
-            return (Relationship)pm.getObjectById(pm.newObjectIdInstance(Relationship.class,
-                Long.valueOf(key)), true);
-        } catch (Exception e) {
+            return Long.valueOf(key);
+        } catch (NumberFormatException e) { // all digits but beyond Long range
+            return null;
+        }
+    }
+
+    // Null means malformed id or no such row; datastore/transaction failures still throw so
+    // callers don't report an outage as a stale record.
+    public Relationship getRelationship(String persistenceID) {
+        Long key = parseRelationshipKey(persistenceID);
+
+        if (key == null) return null;
+        try {
+            return (Relationship)pm.getObjectById(pm.newObjectIdInstance(Relationship.class, key),
+                true);
+        } catch (JDOObjectNotFoundException e) {
             System.out.println("Shepherd.getRelationship(" + persistenceID + ") found nothing: " +
                 e);
             return null;

--- a/src/test/java/org/ecocean/servlet/RelationshipCreateEditServletDbTest.java
+++ b/src/test/java/org/ecocean/servlet/RelationshipCreateEditServletDbTest.java
@@ -19,6 +19,7 @@ import org.ecocean.social.Relationship;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -33,6 +34,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * persistenceID -> 404 Failure, nothing changed, transaction rolled back.
  */
 @Testcontainers
+@ResourceLock("wildbook.context0.pmf") // all classes share the static context0 PMF cache
 class RelationshipCreateEditServletDbTest {
     @Container
     static PostgreSQLContainer<?> postgres =
@@ -154,6 +156,15 @@ class RelationshipCreateEditServletDbTest {
         assertEquals(HttpServletResponse.SC_NOT_FOUND, r.status, "body: " + r.body);
         assertTrue(r.body.contains("Failure"), "failure body routes to the JSP .fail(): "
             + r.body);
+        assertEquals(before, persistedType(), "a failed edit must not alter the row");
+    }
+
+    @Test void editWithMalformedPersistenceIdReports400AndChangesNothing() throws Exception {
+        String before = persistedType();
+        Response r = postEdit("abc", "poisoned");
+
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, r.status,
+            "malformed input is a bad request, not a stale record; body: " + r.body);
         assertEquals(before, persistedType(), "a failed edit must not alter the row");
     }
 }

--- a/src/test/java/org/ecocean/servlet/RelationshipCreateEditServletDbTest.java
+++ b/src/test/java/org/ecocean/servlet/RelationshipCreateEditServletDbTest.java
@@ -1,0 +1,159 @@
+package org.ecocean.servlet;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Properties;
+import javax.jdo.JDOHelper;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.ecocean.CommonConfiguration;
+import org.ecocean.Encounter;
+import org.ecocean.MarkedIndividual;
+import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.shepherd.core.TestPMFUtil;
+import org.ecocean.social.Relationship;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * RelationshipCreate's EDIT path (persistenceID present) had the same datastore-identity bug as
+ * RelationshipDelete: the "<n>[OID]org.ecocean.social.Relationship" id the UI posts hit
+ * Long.parseLong and threw, so every edit failed. Worse, rel was pre-initialized to
+ * new Relationship(), so a null lookup would silently "edit" an unpersisted throwaway object.
+ *
+ * Contract: valid persistenceID -> the persisted row is updated, 200; stale/unknown
+ * persistenceID -> 404 Failure, nothing changed, transaction rolled back.
+ */
+@Testcontainers
+class RelationshipCreateEditServletDbTest {
+    @Container
+    static PostgreSQLContainer<?> postgres =
+        new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("wildbook_test")
+            .withUsername("wildbook")
+            .withPassword("wildbook");
+
+    static String oidString;
+    static String ind1Id; // real (UUID) individual PKs -- the constructor's string arg is a NAME
+    static String ind2Id;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        CommonConfiguration.initialize("context0", new Properties());
+
+        Properties props = new Properties();
+        props.setProperty("datanucleus.ConnectionUserName", postgres.getUsername());
+        props.setProperty("datanucleus.ConnectionPassword", postgres.getPassword());
+        props.setProperty("datanucleus.ConnectionDriverName", postgres.getDriverClassName());
+        props.setProperty("datanucleus.ConnectionURL", postgres.getJdbcUrl());
+        props.setProperty("datanucleus.schema.autoCreateTables", "true");
+        TestPMFUtil.closePMF("context0");
+
+        Shepherd sh = new Shepherd("context0", props);
+        try {
+            sh.beginDBTransaction();
+            ind1Id = storeIndividual(sh, "rel-ind-1");
+            ind2Id = storeIndividual(sh, "rel-ind-2");
+            Relationship rel = new Relationship();
+            rel.setType("familial");
+            rel.setMarkedIndividualName1(ind1Id);
+            rel.setMarkedIndividualName2(ind2Id);
+            sh.getPM().makePersistent(rel);
+            oidString = JDOHelper.getObjectId(rel).toString();
+            sh.commitDBTransaction();
+        } catch (Exception e) {
+            sh.rollbackDBTransaction();
+            throw e;
+        } finally {
+            sh.closeDBTransaction();
+        }
+    }
+
+    @AfterAll
+    static void tearDown() {
+        TestPMFUtil.closePMF("context0");
+    }
+
+    private static String storeIndividual(Shepherd sh, String name) {
+        Encounter enc = new Encounter();
+
+        // keep postStore from enqueueing IndexingManager work: its worker PMs hold open
+        // transactions that make tearDown's closePMF fail and leak this class's PMF into
+        // whatever Testcontainers class runs next
+        enc.setSkipAutoIndexing(true);
+        sh.storeNewEncounter(enc);
+        MarkedIndividual indiv = new MarkedIndividual(name, enc);
+        indiv.setSkipAutoIndexing(true);
+        sh.storeNewMarkedIndividual(indiv);
+        return indiv.getId();
+    }
+
+    private static class Response {
+        int status = HttpServletResponse.SC_OK;
+        String body;
+    }
+
+    private Response postEdit(String persistenceID, String newType) throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        when(request.getParameter("context")).thenReturn("context0");
+        when(request.getParameter("persistenceID")).thenReturn(persistenceID);
+        when(request.getParameter("type")).thenReturn(newType);
+        when(request.getParameter("markedIndividualName1")).thenReturn(ind1Id);
+        when(request.getParameter("markedIndividualName2")).thenReturn(ind2Id);
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(out));
+        Response result = new Response();
+        doAnswer(inv -> {
+            result.status = inv.getArgument(0);
+            return null;
+        }).when(response).setStatus(anyInt());
+
+        new RelationshipCreate().doPost(request, response);
+        result.body = out.toString();
+        return result;
+    }
+
+    private String persistedType() {
+        Shepherd sh = new Shepherd("context0");
+
+        sh.setAction("RelationshipCreateEditServletDbTest");
+        sh.beginDBTransaction();
+        try {
+            Relationship rel = sh.getRelationship(oidString);
+            assertNotNull(rel, "the seeded relationship exists");
+            return rel.getType();
+        } finally {
+            sh.rollbackDBTransaction();
+            sh.closeDBTransaction();
+        }
+    }
+
+    @Test void editWithValidPersistenceIdUpdatesThePersistedRow() throws Exception {
+        Response r = postEdit(oidString, "matriline");
+
+        assertEquals(HttpServletResponse.SC_OK, r.status, "body: " + r.body);
+        assertEquals("matriline", persistedType(),
+            "the edit reaches the persisted row, not a detached throwaway object");
+    }
+
+    @Test void editWithStalePersistenceIdReports404AndChangesNothing() throws Exception {
+        String before = persistedType();
+        Response r = postEdit("999999999[OID]org.ecocean.social.Relationship", "poisoned");
+
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, r.status, "body: " + r.body);
+        assertTrue(r.body.contains("Failure"), "failure body routes to the JSP .fail(): "
+            + r.body);
+        assertEquals(before, persistedType(), "a failed edit must not alter the row");
+    }
+}

--- a/src/test/java/org/ecocean/servlet/RelationshipDeleteServletDbTest.java
+++ b/src/test/java/org/ecocean/servlet/RelationshipDeleteServletDbTest.java
@@ -17,6 +17,7 @@ import org.ecocean.social.Relationship;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -32,6 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * row) -> 404 Failure so the JSP's .fail() handler shows the error; blank/missing param -> 400.
  */
 @Testcontainers
+@ResourceLock("wildbook.context0.pmf") // all classes share the static context0 PMF cache
 class RelationshipDeleteServletDbTest {
     @Container
     static PostgreSQLContainer<?> postgres =
@@ -148,6 +150,14 @@ class RelationshipDeleteServletDbTest {
         Response r = post("");
 
         assertEquals(HttpServletResponse.SC_BAD_REQUEST, r.status);
+        assertTrue(r.body.contains("Failure"), "body: " + r.body);
+    }
+
+    @Test void malformedPersistenceIdReports400Not404() throws Exception {
+        Response r = post("abc");
+
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, r.status,
+            "malformed input is a bad request, not a stale record; body: " + r.body);
         assertTrue(r.body.contains("Failure"), "body: " + r.body);
     }
 }

--- a/src/test/java/org/ecocean/servlet/RelationshipDeleteServletDbTest.java
+++ b/src/test/java/org/ecocean/servlet/RelationshipDeleteServletDbTest.java
@@ -1,0 +1,153 @@
+package org.ecocean.servlet;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Properties;
+import javax.jdo.JDOHelper;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.ecocean.CommonConfiguration;
+import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.shepherd.core.TestPMFUtil;
+import org.ecocean.social.Relationship;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * End-to-end contract of RelationshipDelete against real DataNucleus + Postgres, pinning the
+ * production regression where the persistenceID the UI posts
+ * ("1011[OID]org.ecocean.social.Relationship") blew up in Long.parseLong at the bigint bind,
+ * so every delete failed with a misleading "not enough information" message and HTTP 200 --
+ * which the JSP's $.post success handler then treated as success.
+ *
+ * Contract: found -> delete + 200 Success; not found (including a second delete of the same
+ * row) -> 404 Failure so the JSP's .fail() handler shows the error; blank/missing param -> 400.
+ */
+@Testcontainers
+class RelationshipDeleteServletDbTest {
+    @Container
+    static PostgreSQLContainer<?> postgres =
+        new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("wildbook_test")
+            .withUsername("wildbook")
+            .withPassword("wildbook");
+
+    static String oidString;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        CommonConfiguration.initialize("context0", new Properties());
+
+        Properties props = new Properties();
+        props.setProperty("datanucleus.ConnectionUserName", postgres.getUsername());
+        props.setProperty("datanucleus.ConnectionPassword", postgres.getPassword());
+        props.setProperty("datanucleus.ConnectionDriverName", postgres.getDriverClassName());
+        props.setProperty("datanucleus.ConnectionURL", postgres.getJdbcUrl());
+        props.setProperty("datanucleus.schema.autoCreateTables", "true");
+        TestPMFUtil.closePMF("context0");
+
+        Shepherd sh = new Shepherd("context0", props);
+        try {
+            sh.beginDBTransaction();
+            Relationship rel = new Relationship();
+            rel.setType("familial");
+            rel.setMarkedIndividualName1("indiv-one");
+            rel.setMarkedIndividualName2("indiv-two");
+            sh.getPM().makePersistent(rel);
+            oidString = JDOHelper.getObjectId(rel).toString();
+            sh.commitDBTransaction();
+        } catch (Exception e) {
+            sh.rollbackDBTransaction();
+            throw e;
+        } finally {
+            sh.closeDBTransaction();
+        }
+    }
+
+    @AfterAll
+    static void tearDown() {
+        TestPMFUtil.closePMF("context0");
+    }
+
+    private static class Response {
+        int status = HttpServletResponse.SC_OK; // servlet container default when never set
+        String body;
+    }
+
+    private Response post(String persistenceID) throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        when(request.getParameter("context")).thenReturn("context0");
+        when(request.getParameter("persistenceID")).thenReturn(persistenceID);
+        when(request.getParameter("type")).thenReturn("familial");
+        when(request.getParameter("markedIndividualName1")).thenReturn("indiv-one");
+        when(request.getParameter("markedIndividualName2")).thenReturn("indiv-two");
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        StringWriter out = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(out));
+        Response result = new Response();
+        doAnswer(inv -> {
+            result.status = inv.getArgument(0);
+            return null;
+        }).when(response).setStatus(anyInt());
+
+        new RelationshipDelete().doPost(request, response);
+        result.body = out.toString();
+        return result;
+    }
+
+    private Relationship find(String persistenceID) {
+        Shepherd sh = new Shepherd("context0");
+
+        sh.setAction("RelationshipDeleteServletDbTest");
+        sh.beginDBTransaction();
+        try {
+            return sh.getRelationship(persistenceID);
+        } finally {
+            sh.rollbackDBTransaction();
+            sh.closeDBTransaction();
+        }
+    }
+
+    @Test void deleteSucceedsThenSecondDeleteReports404() throws Exception {
+        Response first = post(oidString);
+
+        assertEquals(HttpServletResponse.SC_OK, first.status,
+            "deleting an existing relationship succeeds");
+        assertTrue(first.body.contains("Success"), "success body for the JSP handler: "
+            + first.body);
+        assertNull(find(oidString), "the row is actually gone");
+
+        Response second = post(oidString);
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, second.status,
+            "a second delete of the same relationship (e.g. double-click race) reports not-found");
+        assertTrue(second.body.contains("Failure"), "failure body routes to the JSP .fail(): "
+            + second.body);
+    }
+
+    @Test void unknownRelationshipReports404NotMisleadingSuccess() throws Exception {
+        Response r = post("999999999[OID]org.ecocean.social.Relationship");
+
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, r.status);
+        assertTrue(r.body.contains("Failure"), "body: " + r.body);
+        assertTrue(r.body.contains("not") && r.body.toLowerCase().contains("found"),
+            "the message says the relationship was not found, not 'missing information': "
+            + r.body);
+    }
+
+    @Test void blankPersistenceIdReports400() throws Exception {
+        Response r = post("");
+
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, r.status);
+        assertTrue(r.body.contains("Failure"), "body: " + r.body);
+    }
+}

--- a/src/test/java/org/ecocean/shepherd/ShepherdGetRelationshipDbTest.java
+++ b/src/test/java/org/ecocean/shepherd/ShepherdGetRelationshipDbTest.java
@@ -11,6 +11,7 @@ import org.ecocean.social.Relationship;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -26,6 +27,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * test can't catch this: the bug lives in how DataNucleus interprets the id argument.
  */
 @Testcontainers
+@ResourceLock("wildbook.context0.pmf") // all classes share the static context0 PMF cache
 class ShepherdGetRelationshipDbTest {
     @Container
     static PostgreSQLContainer<?> postgres =

--- a/src/test/java/org/ecocean/shepherd/ShepherdGetRelationshipDbTest.java
+++ b/src/test/java/org/ecocean/shepherd/ShepherdGetRelationshipDbTest.java
@@ -1,0 +1,130 @@
+package org.ecocean.shepherd;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Properties;
+import javax.jdo.JDOHelper;
+import org.ecocean.CommonConfiguration;
+import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.shepherd.core.TestPMFUtil;
+import org.ecocean.social.Relationship;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Pins Shepherd.getRelationship(persistenceID) against real DataNucleus + Postgres.
+ *
+ * Relationship uses JDO datastore identity (a bigint surrogate key), and the social UI
+ * (individuals.jsp) submits the FULL identity string -- "1011[OID]org.ecocean.social.Relationship"
+ * -- as the persistenceID parameter. The old servlet shorthand
+ * pm.getObjectById(Relationship.class, thatString) treated the whole string as the numeric key,
+ * so every relationship delete/edit died with NumberFormatException at the bigint bind. A mock
+ * test can't catch this: the bug lives in how DataNucleus interprets the id argument.
+ */
+@Testcontainers
+class ShepherdGetRelationshipDbTest {
+    @Container
+    static PostgreSQLContainer<?> postgres =
+        new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("wildbook_test")
+            .withUsername("wildbook")
+            .withPassword("wildbook");
+
+    static String oidString; // "<n>[OID]org.ecocean.social.Relationship", as individuals.jsp sends
+    static String bareKey;   // "<n>"
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        CommonConfiguration.initialize("context0", new Properties());
+
+        Properties props = new Properties();
+        props.setProperty("datanucleus.ConnectionUserName", postgres.getUsername());
+        props.setProperty("datanucleus.ConnectionPassword", postgres.getPassword());
+        props.setProperty("datanucleus.ConnectionDriverName", postgres.getDriverClassName());
+        props.setProperty("datanucleus.ConnectionURL", postgres.getJdbcUrl());
+        props.setProperty("datanucleus.schema.autoCreateTables", "true");
+        TestPMFUtil.closePMF("context0");
+
+        Shepherd sh = new Shepherd("context0", props);
+        try {
+            sh.beginDBTransaction();
+            Relationship rel = new Relationship();
+            rel.setType("familial");
+            rel.setMarkedIndividualName1("indiv-one");
+            rel.setMarkedIndividualName2("indiv-two");
+            sh.getPM().makePersistent(rel);
+            oidString = JDOHelper.getObjectId(rel).toString();
+            sh.commitDBTransaction();
+        } catch (Exception e) {
+            sh.rollbackDBTransaction();
+            throw e;
+        } finally {
+            sh.closeDBTransaction();
+        }
+        assertTrue(oidString.endsWith("[OID]org.ecocean.social.Relationship"),
+            "datastore identity toString has the [OID] form the JSP reconstructs: " + oidString);
+        bareKey = oidString.substring(0, oidString.indexOf("[OID]"));
+    }
+
+    @AfterAll
+    static void tearDown() {
+        TestPMFUtil.closePMF("context0");
+    }
+
+    // Returns null if not found, else {type, markedIndividualName1}. Fields are read INSIDE the
+    // transaction: after rollback+close the instance is hollow and its fields read back null.
+    private String[] lookup(String persistenceID) {
+        Shepherd sh = new Shepherd("context0");
+
+        sh.setAction("ShepherdGetRelationshipDbTest");
+        sh.beginDBTransaction();
+        try {
+            Relationship rel = sh.getRelationship(persistenceID);
+            if (rel == null) return null;
+            return new String[] { rel.getType(), rel.getMarkedIndividualName1() };
+        } finally {
+            sh.rollbackDBTransaction();
+            sh.closeDBTransaction();
+        }
+    }
+
+    @Test void findsByFullOidStringTheUiSubmits() {
+        String[] found = lookup(oidString);
+
+        assertNotNull(found, "the exact persistenceID individuals.jsp posts must resolve");
+        assertEquals("familial", found[0]);
+        assertEquals("indiv-one", found[1]);
+    }
+
+    @Test void findsByBareNumericKey() {
+        String[] found = lookup(bareKey);
+
+        assertNotNull(found, "a bare datastore key must also resolve");
+        assertEquals("familial", found[0]);
+    }
+
+    @Test void returnsNullForMissingRow() {
+        assertNull(lookup("999999999[OID]org.ecocean.social.Relationship"),
+            "a deleted/unknown relationship returns null instead of throwing");
+    }
+
+    @Test void returnsNullForGarbageAndNull() {
+        assertNull(lookup("not-a-number"), "garbage input returns null instead of throwing");
+        assertNull(lookup(null), "null input returns null");
+    }
+
+    @Test void toleratesSurroundingWhitespace() {
+        assertNotNull(lookup("  " + oidString + " \t"),
+            "a whitespace-padded but otherwise valid id resolves");
+        assertNull(lookup("   "), "a whitespace-only id returns null");
+    }
+
+    @Test void rejectsOidStringForAnotherClass() {
+        assertNull(lookup(bareKey + "[OID]org.ecocean.Encounter"),
+            "an [OID] string naming a different class is not accepted as a Relationship key");
+    }
+}

--- a/src/test/java/org/ecocean/shepherd/ShepherdParseRelationshipKeyTest.java
+++ b/src/test/java/org/ecocean/shepherd/ShepherdParseRelationshipKeyTest.java
@@ -1,0 +1,48 @@
+package org.ecocean.shepherd;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.ecocean.shepherd.core.Shepherd;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure parsing contract for Shepherd.parseRelationshipKey -- the piece that turns the
+ * persistenceID the social UI submits ("1011[OID]org.ecocean.social.Relationship", or a bare
+ * numeric key) into a datastore key. Null means "not a well-formed Relationship id", which the
+ * servlets answer with 400, as opposed to a well-formed id whose row is gone (404).
+ */
+class ShepherdParseRelationshipKeyTest {
+    @Test void parsesTheFullOidStringTheUiSubmits() {
+        assertEquals(1011L, Shepherd.parseRelationshipKey(
+            "1011[OID]org.ecocean.social.Relationship"));
+    }
+
+    @Test void parsesABareNumericKey() {
+        assertEquals(7L, Shepherd.parseRelationshipKey("7"));
+    }
+
+    @Test void toleratesSurroundingWhitespace() {
+        assertEquals(1011L, Shepherd.parseRelationshipKey(
+            "  1011[OID]org.ecocean.social.Relationship \t"));
+    }
+
+    @Test void rejectsMalformedInput() {
+        assertNull(Shepherd.parseRelationshipKey(null));
+        assertNull(Shepherd.parseRelationshipKey(""));
+        assertNull(Shepherd.parseRelationshipKey("   "));
+        assertNull(Shepherd.parseRelationshipKey("abc"));
+        assertNull(Shepherd.parseRelationshipKey("12abc"));
+        assertNull(Shepherd.parseRelationshipKey("-5"));
+    }
+
+    @Test void rejectsAnOidStringForAnotherClass() {
+        assertNull(Shepherd.parseRelationshipKey("1011[OID]org.ecocean.Encounter"));
+        assertNull(Shepherd.parseRelationshipKey("1011[OID]anything"));
+    }
+
+    @Test void rejectsDigitsBeyondLongRange() {
+        assertNull(Shepherd.parseRelationshipKey("99999999999999999999999999"));
+        assertNull(Shepherd.parseRelationshipKey(
+            "99999999999999999999999999[OID]org.ecocean.social.Relationship"));
+    }
+}


### PR DESCRIPTION
Fixes #1731

## What

Relationship delete and edit have been broken for every user: both answered a misleading failure (or false success) because the servlet lookup could not parse the id the UI submits.

`Relationship` is a JDO **datastore-identity** class (`social/package.jdo`), and `individuals.jsp` posts the full identity string — `1011[OID]org.ecocean.social.Relationship` — as `persistenceID`. `RelationshipDelete` and `RelationshipCreate`'s edit path looked it up with:

```java
pm.getObjectById(Relationship.class, persistenceID)
```

which treats the whole string as the raw bigint key, so DataNucleus threw

```
java.lang.NumberFormatException: For input string: "1011[OID]org.ecocean.social.Relationship"
    at org.datanucleus.store.rdbms.mapping.column.BigIntColumnMapping.setObject(...)
    at org.ecocean.servlet.RelationshipDelete.doPost(RelationshipDelete.java:45)
```

on **every** delete/edit. The catch swallowed it and answered HTTP 200 + "I did not have all of the information required" — and since the JSP's `$.post` success handler reloads on any 2xx, the UI looked like it worked. (The previously-working `newObjectIdInstance(...)` call is still visible commented out directly above the broken line — a refactor regression.) Observed in production on Flukebook, 2026-08-19.

## How

- **`Shepherd.parseRelationshipKey(String)`** (new, static, pure): accepts the UI's `<n>[OID]org.ecocean.social.Relationship` form or a bare numeric key; `null` for anything else (another class's `[OID]` string, garbage, digits beyond `Long` range).
- **`Shepherd.getRelationship(String persistenceID)`** (new, matching the `getProject(id)` idiom): resolves a parsed key; returns `null` only for malformed input or a genuinely missing row (`JDOObjectNotFoundException`). Any other datastore/transaction failure **propagates**, so an outage can't masquerade as a stale record.
- **`RelationshipDelete`**: uses the new lookup. Not-found answers **404**, malformed id **400**, blank param **400**, real errors **500** — so the JSP's `.fail()` handler shows the failure instead of reloading as if it succeeded. A second delete of the same relationship (double-click race) gets the 404 path.
- **`RelationshipCreate` edit path**: uses the new lookup; a stale `persistenceID` rolls the transaction back and answers **404** (malformed → **400**). Previously `rel` was pre-initialized to `new Relationship()`, so a null lookup would have silently "edited" an unpersisted throwaway object. Also: a datastore failure now answers **500** instead of 400, and a failure *after* the relationship commit (community creation) no longer answers 200 Success.

## Tests

Three Testcontainers suites run the real stack (DataNucleus 5.2.7 + Postgres 15), because the bug lives in how DataNucleus interprets the id argument — mocks would pin the wrong layer — plus one pure unit suite:

- `ShepherdParseRelationshipKeyTest` (no containers) — the parsing contract: `[OID]` form, bare key, whitespace, wrong-class rejection, negatives, `Long` overflow.
- `ShepherdGetRelationshipDbTest` — lookup against the real datastore: `[OID]` form, bare key, whitespace tolerance, wrong-class `[OID]` rejection, missing row → null, garbage/null → null.
- `RelationshipDeleteServletDbTest` — delete succeeds (200) and the row is gone; second delete of the same id → 404 Failure; unknown id → 404 with a "not found" message (not the old misleading one); blank param → 400; malformed id → 400.
- `RelationshipCreateEditServletDbTest` — a valid edit updates the **persisted** row (200); a stale id → 404 and the row is untouched; malformed id → 400 and the row is untouched.

All servlet/DB tests were written first and watched fail against the unfixed servlets with exactly the production symptom (HTTP 200 + misleading body). The Testcontainers classes carry `@ResourceLock` on the shared `context0` PMF cache so an externally-enabled JUnit parallel mode can't race PMF eviction.

Codex adversarial review ran at design, implementation, and re-review stages; final verdict **converged** (its findings — outage-vs-404 exception discipline, 400-vs-404 taxonomy, PMF race, and the 200-after-partial-failure path in Create — are all addressed above).

## Out of scope (follow-ups)

- Neither servlet does an authorization check (adjacent to the known legacy-servlet ACL story).
- Deleting a Project doesn't scrub `projectContext` from `USERS.PREFERENCES`, which floods logs with `JDOObjectNotFoundException` from `MarkedIndividual.getDisplayName` for the affected user — diagnosed alongside this bug; separate issue.
- `Shepherd.getProject` prints a full stack trace for a routine not-found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

