### PR TITLE
Fix DataNucleus 5.2.7 malformed SQL in Encounter.findByAnnotation

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -3717,35 +3717,48 @@ public class Encounter extends Base implements java.io.Serializable {
         return LocationID.getPrefixDigitPaddingForLocationID(this.getLocationID(), null);
     }
 
-    public static Encounter findByAnnotation(Annotation annot, Shepherd myShepherd) {
-        String queryString =
-            "SELECT FROM org.ecocean.Encounter WHERE annotations.contains(ann) && ann.id =='" +
-            annot.getId() + "'";
-        Encounter returnEnc = null;
-        Query query = myShepherd.getPM().newQuery(queryString);
-        List results = (List)query.execute();
+    // Resolves parent encounter catalogNumbers via the ENCOUNTER_ANNOTATIONS join table
+    // with native SQL rather than a JDOQL annotations.contains() query: the JDOQL
+    // candidate query makes DataNucleus 5.2.7 bulk-fetch every default-fetch-group
+    // collection on Encounter, and it can emit malformed SQL for those statements
+    // (e.g. the measurements fetch), which PostgreSQL rejects.
+    private static List<String> findCatalogNumbersByAnnotationId(String annId,
+        Shepherd myShepherd) {
+        List<String> catalogNumbers = new ArrayList<String>();
 
-        if ((results != null) && (results.size() >= 1)) {
-            if (results.size() > 1)
-                System.out.println("WARNING: Encounter.findByAnnotation() found " + results.size() +
-                    " Encounters that contain Annotation " + annot.getId());
-            returnEnc = (Encounter)results.get(0);
+        if (annId == null) return catalogNumbers;
+        Query query = myShepherd.getPM().newQuery("javax.jdo.query.SQL",
+            "SELECT DISTINCT \"CATALOGNUMBER_OID\" FROM \"ENCOUNTER_ANNOTATIONS\" WHERE \"ID_EID\" = ?");
+        try {
+            List results = (List)query.execute(annId);
+            if (results != null)
+                for (Object o : results) {
+                    if (o != null) catalogNumbers.add((String)o);
+                }
+        } finally {
+            query.closeAll();
         }
-        query.closeAll();
-        return returnEnc;
+        return catalogNumbers;
+    }
+
+    public static Encounter findByAnnotation(Annotation annot, Shepherd myShepherd) {
+        if (annot == null) return null;
+        List<String> catalogNumbers = findCatalogNumbersByAnnotationId(annot.getId(), myShepherd);
+        if (catalogNumbers.isEmpty()) return null;
+        if (catalogNumbers.size() > 1)
+            System.out.println("WARNING: Encounter.findByAnnotation() found " +
+                catalogNumbers.size() + " Encounters that contain Annotation " + annot.getId());
+        return myShepherd.getEncounter(catalogNumbers.get(0));
     }
 
     /** All encounters whose annotations contain this annotation (usually 0 or 1; >1 is anomalous). */
     public static java.util.List<Encounter> findAllByAnnotation(Annotation annot, Shepherd myShepherd) {
-        javax.jdo.Query query = myShepherd.getPM().newQuery(
-            "SELECT FROM org.ecocean.Encounter WHERE annotations.contains(ann) && ann.id == annId");
-        query.declareParameters("String annId");
         java.util.List<Encounter> out = new java.util.ArrayList<Encounter>();
-        try {
-            java.util.List results = (java.util.List)query.execute(annot.getId());
-            if (results != null) for (Object o : results) out.add((Encounter)o);
-        } finally {
-            query.closeAll();
+
+        if (annot == null) return out;
+        for (String catalogNumber : findCatalogNumbersByAnnotationId(annot.getId(), myShepherd)) {
+            Encounter enc = myShepherd.getEncounter(catalogNumber);
+            if (enc != null) out.add(enc);
         }
         return out;
     }

--- a/src/test/java/org/ecocean/EncounterFindByAnnotationTest.java
+++ b/src/test/java/org/ecocean/EncounterFindByAnnotationTest.java
@@ -1,0 +1,88 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.jdo.PersistenceManager;
+import javax.jdo.Query;
+import org.ecocean.shepherd.core.Shepherd;
+import org.junit.jupiter.api.Test;
+
+class EncounterFindByAnnotationTest {
+    private Shepherd shepherdReturning(List<String> catalogNumbers, Query query) {
+        Shepherd sh = mock(Shepherd.class);
+        PersistenceManager pm = mock(PersistenceManager.class);
+
+        when(sh.getPM()).thenReturn(pm);
+        when(pm.newQuery(eq("javax.jdo.query.SQL"), anyString())).thenReturn(query);
+        when(query.execute(anyString())).thenReturn(catalogNumbers);
+        return sh;
+    }
+
+    private Annotation annotationWithId(String id) {
+        Annotation ann = mock(Annotation.class);
+
+        when(ann.getId()).thenReturn(id);
+        return ann;
+    }
+
+    @Test void findByAnnotation_nullAnnotation_returnsNull() {
+        assertNull(Encounter.findByAnnotation(null, mock(Shepherd.class)), "null annot -> null");
+    }
+
+    @Test void findByAnnotation_nullAnnotationId_returnsNullWithoutQuerying() {
+        Shepherd sh = mock(Shepherd.class);
+
+        assertNull(Encounter.findByAnnotation(annotationWithId(null), sh), "null id -> null");
+        verify(sh, never()).getPM();
+    }
+
+    @Test void findByAnnotation_noJoinRows_returnsNull() {
+        Query query = mock(Query.class);
+        Shepherd sh = shepherdReturning(Collections.emptyList(), query);
+
+        assertNull(Encounter.findByAnnotation(annotationWithId("ann-1"), sh), "orphan -> null");
+        verify(query).closeAll();
+    }
+
+    @Test void findByAnnotation_singleParent_loadsByCatalogNumber() {
+        Query query = mock(Query.class);
+        Shepherd sh = shepherdReturning(Arrays.asList("ENC-1"), query);
+        Encounter enc = mock(Encounter.class);
+
+        when(sh.getEncounter("ENC-1")).thenReturn(enc);
+        assertSame(enc, Encounter.findByAnnotation(annotationWithId("ann-1"), sh),
+            "single parent returned");
+        verify(query).closeAll();
+    }
+
+    @Test void findByAnnotation_multipleParents_returnsFirst() {
+        Query query = mock(Query.class);
+        Shepherd sh = shepherdReturning(Arrays.asList("ENC-1", "ENC-2"), query);
+        Encounter enc = mock(Encounter.class);
+
+        when(sh.getEncounter("ENC-1")).thenReturn(enc);
+        assertSame(enc, Encounter.findByAnnotation(annotationWithId("ann-1"), sh),
+            "first parent returned when anomalous multiple");
+    }
+
+    @Test void findAllByAnnotation_nullAnnotation_returnsEmpty() {
+        assertTrue(Encounter.findAllByAnnotation(null, mock(Shepherd.class)).isEmpty(),
+            "null annot -> empty list");
+    }
+
+    @Test void findAllByAnnotation_skipsUnresolvableCatalogNumbers() {
+        Query query = mock(Query.class);
+        Shepherd sh = shepherdReturning(Arrays.asList("ENC-GONE", "ENC-2"), query);
+        Encounter enc2 = mock(Encounter.class);
+
+        when(sh.getEncounter("ENC-GONE")).thenReturn(null);
+        when(sh.getEncounter("ENC-2")).thenReturn(enc2);
+        List<Encounter> out = Encounter.findAllByAnnotation(annotationWithId("ann-1"), sh);
+        assertEquals(1, out.size(), "dangling join row skipped");
+        assertSame(enc2, out.get(0));
+    }
+}


### PR DESCRIPTION
## What

Rewrites `Encounter.findByAnnotation()` and `findAllByAnnotation()` to resolve parent encounters via a parameter-bound native SQL lookup on the `ENCOUNTER_ANNOTATIONS` join table plus the existing `Shepherd.getEncounter()` PK load, replacing the JDOQL `annotations.contains()` candidate query. Adds unit tests for the lookup contract.

## Why

On Flukebook, every MiewID identify task with a location filter was failing deterministically and requeueing until its 30 retries exhausted. The path is `sendIdentify → annotGetIndiv → Annotation.findIndividualId → findEncounter → Encounter.findByAnnotation`.

The JDOQL candidate query makes DataNucleus 5.2.7 bulk-fetch every `default-fetch-group="true"` collection on Encounter (measurements, photographers, submitters, informOthers, …) with one EXISTS statement per field — and it emits malformed SQL for some of them (doubled/interleaved column lists, `FROM  FROM`, duplicated WHERE), which PostgreSQL rejects:

```
org.postgresql.util.PSQLException: ERROR: syntax error at or near ","
```

This is the same DataNucleus 5.2.7 bug previously patched only at the ImportTask call site (79562a5fbe). `findByAnnotation` sits behind ~38 call sites (identify send path, IA callbacks, API, servlets), so any install can hit it — the trigger is data-shaped, not Flukebook-specific.

## How

- New private helper `findCatalogNumbersByAnnotationId()`: `SELECT DISTINCT "CATALOGNUMBER_OID" FROM "ENCOUNTER_ANNOTATIONS" WHERE "ID_EID" = ?` (bound positional parameter, not string concatenation).
- `findByAnnotation` keeps the existing >1-parents WARNING and first-result behavior; `findAllByAnnotation` returns distinct logical parents, skipping dangling join rows.
- The PK load via `Shepherd.getEncounter()` never takes the bulk-fetch path, and is faster: an indexed join-table lookup instead of a `contains()` subquery that hydrates the encounter's entire default fetch group.
- Deliberate contract change (Codex-reviewed): null annotation / null id now returns null/empty instead of throwing NPE; locked in by the new tests.

## Testing

- `mvn compile` clean; `mvn test -Dtest=EncounterFindByAnnotationTest` → 7/7 pass (null-safety, 0/1/N parents, dangling join rows, query lifecycle).
- Codex adversarial review: plan and implementation both converged, no outstanding findings.

## Follow-ups (separate scope)

Sibling Encounter-candidate `annotations.contains()` JDOQL remains in `findByMediaAsset`/`findAllByMediaAsset`, `Shepherd.getEncountersByAnnotationIds` (notable hot-path candidate), and some query/admin paths — same latent exposure to the DataNucleus bulk-fetch bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)