### PR TITLE
Keep subspecies when submitting an encounter via /EncounterForm

### DIFF
--- a/src/main/java/org/ecocean/Util.java
+++ b/src/main/java/org/ecocean/Util.java
@@ -422,6 +422,34 @@ public class Util {
         return gs;
     }
 
+    // parses a user-submitted "genusSpecies" form value (e.g. "Delphinus capensis
+    // tropicalis") into { genus, specificEpithet }. everything after the genus is kept as
+    // the specific epithet, which is how Encounter/Taxonomy already store trinomials --
+    // see setTaxonomyFromString() and Taxonomy.getGenusSpecificEpithet(). also applies the
+    // normalization the submit/edit servlets have always done (drop commas from the
+    // epithet, underscores become spaces). returns null only when there is no epithet at
+    // all, so callers keep their own "malformed genusSpecies" handling.
+    // two things here are load-bearing, both matching what the servlets' old two-token
+    // StringTokenizer did:
+    //   - the parsed parts are NOT screened with stringExists(), which is false for the
+    //     literal values "unknown" and "none" -- those have always been passed through and
+    //     judged downstream.
+    //   - commas are dropped from the epithet only. a comma left on the genus is a config
+    //     typo that survives into the taxonomy, as it always has.
+    // the one intentional difference: whitespace is normalized before the split, so any
+    // run of it separates the parts and none of it ends up inside them. precisely, trim()
+    // strips leading/trailing characters <= U+0020 (stray control characters go with the
+    // whitespace) and interior \s runs collapse to one space. the old tokenizer split on
+    // the literal space alone, which both rejected e.g. a tab-separated value as malformed
+    // (silently costing the encounter its taxonomy) and embedded stray tabs, newlines and
+    // control characters in the stored genus or epithet.
+    public static String[] parseGenusSpecies(String value) {
+        if (value == null) return null;
+        String[] gs = stringToGenusSpecificEpithet(value.trim().replaceAll("\\s+", " "));
+        if ((gs == null) || (gs.length < 2)) return null;
+        return new String[] { gs[0], gs[1].replaceAll(",", "").replaceAll("_", " ") };
+    }
+
     // a generic version of our uuid-dir-structure-creating algorithm -- adjust as needed!?
     // TODO: check for incoming slashes and similar weirdness
     public static String hashDirectories(String in, String separator) {

--- a/src/main/java/org/ecocean/servlet/EncounterForm.java
+++ b/src/main/java/org/ecocean/servlet/EncounterForm.java
@@ -398,12 +398,13 @@ public class EncounterForm extends HttpServlet {
             try {
                 // now we have to break apart genus species
                 if (formValues.get("genusSpecies") != null) {
-                    StringTokenizer tokenizer = new StringTokenizer(formValues.get(
-                        "genusSpecies").toString(), " ");
-                    if (tokenizer.countTokens() >= 2) {
-                        genus = tokenizer.nextToken();
-                        specificEpithet = tokenizer.nextToken().replaceAll(",", "").replaceAll("_",
-                            " ");
+                    // everything after the genus stays in the specific epithet, so a
+                    // trinomial keeps its subspecies (e.g. "Delphinus capensis tropicalis")
+                    String[] gs = Util.parseGenusSpecies(formValues.get(
+                        "genusSpecies").toString());
+                    if (gs != null) {
+                        genus = gs[0];
+                        specificEpithet = gs[1];
                     }
                     // handle malformed Genus Species formats
                     else {

--- a/src/test/java/org/ecocean/UtilTest.java
+++ b/src/test/java/org/ecocean/UtilTest.java
@@ -68,4 +68,85 @@ class UtilTest {
         assertTrue(cs.contains("Palestinian Territories"));
         assertTrue(cs.contains("United States"));
     }
+
+    // issue: submit.jsp -> /EncounterForm silently dropped the subspecies of a
+    // trinomial genusSpecies value (e.g. "Delphinus capensis tropicalis"), because it
+    // only ever read two space-delimited tokens. Everything after the genus belongs to
+    // the specific epithet -- that is how Encounter/Taxonomy already store trinomials.
+    @Test void testParseGenusSpecies() {
+        assertArrayEquals(new String[] { "Delphinus", "capensis tropicalis" },
+            Util.parseGenusSpecies("Delphinus capensis tropicalis"));
+        assertArrayEquals(new String[] { "Tursiops", "truncatus gephyreus" },
+            Util.parseGenusSpecies("Tursiops truncatus gephyreus"));
+
+        // plain binomials are unchanged
+        assertArrayEquals(new String[] { "Megaptera", "novaeangliae" },
+            Util.parseGenusSpecies("Megaptera novaeangliae"));
+
+        // legacy normalization is preserved: commas dropped, underscores become spaces
+        assertArrayEquals(new String[] { "Delphinus", "capensis tropicalis" },
+            Util.parseGenusSpecies("Delphinus capensis_tropicalis"));
+        assertArrayEquals(new String[] { "Megaptera", "novaeangliae" },
+            Util.parseGenusSpecies("Megaptera novaeangliae,"));
+
+        // surrounding/repeated whitespace must not leak into the epithet
+        assertArrayEquals(new String[] { "Delphinus", "capensis tropicalis" },
+            Util.parseGenusSpecies("  Delphinus   capensis  tropicalis "));
+
+        // no epithet (or no value at all) -> null, so callers keep their existing
+        // "malformed genusSpecies" handling
+        assertNull(Util.parseGenusSpecies("Delphinus"));
+        assertNull(Util.parseGenusSpecies("unknown"));
+        assertNull(Util.parseGenusSpecies(""));
+        assertNull(Util.parseGenusSpecies("   "));
+        assertNull(Util.parseGenusSpecies(null));
+    }
+
+    // whatever the legacy two-token parse accepted must still be accepted -- a value with
+    // an epithet is never rejected here, it is judged downstream exactly as before. in
+    // particular do not run the parts through Util.stringExists(), which is false for the
+    // literal strings "unknown" and "none".
+    @Test void testParseGenusSpeciesLegacyBoundaries() {
+        assertArrayEquals(new String[] { "unknown", "species" },
+            Util.parseGenusSpecies("unknown species"));
+        assertArrayEquals(new String[] { "Delphinus", "unknown" },
+            Util.parseGenusSpecies("Delphinus unknown"));
+        assertArrayEquals(new String[] { "Delphinus", "none" },
+            Util.parseGenusSpecies("Delphinus none"));
+
+        // an underscore-only epithet normalizes to whitespace, which the old code also
+        // produced; Util.taxonomyString() then reports it as a genus-only taxonomy
+        assertArrayEquals(new String[] { "Delphinus", " " },
+            Util.parseGenusSpecies("Delphinus _"));
+        assertEquals("Delphinus", Util.taxonomyString("Delphinus", " "));
+
+        // commas are dropped from the epithet only -- a comma left on the genus is a
+        // config typo, and it survived into the taxonomy before this change too
+        assertArrayEquals(new String[] { "Delphinus,", "capensis" },
+            Util.parseGenusSpecies("Delphinus, capensis"));
+    }
+
+    // the one intentional difference from the old two-token parse: whitespace is
+    // normalized before the split. the old tokenizer split on the literal space alone,
+    // which had two consequences worth being rid of -- and both are deliberate here.
+    @Test void testParseGenusSpeciesNormalizesWhitespace() {
+        // (1) a value separated by anything other than a space parsed as a single token
+        // and was rejected as malformed, silently costing the encounter its taxonomy
+        assertArrayEquals(new String[] { "Delphinus", "capensis tropicalis" },
+            Util.parseGenusSpecies("Delphinus\tcapensis\ttropicalis"));
+        assertArrayEquals(new String[] { "Megaptera", "novaeangliae" },
+            Util.parseGenusSpecies("Megaptera\nnovaeangliae"));
+
+        // (2) stray whitespace adjacent to a real space delimiter used to be stored as
+        // part of the genus or the epithet
+        assertArrayEquals(new String[] { "Delphinus", "capensis" },
+            Util.parseGenusSpecies("Delphinus\t capensis"));
+        assertArrayEquals(new String[] { "Delphinus", "capensis" },
+            Util.parseGenusSpecies("Delphinus capensis\n"));
+
+        // trim() strips any leading/trailing character <= U+0020, so a stray control
+        // character goes with the whitespace instead of into the genus
+        assertArrayEquals(new String[] { "Delphinus", "capensis" },
+            Util.parseGenusSpecies("\u0000Delphinus capensis"));
+    }
 }


### PR DESCRIPTION
## Problem

`submit.jsp` posts its `genusSpecies` select value to the `/EncounterForm` servlet. The option values are the install's `genusSpeciesN` properties verbatim, and on installs that track subspecies some of those are **trinomials** — the Flukebook species list, for instance, carries `Delphinus capensis tropicalis` and `Tursiops truncatus gephyreus`. (The default bundle on `main` ships a single `genusSpecies0`, so this is not reproducible from a stock checkout; it needs a real install's config.)

`EncounterForm` tokenized that value on spaces and read exactly **two** tokens:

```java
StringTokenizer tokenizer = new StringTokenizer(formValues.get("genusSpecies").toString(), " ");
if (tokenizer.countTokens() >= 2) {
    genus = tokenizer.nextToken();
    specificEpithet = tokenizer.nextToken().replaceAll(",", "").replaceAll("_", " ");
}
```

So the subspecies was silently dropped on every submitted Encounter — `Delphinus capensis tropicalis` was stored as `Delphinus capensis`. It also propagated: the same two locals build the taxonomy string for the Annotations created on the submit path (`Util.taxonomyString(genus, specificEpithet)`, three call sites including both `makeMediaAssetsFromJava*` helpers), so those annotations carried the truncated taxonomy too.

The **edit** path already handles this. `EncounterSetGenusSpecies` got an explicit third-token branch in 0c0f803 ("Fix subspecies support", Dec 2025) — that commit touched only that one file, so the submit path was never given the same treatment.

## Fix

One shared, tested helper instead of a third copy of the parsing:

```java
Util.parseGenusSpecies("Delphinus capensis tropicalis")
    -> { "Delphinus", "capensis tropicalis" }
```

Everything after the genus is kept as the specific epithet. That is not an invention — it is already how this codebase represents trinomials: `Util.stringToGenusSpecificEpithet()` splits at the *first* space and keeps the whole remainder, and both `Encounter.setTaxonomyFromString()` and `Taxonomy.getGenusSpecificEpithet()` build on it. `Taxonomy`'s own comment says the scientific name is "usually `Genus species` or `Genus species subspecies`".

`EncounterForm` now calls the helper. Compatibility notes:

- the legacy normalization is preserved — commas dropped, underscores become spaces, and an underscore-only epithet still normalizes to whitespace (which `Util.taxonomyString()` reports as a genus-only taxonomy, same as before);
- the helper returns `null` only when there is no epithet, so `EncounterForm`'s existing "malformed genusSpecies parameter" branch still fires — including the pre-existing quirk that the exception is caught and logged and the encounter is created with null taxonomy;
- the parsed parts are deliberately **not** run through `Util.stringExists()`, which is false for the literal strings `unknown` and `none` — screening on it would have started rejecting values like `unknown species` that the old parse passed through. There is a test pinning that;
- commas are still dropped from the epithet only. A comma left on the genus (`Delphinus, capensis`) is a config typo that survives into the taxonomy, exactly as it did before — also pinned by a test;
- **one intentional difference:** whitespace is normalized before the split. The old `StringTokenizer` split on the literal space alone, which meant a tab- or newline-separated config value parsed as a single token and was rejected as malformed (silently costing the encounter its taxonomy), and stray whitespace next to a real delimiter was stored *inside* the genus or epithet (`"Delphinus\t capensis"` gave a genus of `Delphinus<TAB>`). Both are now normalized away. Precisely: `trim()` strips leading/trailing characters `<= U+0020` (so a stray control character goes with the whitespace rather than into the genus) and interior `\s` runs collapse to one space. This is the only input class that behaves differently, and it has its own test.

## Tests

`UtilTest.testParseGenusSpecies` pins the bug — both trinomials, plain binomials, the comma/underscore normalization, messy whitespace, and every "no epithet" case. It fails against the old two-token logic.

`UtilTest.testParseGenusSpeciesLegacyBoundaries` pins the compatibility contract above — `unknown`/`none` parts, the underscore-only epithet, the comma-on-the-genus typo — and `testParseGenusSpeciesNormalizesWhitespace` pins the one intentional difference.

Expected values in those tests were derived by running the original `StringTokenizer` logic standalone against each input, not from reading it.

## Deployment note for installs that offer trinomials

`IAJsonProperties.taxonomyKey()` turns the scientific name into a dotted IA.json path and `JsonProperties.getRecursive()` does no fallback up the hierarchy, so `Delphinus capensis tropicalis` resolves `Delphinus.capensis.tropicalis`. An install that lists a trinomial in `genusSpecies` needs that subspecies node in its `IA.json` — typically the `"tropicalis": "@Delphinus.capensis"` redirect form — or detection/ID config lookups return null and IA simply does not start for it. Matching likewise treats a trinomial as its own taxonomy, which is intended.

None of that is new with this PR — it has been true for every encounter edited through `EncounterSetGenusSpecies` since Dec 2025 — but it is the thing to check on Flukebook when this ships.

## Out of scope

`EncounterSetGenusSpecies` still appends only one extra token, so a hypothetical four-word name would truncate there. No such value exists in any shipped config, so I left that servlet alone rather than widen the diff; it can adopt `Util.parseGenusSpecies()` in a follow-up.

I also did not add a servlet-level integration test asserting the trinomial lands on both the encounter and its annotations — `EncounterForm.doPost` needs a multipart request, an `AssetStore` and a live `Shepherd`, which is a disproportionate harness for a parse fix. The three annotation call sites read the same two locals the encounter does, so the unit-level contract covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Adversarially reviewed with [Codex](https://developers.openai.com/codex/cli) across four rounds to convergence; see the review-provenance comment for what it caught, including one finding that was disproven rather than accepted.
