### PR TITLE
fix(individuals): show each co-occurring individual's own sex and location

### DIFF
--- a/src/main/webapp/javascript/bubbleDiagram/encounter-calls.js
+++ b/src/main/webapp/javascript/bubbleDiagram/encounter-calls.js
@@ -22,6 +22,10 @@ var getData = function(individualID, displayName) {
     var encArrWithUUID = [];
     var occurrenceArray = [];
     var dataObject = {};
+    // sex and location of each co-occurring individual, keyed by the same "name id=uuid" string
+    // used for dataObject. These belong to the individual whose row they are shown in, so they
+    // cannot be held in a variable shared by every row.
+    var individualDetails = {};
 
 	console.log("QUERY: "+wildbookGlobals.baseUrl + "/api?useProjectContext=true&query="+encodeURIComponent("SELECT FROM org.ecocean.Occurrence WHERE encounters.contains(enc) && enc.individual.individualID == \"" + individualID + "\" VARIABLES org.ecocean.Encounter enc"));
 
@@ -39,10 +43,8 @@ var getData = function(individualID, displayName) {
             // make encounterArray, containing the individualIDs of every encounter in thisOcc;
             for(var j=0; j < encounterSize; j++) {
 				console.info('[%d] %o %o', j, thisOcc.encounters, thisOcc.encounters[j]);
-				var thisEncIndID = getIndividualIDFromEncounterToString(thisOcc.encounters[j]);
-				var sex=thisOcc.encounters[j].sex;
-				var haplotype=thisOcc.encounters[j].haplotype;
-				var location=thisOcc.encounters[j].locationID;
+				var thisEnc = thisOcc.encounters[j];
+				var thisEncIndID = getIndividualIDFromEncounterToString(thisEnc);
 				//console.log("thisEncIndID="+thisEncIndID);
 		
 				//var thisEncIndID = jsonData[i].encounters[j].individualID;   ///only when we fix thisOcc.encounters to be real json   :(
@@ -50,6 +52,18 @@ var getData = function(individualID, displayName) {
 				if (!thisEncIndID) continue;
 				var individualName = thisEncIndID.split(" id=")[0];
 				if (individualName === displayName) continue;  //unknown indiv -> false
+
+				// record against this individual, not against the loop: an individual can be seen in
+				// several occurrences, and each of them may state a different location
+				var indivDetails = individualDetails[thisEncIndID];
+				if (!indivDetails) {
+					indivDetails = {sex: thisEnc.sex, locations: []};
+					individualDetails[thisEncIndID] = indivDetails;
+				}
+				if (thisEnc.locationID && indivDetails.locations.indexOf(thisEnc.locationID) < 0) {
+					indivDetails.locations.push(thisEnc.locationID);
+				}
+
 				if(!encounterArray.includes(individualName)) {
 					encounterArray.push(individualName);
 					encArrWithUUID.push(thisEncIndID);
@@ -79,8 +93,11 @@ var getData = function(individualID, displayName) {
             ++dataObject[occurrenceArray[i]];
 	}
 	for (var prop in dataObject) {
+            var rowDetails = individualDetails[prop] || {};
             var whale = new Object();
-            whale = {text:prop, count:dataObject[prop], sex: sex, location: location};
+            whale = {text:prop, count:dataObject[prop],
+                     sex: rowDetails.sex || dict['unknown'],
+                     location: (rowDetails.locations || []).join(", ")};
             items.push(whale);	
 	}
 	//if (items.length > 0) {


### PR DESCRIPTION
Fixes #1703.

## The bug

The co-occurrence table on `individuals.jsp` gave every co-occurring individual the same sex and the same location. On the reported giraffespotter.org individual (`LG-0068M`) every ID ending in `M` was listed as female; on the Flukebook example, `5564` (unknown) and `5550` (male) were both listed as female.

## Cause

`getData()` in `src/main/webapp/javascript/bubbleDiagram/encounter-calls.js` read the values into `var` declarations inside the loop over an occurrence's encounters:

```js
for (var j = 0; j < encounterSize; j++) {
    var sex = thisOcc.encounters[j].sex;
    var location = thisOcc.encounters[j].locationID;
    ...
}
```

`var` is function-scoped, so both variables outlived the loop. The table rows were not built until every occurrence had been walked:

```js
for (var prop in dataObject) {
    whale = {text: prop, count: dataObject[prop], sex: sex, location: location};
}
```

By then `sex` and `location` held whatever the *last* encounter processed happened to state, and every row was given that one value. Which value you got was incidental — hence "all female" in one catalogue and a different wrong constant in another.

## Fix

Record sex and location against the individual they belong to, in a map keyed by the same `"name id=uuid"` string the occurrence counts already use, then read them back per row. No backend change: `encounters/occurrenceGraphJson.jsp` already emits `sex` and `locationID` per encounter.

Two related behaviours fall out of doing this correctly:

- **Location lists every distinct place.** An individual can be co-observed across several occurrences recorded at different locations. Picking one would silently drop the others, so the cell now joins the distinct values (`"Loc A, Loc B"`).
- **An individual with no sex set reads as the localized "Unknown"** rather than blank, matching what the issue expects for Flukebook `5564`.

This also fixes sorting on the Sex and Location columns, which previously could only compare identical values.

The unused `haplotype` variable in the same block is removed — its only consumer is the commented-out `getSexHaploData()` directly below.

## Verification

There is no test runner covering `src/main/webapp/javascript` (CI runs `frontend` jest and maven only), so this was verified with a throwaway Node harness that loads the real file in a `vm` sandbox, stubs `d3`/`jQuery`/`makeTable`, and feeds it JSON shaped exactly as `occurrenceGraphJson.jsp` emits: the individual under view, a male co-occurring in two occurrences at two different locations, a female, and one individual with `sex: null`.

Before:

```
FAIL male sex      -> null            (expected "male")
FAIL female sex    -> null            (expected "female")
FAIL unset sex     -> null            (expected "Unknown")
FAIL male location -> "Loc B"         (expected "Loc A, Loc B")
FAIL female location -> "Loc B"       (expected "Loc A")
```

Every row collapsed onto the last encounter processed, reproducing the reported behaviour.

After:

```
PASS self excluded   -> 3
PASS male sex        -> "male"
PASS female sex      -> "female"
PASS unset sex       -> "Unknown"
PASS male count      -> 2
PASS female count    -> 1
PASS male locations  -> "Loc A, Loc B"
PASS female location -> "Loc A"
```

Happy to contribute the harness as a proper test if you'd like a JS test target for the legacy `webapp/javascript` tree, but that felt like a separate PR from the fix.

## Note

The issue mentions this may be resolved by the individual page redesign. This is a small, self-contained fix to the current page for catalogues on 10.x in the meantime — it touches one file and no shared code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnYvkvJGprMb41dZe38H6R
