### PR TITLE
fix(match-results): serve master-resolution images and auto-zoom to the annotation

### DIFF
--- a/frontend/src/__tests__/utils/annotationZoom.test.js
+++ b/frontend/src/__tests__/utils/annotationZoom.test.js
@@ -1,0 +1,120 @@
+import {
+  annotationDisplayRect,
+  computeMaxZoom,
+  computeFitToAnnotation,
+} from "../../utils/annotationZoom";
+
+describe("computeMaxZoom", () => {
+  it("lets a 4096px master be zoomed to its native pixels", () => {
+    // 4096 source pixels across a 640px-wide pane is 6.4x; OpenSeadragon's
+    // maxZoomPixelRatio of 1.1 is the ceiling the legacy viewer used.
+    expect(computeMaxZoom({ naturalWidth: 4096, displayWidth: 640 })).toBeCloseTo(
+      7.04,
+      5,
+    );
+  });
+
+  it("never drops below the floor for a small source image", () => {
+    // 1024 / 640 * 1.1 = 1.76, which would be a worse ceiling than today's 3x.
+    expect(
+      computeMaxZoom({ naturalWidth: 1024, displayWidth: 640, floor: 3 }),
+    ).toBe(3);
+  });
+
+  it("falls back to the floor before the image has laid out", () => {
+    expect(computeMaxZoom({ naturalWidth: 0, displayWidth: 0, floor: 3 })).toBe(3);
+  });
+});
+
+describe("annotationDisplayRect", () => {
+  const annotation = { x: 100, y: 50, width: 400, height: 200 };
+
+  it("scales source-pixel coordinates into displayed pixels", () => {
+    expect(annotationDisplayRect(annotation, { scaleX: 2, scaleY: 2 })).toEqual({
+      x: 50,
+      y: 25,
+      width: 200,
+      height: 100,
+      rotation: 0,
+    });
+  });
+
+  it("applies the aspect adjustment when the asset carries rotation info", () => {
+    expect(
+      annotationDisplayRect(annotation, {
+        scaleX: 2,
+        scaleY: 2,
+        originalWidth: 1000,
+        originalHeight: 500,
+        hasRotation: true,
+      }),
+    ).toEqual({ x: 100, y: 12.5, width: 400, height: 50, rotation: 0 });
+  });
+
+  it("returns null for a trivial whole-image annotation", () => {
+    expect(
+      annotationDisplayRect(
+        { ...annotation, trivial: true },
+        { scaleX: 1, scaleY: 1 },
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when the box has no area", () => {
+    expect(
+      annotationDisplayRect(
+        { x: 1, y: 1, width: 0, height: 10 },
+        { scaleX: 1, scaleY: 1 },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("computeFitToAnnotation", () => {
+  const container = { containerWidth: 640, containerHeight: 480 };
+
+  it("fills the pane with the annotation and centers it", () => {
+    const { zoom, pan } = computeFitToAnnotation({
+      rect: { x: 50, y: 25, width: 200, height: 100 },
+      ...container,
+      minZoom: 1,
+      maxZoom: 8,
+      margin: 0.1,
+    });
+
+    // width is the binding dimension: 640 / (200 * 1.1)
+    expect(zoom).toBeCloseTo(2.909090909, 6);
+    expect(pan.x).toBeCloseTo(320 - 150 * 2.909090909, 5);
+    expect(pan.y).toBeCloseTo(240 - 75 * 2.909090909, 5);
+  });
+
+  it("does not zoom past the ceiling for a tiny annotation", () => {
+    const { zoom } = computeFitToAnnotation({
+      rect: { x: 0, y: 0, width: 4, height: 4 },
+      ...container,
+      minZoom: 1,
+      maxZoom: 8,
+      margin: 0.1,
+    });
+
+    expect(zoom).toBe(8);
+  });
+
+  it("does not zoom out past the floor for an annotation that fills the frame", () => {
+    const { zoom } = computeFitToAnnotation({
+      rect: { x: 0, y: 0, width: 640, height: 480 },
+      ...container,
+      minZoom: 1,
+      maxZoom: 8,
+      margin: 0.1,
+    });
+
+    expect(zoom).toBe(1);
+  });
+
+  it("returns null when there is no rect to fit", () => {
+    expect(
+      computeFitToAnnotation({ rect: null, ...container, minZoom: 1, maxZoom: 8 }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/components/AnnotationOverlay.jsx
+++ b/frontend/src/components/AnnotationOverlay.jsx
@@ -71,15 +71,23 @@ const InteractiveAnnotationOverlay = forwardRef(
 
     const hasRotation = !!rotationInfo;
 
+    // A new image starts from the default view -- otherwise the zoom chosen for the
+    // previous prospect carries over onto the next one. Keyed on imageUrl alone, so a
+    // metadata-only change to the dimensions does not throw away the user's zoom, and
+    // run as a layout effect so a cached replacement cannot paint at the old transform
+    // first. The auto-fit effect reframes once the new image has loaded.
+    useLayoutEffect(() => {
+      setZoom(Number.isFinite(initialZoom) ? initialZoom : 1);
+      setPan((prev) => (prev.x === 0 && prev.y === 0 ? prev : { x: 0, y: 0 }));
+      // initialZoom is the default view, not a trigger: changing it alone should not
+      // yank the image out from under the user.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [imageUrl]);
+
     useEffect(() => {
       if (!imgRef.current) return;
 
       setImageLoaded(false);
-      // A new image starts from the default view -- otherwise the zoom chosen for
-      // the previous prospect carries over onto the next one. The auto-fit effect
-      // reframes once this image has loaded and its scale is known.
-      setZoom(Number.isFinite(initialZoom) ? initialZoom : 1);
-      setPan({ x: 0, y: 0 });
 
       const handleImageLoad = () => {
         if (imgRef.current) {

--- a/frontend/src/components/AnnotationOverlay.jsx
+++ b/frontend/src/components/AnnotationOverlay.jsx
@@ -7,8 +7,15 @@ import {
   useState,
 } from "react";
 import useWheelZoom from "../hooks/useWheelZoom";
+import {
+  annotationDisplayRect,
+  computeFitToAnnotation,
+  computeMaxZoom,
+} from "../utils/annotationZoom";
 
 const VISIBLE_MARGIN_PX = 40;
+// Breathing room left around an auto-fitted annotation, as a fraction of the box.
+const ANNOTATION_FIT_MARGIN = 0.1;
 
 const InteractiveAnnotationOverlay = forwardRef(
   (
@@ -20,8 +27,12 @@ const InteractiveAnnotationOverlay = forwardRef(
       rotationInfo = null,
       initialZoom = 1,
       minZoom = 1,
+      // Floor for the zoom ceiling, not the ceiling itself: the real limit is
+      // derived from the served image's own resolution, so a 4096px _master can
+      // be inspected down to its native pixels instead of stopping at 3x.
       maxZoom = 3,
-      zoomStep = 0.25,
+      zoomFactor = 1.25,
+      fitToAnnotation = false,
       showAnnotations: showAnnotationsProp,
       strokeColor = "red",
       lineWidth = 2,
@@ -47,6 +58,9 @@ const InteractiveAnnotationOverlay = forwardRef(
     const [scaleX, setScaleX] = useState(1);
     const [scaleY, setScaleY] = useState(1);
     const [imageLoaded, setImageLoaded] = useState(false);
+    // Pixel width of the image we were actually served, and the width it is
+    // drawn at -- together these say how much detail is left to zoom into.
+    const [sourceSize, setSourceSize] = useState({ natural: 0, display: 0 });
 
     const [internalShowAnn, setInternalShowAnn] = useState(true);
     const showAnn =
@@ -76,6 +90,10 @@ const InteractiveAnnotationOverlay = forwardRef(
             setScaleY(1);
           }
 
+          setSourceSize({
+            natural: imgRef.current.naturalWidth,
+            display: displayWidth,
+          });
           setImageLoaded(true);
         }
       };
@@ -126,7 +144,24 @@ const InteractiveAnnotationOverlay = forwardRef(
         });
     }, [annotations]);
 
-    const clampZoom = (z) => Math.max(minZoom, Math.min(maxZoom, z));
+    const effectiveMaxZoom = useMemo(
+      () =>
+        computeMaxZoom({
+          naturalWidth: sourceSize.natural,
+          displayWidth: sourceSize.display,
+          floor: maxZoom,
+        }),
+      [sourceSize, maxZoom],
+    );
+
+    // The imperative handle is built once, so it must read the ceiling through a
+    // ref -- closing over effectiveMaxZoom would pin it to the pre-load value.
+    const maxZoomRef = useRef(effectiveMaxZoom);
+    useEffect(() => {
+      maxZoomRef.current = effectiveMaxZoom;
+    }, [effectiveMaxZoom]);
+
+    const clampZoom = (z) => Math.max(minZoom, Math.min(maxZoomRef.current, z));
 
     const clampPan = (nextPan, nextZoom = zoom) => {
       const container = outerContainerRef.current;
@@ -158,26 +193,98 @@ const InteractiveAnnotationOverlay = forwardRef(
       stateRef.current = { zoom, pan, showAnn, imageLoaded };
     }, [zoom, pan, showAnn, imageLoaded]);
 
+    // The single annotation worth framing. More than one and there is no
+    // obvious subject, so we leave the whole image showing.
+    const fitTarget = useMemo(
+      () => (visibleAnnotations.length === 1 ? visibleAnnotations[0] : null),
+      [visibleAnnotations],
+    );
+
+    // Zoom and pan to the annotation, the way the legacy OpenSeadragon viewer
+    // did with viewport.fitBounds(). Returns false if there is nothing to fit.
+    const fitAnnotationView = () => {
+      const container = outerContainerRef.current;
+
+      if (!container || !fitTarget) return false;
+      const rect = annotationDisplayRect(fitTarget, {
+        scaleX,
+        scaleY,
+        originalWidth,
+        originalHeight,
+        hasRotation,
+      });
+      const fit = computeFitToAnnotation({
+        rect,
+        containerWidth: container.clientWidth,
+        containerHeight: container.clientHeight,
+        minZoom,
+        maxZoom: maxZoomRef.current,
+        margin: ANNOTATION_FIT_MARGIN,
+      });
+
+      if (!fit) return false;
+      setZoom(fit.zoom);
+      setPan(clampPan(fit.pan, fit.zoom));
+      return true;
+    };
+
+    // Same reason as maxZoomRef: the imperative handle needs the current closure.
+    const fitRef = useRef(() => false);
+    useEffect(() => {
+      fitRef.current = fitAnnotationView;
+    });
+
+    const fitSignature = useMemo(() => {
+      if (!fitToAnnotation || !fitTarget) return null;
+      return [
+        fitTarget.id,
+        fitTarget.x,
+        fitTarget.y,
+        fitTarget.width,
+        fitTarget.height,
+        fitTarget.theta,
+      ].join("|");
+    }, [fitToAnnotation, fitTarget]);
+
+    useEffect(() => {
+      if (!imageLoaded || !fitSignature) return;
+      fitRef.current();
+      // fitRef always holds the latest closure; re-running on its identity would loop.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [imageLoaded, imageUrl, fitSignature, effectiveMaxZoom, scaleX, scaleY]);
+
     useImperativeHandle(ref, () => ({
       zoomIn: () => {
         setZoom((z) => {
-          const nextZoom = clampZoom(z + zoomStep);
+          const nextZoom = clampZoom(z * zoomFactor);
           setPan((prev) => clampPan(prev, nextZoom));
           return nextZoom;
         });
       },
       zoomOut: () => {
         setZoom((z) => {
-          const nextZoom = clampZoom(z - zoomStep);
-          setPan((prev) => clampPan(prev, nextZoom));
+          const nextZoom = clampZoom(z / zoomFactor);
+          // Zooming all the way out means "show me the whole photo", so drop the
+          // pan rather than leaving the image parked off to one side.
+          setPan((prev) =>
+            nextZoom <= minZoom ? { x: 0, y: 0 } : clampPan(prev, nextZoom),
+          );
           return nextZoom;
         });
       },
+      // The default view: the annotation when auto-fit is on, else whole image.
       reset: () => {
+        if (fitRef.current()) return;
         const nextZoom = clampZoom(initialZoom || 1);
         setZoom(nextZoom);
         setPan(clampPan({ x: 0, y: 0 }, nextZoom));
       },
+      fitImage: () => {
+        const nextZoom = clampZoom(initialZoom || 1);
+        setZoom(nextZoom);
+        setPan(clampPan({ x: 0, y: 0 }, nextZoom));
+      },
+      fitAnnotation: () => fitRef.current(),
       toggleAnnotations: () => {
         if (typeof showAnnotationsProp === "boolean") return;
         setInternalShowAnn((v) => !v);
@@ -253,8 +360,12 @@ const InteractiveAnnotationOverlay = forwardRef(
     // Mouse-wheel zoom mirrors the zoomIn/zoomOut imperative-handle behavior.
     const handleWheelZoom = (direction) => {
       setZoom((z) => {
-        const nextZoom = clampZoom(z + direction * zoomStep);
-        setPan((prev) => clampPan(prev, nextZoom));
+        const nextZoom = clampZoom(
+          direction > 0 ? z * zoomFactor : z / zoomFactor,
+        );
+        setPan((prev) =>
+          nextZoom <= minZoom ? { x: 0, y: 0 } : clampPan(prev, nextZoom),
+        );
         return nextZoom;
       });
     };
@@ -329,45 +440,17 @@ const InteractiveAnnotationOverlay = forwardRef(
               }}
             >
               {visibleAnnotations.map((a, idx) => {
-                let rect = {
-                  x: Number(a.x),
-                  y: Number(a.y),
-                  width: Number(a.width),
-                  height: Number(a.height),
-                  rotation: Number(a.theta || 0),
-                };
+                // Same helper the auto-fit uses, so the drawn box and the view
+                // it zooms to can never disagree.
+                const rect = annotationDisplayRect(a, {
+                  scaleX,
+                  scaleY,
+                  originalWidth,
+                  originalHeight,
+                  hasRotation,
+                });
 
-                if (hasRotation) {
-                  const imgW = Number(originalWidth);
-                  const imgH = Number(originalHeight);
-                  const adjW = imgH / imgW;
-                  const adjH = imgW / imgH;
-
-                  rect = {
-                    x: rect.x / scaleX / adjW,
-                    width: rect.width / scaleX / adjW,
-                    y: rect.y / scaleY / adjH,
-                    height: rect.height / scaleY / adjH,
-                    rotation: rect.rotation,
-                  };
-                } else {
-                  rect = {
-                    x: rect.x / scaleX,
-                    y: rect.y / scaleY,
-                    width: rect.width / scaleX,
-                    height: rect.height / scaleY,
-                    rotation: rect.rotation,
-                  };
-                }
-
-                if (
-                  !Number.isFinite(rect.width) ||
-                  !Number.isFinite(rect.height) ||
-                  rect.width <= 0 ||
-                  rect.height <= 0
-                ) {
-                  return null;
-                }
+                if (!rect) return null;
 
                 const key =
                   a.id ??

--- a/frontend/src/components/AnnotationOverlay.jsx
+++ b/frontend/src/components/AnnotationOverlay.jsx
@@ -2,6 +2,7 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -74,6 +75,11 @@ const InteractiveAnnotationOverlay = forwardRef(
       if (!imgRef.current) return;
 
       setImageLoaded(false);
+      // A new image starts from the default view -- otherwise the zoom chosen for
+      // the previous prospect carries over onto the next one. The auto-fit effect
+      // reframes once this image has loaded and its scale is known.
+      setZoom(Number.isFinite(initialZoom) ? initialZoom : 1);
+      setPan({ x: 0, y: 0 });
 
       const handleImageLoad = () => {
         if (imgRef.current) {
@@ -157,7 +163,7 @@ const InteractiveAnnotationOverlay = forwardRef(
     // The imperative handle is built once, so it must read the ceiling through a
     // ref -- closing over effectiveMaxZoom would pin it to the pre-load value.
     const maxZoomRef = useRef(effectiveMaxZoom);
-    useEffect(() => {
+    useLayoutEffect(() => {
       maxZoomRef.current = effectiveMaxZoom;
     }, [effectiveMaxZoom]);
 
@@ -228,9 +234,10 @@ const InteractiveAnnotationOverlay = forwardRef(
       return true;
     };
 
-    // Same reason as maxZoomRef: the imperative handle needs the current closure.
+    // Same reason as maxZoomRef: the imperative handle needs the current closure,
+    // and it must be in place before a parent effect can call reset().
     const fitRef = useRef(() => false);
-    useEffect(() => {
+    useLayoutEffect(() => {
       fitRef.current = fitAnnotationView;
     });
 

--- a/frontend/src/components/AnnotationOverlay.jsx
+++ b/frontend/src/components/AnnotationOverlay.jsx
@@ -59,9 +59,15 @@ const InteractiveAnnotationOverlay = forwardRef(
     const [scaleX, setScaleX] = useState(1);
     const [scaleY, setScaleY] = useState(1);
     const [imageLoaded, setImageLoaded] = useState(false);
-    // Pixel width of the image we were actually served, and the width it is
-    // drawn at -- together these say how much detail is left to zoom into.
-    const [sourceSize, setSourceSize] = useState({ natural: 0, display: 0 });
+    // Pixel width of the image we were actually served, and the width it is drawn
+    // at -- together these say how much detail is left to zoom into. Stamped with
+    // the url they were measured from: scaleX/scaleY are set in the same batch, so
+    // a matching url means every measurement below belongs to the current image.
+    const [sourceSize, setSourceSize] = useState({
+      natural: 0,
+      display: 0,
+      url: null,
+    });
 
     const [internalShowAnn, setInternalShowAnn] = useState(true);
     const showAnn =
@@ -107,6 +113,7 @@ const InteractiveAnnotationOverlay = forwardRef(
           setSourceSize({
             natural: imgRef.current.naturalWidth,
             display: displayWidth,
+            url: imageUrl,
           });
           setImageLoaded(true);
         }
@@ -263,10 +270,22 @@ const InteractiveAnnotationOverlay = forwardRef(
 
     useEffect(() => {
       if (!imageLoaded || !fitSignature) return;
+      // A cached image re-runs this effect on the url change before the new
+      // measurements are committed; fitting then would use the previous image's
+      // scale. Wait for the measurements to catch up -- they will, next render.
+      if (sourceSize.url !== imageUrl) return;
       fitRef.current();
       // fitRef always holds the latest closure; re-running on its identity would loop.
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [imageLoaded, imageUrl, fitSignature, effectiveMaxZoom, scaleX, scaleY]);
+    }, [
+      imageLoaded,
+      imageUrl,
+      fitSignature,
+      effectiveMaxZoom,
+      scaleX,
+      scaleY,
+      sourceSize.url,
+    ]);
 
     useImperativeHandle(ref, () => ({
       zoomIn: () => {

--- a/frontend/src/pages/MatchResultsPage/components/MatchProspectTable.jsx
+++ b/frontend/src/pages/MatchResultsPage/components/MatchProspectTable.jsx
@@ -686,6 +686,7 @@ const MatchProspectTable = ({
               {hasLeftImage ? (
                 <InteractiveAnnotationOverlay
                   ref={leftOverlayRef}
+                  fitToAnnotation
                   imageUrl={leftImageUrl}
                   originalWidth={leftOrigW}
                   originalHeight={leftOrigH}
@@ -766,6 +767,7 @@ const MatchProspectTable = ({
               {hasRightImage ? (
                 <InteractiveAnnotationOverlay
                   ref={rightOverlayRef}
+                  fitToAnnotation
                   imageUrl={rightImageUrl}
                   originalWidth={rightOrigW}
                   originalHeight={rightOrigH}
@@ -988,6 +990,7 @@ const MatchProspectTable = ({
 
                   <InteractiveAnnotationOverlay
                     ref={fsLeftRef}
+                    fitToAnnotation
                     imageUrl={leftImageUrl}
                     originalWidth={leftOrigW}
                     originalHeight={leftOrigH}
@@ -1117,6 +1120,7 @@ const MatchProspectTable = ({
 
                   <InteractiveAnnotationOverlay
                     ref={fsRightRef}
+                    fitToAnnotation
                     imageUrl={rightImageUrl}
                     originalWidth={rightOrigW}
                     originalHeight={rightOrigH}

--- a/frontend/src/pages/MatchResultsPage/components/MatchProspectTable.jsx
+++ b/frontend/src/pages/MatchResultsPage/components/MatchProspectTable.jsx
@@ -314,8 +314,11 @@ const MatchProspectTable = ({
   const [hoveredRow, setHoveredRow] = React.useState(null);
 
   const handleRowClick = (rowData, rowKey) => {
+    // No reset() here: at this point the overlay still holds the previous
+    // prospect's geometry, so resetting would frame the outgoing annotation for
+    // a beat. The overlay returns to its default view when the image changes and
+    // fits the new annotation once it loads.
     setPreviewedRow({ ...rowData, _rowKey: rowKey });
-    rightOverlayRef.current?.reset?.();
   };
 
   const isSelected = (rowKey) => selectedMatch?.some((d) => d.key === rowKey);

--- a/frontend/src/utils/annotationZoom.js
+++ b/frontend/src/utils/annotationZoom.js
@@ -1,0 +1,127 @@
+/**
+ * Zoom/pan math for the annotation overlay used by the match-results page.
+ *
+ * Kept as pure functions so the render path and the auto-fit path share one
+ * definition of where an annotation lands on screen -- if those two ever
+ * disagree, the box and the zoom drift apart.
+ */
+
+// OpenSeadragon's maxZoomPixelRatio, which is what the legacy iaResults viewer
+// allowed: zoom until one source pixel covers ~1.1 screen pixels, and no further
+// (past that you are magnifying blur, not revealing detail).
+export const NATIVE_PIXEL_RATIO = 1.1;
+
+const isPositiveNumber = (v) => Number.isFinite(v) && v > 0;
+
+/**
+ * Zoom ceiling for an image, derived from how much resolution it actually has.
+ *
+ * `naturalWidth` is the served image's own pixel width, so a 4096px `_master`
+ * earns a much higher ceiling than a 1024px `_mid` of the same photo.
+ */
+export function computeMaxZoom({
+  naturalWidth,
+  displayWidth,
+  floor = 3,
+  pixelRatio = NATIVE_PIXEL_RATIO,
+}) {
+  const natural = Number(naturalWidth);
+  const display = Number(displayWidth);
+
+  if (!isPositiveNumber(natural) || !isPositiveNumber(display)) return floor;
+  return Math.max(floor, (natural / display) * pixelRatio);
+}
+
+/**
+ * Where an annotation's bounding box lands in *displayed* pixels.
+ *
+ * Bounding boxes arrive in the source asset's pixel frame; `scaleX`/`scaleY`
+ * are that frame divided by the on-screen size. Assets carrying rotation info
+ * need the extra aspect adjustment. Returns null for anything unusable --
+ * a trivial whole-image annotation, or a box with no area.
+ */
+export function annotationDisplayRect(
+  annotation,
+  { scaleX, scaleY, originalWidth, originalHeight, hasRotation = false } = {},
+) {
+  if (!annotation) return null;
+  if (annotation.trivial || annotation.isTrivial) return null;
+
+  const sx = Number(scaleX);
+  const sy = Number(scaleY);
+
+  if (!isPositiveNumber(sx) || !isPositiveNumber(sy)) return null;
+
+  const x = Number(annotation.x);
+  const y = Number(annotation.y);
+  const width = Number(annotation.width);
+  const height = Number(annotation.height);
+
+  if (![x, y].every(Number.isFinite)) return null;
+  if (!isPositiveNumber(width) || !isPositiveNumber(height)) return null;
+
+  let rect;
+  if (hasRotation) {
+    const imgW = Number(originalWidth);
+    const imgH = Number(originalHeight);
+
+    if (!isPositiveNumber(imgW) || !isPositiveNumber(imgH)) return null;
+    const adjW = imgH / imgW;
+    const adjH = imgW / imgH;
+
+    rect = {
+      x: x / sx / adjW,
+      y: y / sy / adjH,
+      width: width / sx / adjW,
+      height: height / sy / adjH,
+      rotation: Number(annotation.theta || 0),
+    };
+  } else {
+    rect = {
+      x: x / sx,
+      y: y / sy,
+      width: width / sx,
+      height: height / sy,
+      rotation: Number(annotation.theta || 0),
+    };
+  }
+
+  if (!isPositiveNumber(rect.width) || !isPositiveNumber(rect.height)) return null;
+  return rect;
+}
+
+/**
+ * Zoom and pan that put `rect` in the middle of the pane at the largest size
+ * that still fits, with `margin` (a fraction of the box) of breathing room --
+ * the React equivalent of the legacy viewer's `viewport.fitBounds()`.
+ *
+ * Pan is in the same frame as the overlay's transform: `translate(pan) scale(zoom)`
+ * about a top-left origin.
+ */
+export function computeFitToAnnotation({
+  rect,
+  containerWidth,
+  containerHeight,
+  minZoom = 1,
+  maxZoom = 3,
+  margin = 0.1,
+}) {
+  if (!rect) return null;
+  const cw = Number(containerWidth);
+  const ch = Number(containerHeight);
+
+  if (!isPositiveNumber(cw) || !isPositiveNumber(ch)) return null;
+  if (!isPositiveNumber(rect.width) || !isPositiveNumber(rect.height)) return null;
+
+  const padded = 1 + Math.max(0, margin);
+  const fit = Math.min(cw / (rect.width * padded), ch / (rect.height * padded));
+  const zoom = Math.max(minZoom, Math.min(maxZoom, fit));
+
+  return {
+    zoom,
+    pan: {
+      x: cw / 2 - (rect.x + rect.width / 2) * zoom,
+      y: ch / 2 - (rect.y + rect.height / 2) * zoom,
+    },
+  };
+}

--- a/src/main/java/org/ecocean/ia/MatchResult.java
+++ b/src/main/java/org/ecocean/ia/MatchResult.java
@@ -726,6 +726,37 @@ public class MatchResult implements java.io.Serializable {
     // Prefer a pre-batched annotation-id -> Encounter map (one loader call for the whole result) and
     // fall back to the per-annotation query when the map is absent or lacks this id (e.g. the single
     // queryAnnotation call). Absent id -> findEncounter; the map never holds null values.
+    /**
+     * Highest-resolution servable URL for a match-results image.
+     *
+     * MediaAsset.toSimpleJSONObject() resolves its url through the no-argument safeURL(), which has
+     * no request and so always resolves as anonymous -- pinning every caller to the "mid" (1024px)
+     * derivative. The match-results endpoint is login-gated (GenericObject returns 401 without a
+     * currentUser), and the legacy iaResults page served "master" (4096px) here via
+     * sanitizeJson(request, ...), so 1024px is both a regression and too small to inspect fluke or
+     * fin detail at zoom.
+     *
+     * bestSafeAsset() matches its bestType exactly and returns null rather than degrading, hence the
+     * explicit master -> mid walk. The final no-bestType call preserves the previous behavior for
+     * anything the walk cannot resolve, so this can only ever widen what we serve, never narrow it.
+     */
+    private static URL bestResolutionURL(MediaAsset ma, Shepherd myShepherd) {
+        if (ma == null) return null;
+        for (String bestType : new String[] { "master", "mid" }) {
+            try {
+                URL u = ma.safeURL(myShepherd, null, bestType);
+                if (u != null) return u;
+            } catch (RuntimeException ex) {
+                // e.g. bestSafeAsset() throws when a parent asset row is missing; try the next type
+            }
+        }
+        try {
+            return ma.safeURL(myShepherd);
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+
     private static Encounter resolveEncounter(Annotation ann, Shepherd myShepherd,
         java.util.Map<String, Encounter> encByAnnId) {
         if ((encByAnnId != null) && (ann.getId() != null) && encByAnnId.containsKey(ann.getId())) {
@@ -760,6 +791,8 @@ public class MatchResult implements java.io.Serializable {
         }
         if (ma != null) {
             JSONObject mj = ma.toSimpleJSONObject();
+            URL best = bestResolutionURL(ma, myShepherd);
+            if (best != null) mj.put("url", best.toString());
             mj.put("rotationInfo", ma.getRotationInfo());
             aj.put("asset", mj);
         }

--- a/src/main/java/org/ecocean/ia/MatchResult.java
+++ b/src/main/java/org/ecocean/ia/MatchResult.java
@@ -739,6 +739,10 @@ public class MatchResult implements java.io.Serializable {
      * bestSafeAsset() matches its bestType exactly and returns null rather than degrading, hence the
      * explicit master -> mid walk. The final no-bestType call preserves the previous behavior for
      * anything the walk cannot resolve, so this can only ever widen what we serve, never narrow it.
+     *
+     * Resolving here rather than inside toSimpleJSONObject() also means one lookup per asset on the
+     * caller's Shepherd instead of two, one of them on a throwaway Shepherd -- and it puts the whole
+     * resolution behind this method's fail-soft, where a missing parent row would otherwise throw.
      */
     private static URL bestResolutionURL(MediaAsset ma, Shepherd myShepherd) {
         if (ma == null) return null;
@@ -790,9 +794,7 @@ public class MatchResult implements java.io.Serializable {
             }
         }
         if (ma != null) {
-            JSONObject mj = ma.toSimpleJSONObject();
-            URL best = bestResolutionURL(ma, myShepherd);
-            if (best != null) mj.put("url", best.toString());
+            JSONObject mj = ma.toSimpleJSONObject(bestResolutionURL(ma, myShepherd));
             mj.put("rotationInfo", ma.getRotationInfo());
             aj.put("asset", mj);
         }

--- a/src/main/java/org/ecocean/media/MediaAsset.java
+++ b/src/main/java/org/ecocean/media/MediaAsset.java
@@ -996,11 +996,23 @@ public class MediaAsset extends Base implements java.io.Serializable {
 
     // carefree, safe json version
     public JSONObject toSimpleJSONObject() {
+        return toSimpleJSONObject(safeURL());
+    }
+
+    /**
+     * As toSimpleJSONObject(), but with the url already resolved by the caller.
+     *
+     * The no-argument safeURL() builds a throwaway Shepherd per call and resolves as anonymous.
+     * A caller that already holds a Shepherd, or that wants a particular derivative, should
+     * resolve once and pass the result rather than paying for a lookup it is about to discard.
+     * A null url is omitted from the object, exactly as before.
+     */
+    public JSONObject toSimpleJSONObject(URL url) {
         JSONObject j = new JSONObject();
 
         j.put("id", getIdInt());
         j.put("uuid", getUUID());
-        j.put("url", safeURL());
+        j.put("url", url);
         if ((getMetadata() != null) && (getMetadata().getData() != null) &&
             (getMetadata().getData().opt("attributes") != null)) {
             j.put("attributes", getMetadata().getData().opt("attributes"));

--- a/src/test/java/org/ecocean/MatchResultTest.java
+++ b/src/test/java/org/ecocean/MatchResultTest.java
@@ -1,6 +1,7 @@
 package org.ecocean;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import javax.jdo.PersistenceManagerFactory;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
@@ -275,5 +277,54 @@ class MatchResultTest {
         assertEquals(0.7, pj.getJSONArray("annot").getJSONObject(0).getDouble("score"), 1e-9);
         assertEquals(1, pj.getJSONArray("indiv").length());
         assertEquals(0.5, pj.getJSONArray("indiv").getJSONObject(0).getDouble("score"), 1e-9);
+    }
+
+    // The match-results endpoint is login-gated, so the image URL it emits should be the
+    // highest-resolution derivative available. MediaAsset.toSimpleJSONObject() resolves its
+    // url via the no-request safeURL(), which always falls to the anonymous "mid" (1024px)
+    // derivative -- too small to inspect fluke/fin detail at zoom.
+    @Test void annotationDetailsPrefersMasterOverMid()
+    throws Exception {
+        Shepherd myShepherd = mock(Shepherd.class);
+        MediaAsset ma = mock(MediaAsset.class);
+        JSONObject simple = new JSONObject();
+
+        simple.put("url", "http://example.org/mid.jpg");
+        when(ma.toSimpleJSONObject()).thenReturn(simple);
+        when(ma.safeURL(any(), any(), eq("master"))).thenReturn(new URL(
+            "http://example.org/master.jpg"));
+        when(ma.safeURL(any(), any(), eq("mid"))).thenReturn(new URL("http://example.org/mid.jpg"));
+
+        Annotation ann = mock(Annotation.class);
+        when(ann.getMediaAsset()).thenReturn(ma);
+
+        JSONObject aj = MatchResult.annotationDetails(ann, myShepherd);
+        org.junit.jupiter.api.Assertions.assertEquals("http://example.org/master.jpg",
+            aj.getJSONObject("asset").getString("url"),
+            "match-results should serve the _master derivative, not the anonymous _mid one");
+    }
+
+    // bestSafeAsset() matches its bestType exactly and returns null rather than degrading, so an
+    // asset with no _master child must still yield its _mid URL -- never a missing image.
+    @Test void annotationDetailsFallsBackToMidWhenNoMaster()
+    throws Exception {
+        Shepherd myShepherd = mock(Shepherd.class);
+        MediaAsset ma = mock(MediaAsset.class);
+        JSONObject simple = new JSONObject();
+
+        // org.json omits a null value, so an asset whose anonymous resolution yields nothing
+        // reaches us with no "url" key at all.
+        simple.put("id", 42);
+        when(ma.toSimpleJSONObject()).thenReturn(simple);
+        when(ma.safeURL(any(), any(), eq("master"))).thenReturn(null);
+        when(ma.safeURL(any(), any(), eq("mid"))).thenReturn(new URL("http://example.org/mid.jpg"));
+
+        Annotation ann = mock(Annotation.class);
+        when(ann.getMediaAsset()).thenReturn(ma);
+
+        JSONObject aj = MatchResult.annotationDetails(ann, myShepherd);
+        org.junit.jupiter.api.Assertions.assertEquals("http://example.org/mid.jpg",
+            aj.getJSONObject("asset").optString("url"),
+            "a _mid-only asset must still render, not drop its url");
     }
 }

--- a/src/test/java/org/ecocean/MatchResultTest.java
+++ b/src/test/java/org/ecocean/MatchResultTest.java
@@ -287,10 +287,7 @@ class MatchResultTest {
     throws Exception {
         Shepherd myShepherd = mock(Shepherd.class);
         MediaAsset ma = mock(MediaAsset.class);
-        JSONObject simple = new JSONObject();
-
-        simple.put("url", "http://example.org/mid.jpg");
-        when(ma.toSimpleJSONObject()).thenReturn(simple);
+        echoResolvedUrl(ma);
         when(ma.safeURL(any(), any(), eq("master"))).thenReturn(new URL(
             "http://example.org/master.jpg"));
         when(ma.safeURL(any(), any(), eq("mid"))).thenReturn(new URL("http://example.org/mid.jpg"));
@@ -300,7 +297,7 @@ class MatchResultTest {
 
         JSONObject aj = MatchResult.annotationDetails(ann, myShepherd);
         org.junit.jupiter.api.Assertions.assertEquals("http://example.org/master.jpg",
-            aj.getJSONObject("asset").getString("url"),
+            aj.getJSONObject("asset").optString("url"),
             "match-results should serve the _master derivative, not the anonymous _mid one");
     }
 
@@ -310,12 +307,7 @@ class MatchResultTest {
     throws Exception {
         Shepherd myShepherd = mock(Shepherd.class);
         MediaAsset ma = mock(MediaAsset.class);
-        JSONObject simple = new JSONObject();
-
-        // org.json omits a null value, so an asset whose anonymous resolution yields nothing
-        // reaches us with no "url" key at all.
-        simple.put("id", 42);
-        when(ma.toSimpleJSONObject()).thenReturn(simple);
+        echoResolvedUrl(ma);
         when(ma.safeURL(any(), any(), eq("master"))).thenReturn(null);
         when(ma.safeURL(any(), any(), eq("mid"))).thenReturn(new URL("http://example.org/mid.jpg"));
 
@@ -326,5 +318,37 @@ class MatchResultTest {
         org.junit.jupiter.api.Assertions.assertEquals("http://example.org/mid.jpg",
             aj.getJSONObject("asset").optString("url"),
             "a _mid-only asset must still render, not drop its url");
+    }
+
+    // bestSafeAsset() throws when an asset's parent row is missing. That must not cost us the
+    // image -- the walk should carry on to the next derivative.
+    @Test void annotationDetailsFallsBackToMidWhenMasterLookupThrows()
+    throws Exception {
+        Shepherd myShepherd = mock(Shepherd.class);
+        MediaAsset ma = mock(MediaAsset.class);
+
+        echoResolvedUrl(ma);
+        when(ma.safeURL(any(), any(), eq("master"))).thenThrow(new RuntimeException(
+            "bestSafeAsset() failed to find parent"));
+        when(ma.safeURL(any(), any(), eq("mid"))).thenReturn(new URL("http://example.org/mid.jpg"));
+
+        Annotation ann = mock(Annotation.class);
+        when(ann.getMediaAsset()).thenReturn(ma);
+
+        JSONObject aj = MatchResult.annotationDetails(ann, myShepherd);
+        org.junit.jupiter.api.Assertions.assertEquals("http://example.org/mid.jpg",
+            aj.getJSONObject("asset").optString("url"),
+            "a throwing master lookup must not cost us the image");
+    }
+
+    // Serialize whatever url annotationDetails resolved, so the assertions read the real
+    // decision instead of a canned mock value.
+    private static void echoResolvedUrl(MediaAsset ma) {
+        when(ma.toSimpleJSONObject(any())).thenAnswer(inv -> {
+            JSONObject j = new JSONObject();
+
+            j.put("url", (URL)inv.getArgument(0));
+            return j;
+        });
     }
 }


### PR DESCRIPTION
Two pieces of user feedback on `/react/match-results`, comparing it to the old `iaResults.jsp` page:

> "Can't zoom in far enough to see details on the whale."

> "The old match page would automatically zoom in to the annotation whereas now it shows the full image and they have to zoom into all their match results now."

Both are regressions against the legacy page. There are three distinct causes.

## 1. The page was serving the 1024px derivative, not the 4096px one

This is the load-bearing one. `MatchResult.annotationDetails` built the image url via `MediaAsset.toSimpleJSONObject()`, which resolves through the **no-argument** `safeURL()`. That path has no `HttpServletRequest`, so `AccessControl.isAnonymous(null)` returns `true`, `bestSafeAsset` sets `bestType = "mid"`, and **every user got the anonymous 1024×768 derivative — logged in or not.**

The legacy page did not do this: `iaResultsAnnotFeed.jsp` serialized via `ma.sanitizeJson(request, ...)` → `safeURL(myShepherd, request)` → `_master` (4096) for an authenticated user.

The arithmetic matters here. On a 1440px screen the image column is ~640px wide, so a 1024px `_mid` was already being displayed at ~1.6× its native size. At the old 3× cap the page was magnifying blur — there was no detail left to reveal. **Raising the zoom cap alone would have made the image bigger and no sharper.**

`annotationDetails` serves both the query annotation and every prospect, so one fix covers both panes.

## 2. The zoom ceiling was hardcoded at 3×

`AnnotationOverlay` defaulted to `minZoom = 1, maxZoom = 3, zoomStep = 0.25`, and no caller overrode them. The ceiling is now derived from the served image's own resolution — `naturalWidth / displayWidth * 1.1`, mirroring OpenSeadragon's `maxZoomPixelRatio`, with the old 3× kept as a floor. A 4096px master now reaches roughly 7× instead of 3×, and stops where magnifying blur would begin. Steps are multiplicative (1.25×) so getting there is a few notches rather than two dozen.

## 3. Auto-zoom to the annotation was never ported

The old page ran an OpenSeadragon viewer per annotation and called `viewer.viewport.fitBounds(rect)` on `open`, and again on `switchAnnots` when you clicked a different result. The React overlay always opened fit-to-whole-image.

It now fits and centres the annotation on load and whenever the previewed prospect changes. The bounding box was already in the props, so this needed no API change. `reset()` now means "the default view", so selecting a new row reframes rather than dropping back to the whole photo; zooming all the way out still shows it. A trivial (whole-image) annotation is left unfitted, and so is an image carrying more than one box, where there is no obvious subject.

The bbox → display-pixel math is now a single helper used by **both** the drawn box and the fit, so the two cannot drift apart.

## Also in here

`MediaAsset.toSimpleJSONObject(URL)` overload; the no-arg version delegates to it. Resolving the url once and passing it in avoids a second lookup per asset **and** removes a throwaway `Shepherd` per asset — a match-results response carries up to `DEFAULT_PROSPECTS_CUTOFF` (100) prospects and can be asked for all of them. It also puts the whole asset block behind `bestResolutionURL()`'s fail-soft, where a missing parent row previously threw out of `toSimpleJSONObject()` before any catch could see it.

`bestSafeAsset` matches its `bestType` **exactly** and returns `null` rather than degrading, which is why the `master → mid` walk is explicit rather than a single call. The final no-`bestType` call preserves the previous behaviour as a floor, so this can only ever widen what is served, never narrow it.

## Testing

- `MatchResultTest`: 9/9. The three new `annotationDetails*` tests echo the resolved url back through the serializer, so they assert the real routing decision rather than a canned mock value. The fail-soft case was verified load-bearing by removing the catch and confirming only that test breaks.
- Full `mvn test`: **864 passed, 0 failures, 0 errors**.
- New `frontend/src/utils/annotationZoom.js` has 11 jest tests covering the zoom ceiling, the rotation branch of the rect math, and the fit including both clamps.
- Frontend suite: 186 passed. Seven tests are red (`MatchResults.test.jsx` ×5, `CreateNewIndividualModal`, `MatchConfirmedModal`) — these were **baselined against the branch base and fail there too**; this PR adds none.

Reviewed by Codex over four rounds to converged / no Major findings.

## Notes for the reviewer

**Not visually verified.** The maths and the data path are tested, but nobody has yet watched this frame a real fluke on flukebook. Worth a look before release.

**A pre-existing gap this touches but does not fix.** `/api/v3/tasks/{id}/match-results` deliberately skips `task.canUserAccess()` — its own comment says it "allow[s] access to anyone based on task id only". So any authenticated user holding a task id can read those results, and after this change they read them at master resolution. That is not a widening: `/iaResults.jsp` has no rule in the Shiro table and no catch-all covers it, so the legacy page already served `_master` to any authenticated user with the same task id, and this endpoint 401s without a session — its population is a strict subset. The `bestType == "mid"` rule is an anonymous-tier resolution downgrade, not a per-object ACL. The missing task ACL is still worth fixing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
