### PR TITLE
fix(pairx): resolve PairX model id and layer key from MLService config

### DIFF
--- a/src/main/java/org/ecocean/ia/MatchInspectionPairxEnricher.java
+++ b/src/main/java/org/ecocean/ia/MatchInspectionPairxEnricher.java
@@ -124,9 +124,15 @@ public final class MatchInspectionPairxEnricher {
             return null;
         }
         if (!Util.stringExists(dto.taxonomyString)) return null;
-        URL pairxUrl = MatchResult._getPairxUrl(dto.taxonomyString);
+        // One IA.json read for endpoint + model id + layer key; MLService
+        // re-parses the file per construction, so resolving these
+        // separately would read it three times per visualisation.
+        JSONObject pairxConf = MatchResult._getPairxConfig(dto.taxonomyString);
+        URL pairxUrl = MatchResult._pairxUrlFromConfig(pairxConf);
         if (pairxUrl == null) return null;
-        JSONObject payload = buildPayload(dto);
+        JSONObject payload = buildPayload(dto,
+            MatchResult._pairxModelIdFromConfig(pairxConf),
+            MatchResult._pairxLayerKeyFromConfig(pairxConf));
         JSONObject res = RestClient.postJSON(pairxUrl, payload, null);
         if (res == null) return null;
         JSONArray imgs = res.optJSONArray("images");
@@ -143,13 +149,30 @@ public final class MatchInspectionPairxEnricher {
      * C12 clampBbox and addBboxPayload fixes baked in.
      */
     static JSONObject buildPayload(PairxDto dto) {
+        return buildPayload(dto, MatchResult.DEFAULT_PAIRX_MODEL_ID,
+            MatchResult.DEFAULT_PAIRX_LAYER_KEY);
+    }
+
+    /**
+     * As {@link #buildPayload(PairxDto)}, with {@code model_id} and
+     * {@code layer_key} supplied by the caller. Both are resolved from the
+     * taxonomy's MLService config rather than hardcoded, because
+     * ml-service registries differ per installation and an unknown id used
+     * to produce an HTTP 500 that Wildbook then retried indefinitely.
+     *
+     * <p>A null or blank argument normalises to the historic default: the
+     * payload must never carry a null {@code model_id}.
+     */
+    static JSONObject buildPayload(PairxDto dto, String modelId, String layerKey) {
+        if (!Util.stringExists(modelId)) modelId = MatchResult.DEFAULT_PAIRX_MODEL_ID;
+        if (!Util.stringExists(layerKey)) layerKey = MatchResult.DEFAULT_PAIRX_LAYER_KEY;
         JSONObject payload = new JSONObject();
         payload.put("algorithm", "pairx");
         payload.put("visualization_type", "only_colors");
         payload.put("k_colors", 5);
-        payload.put("model_id", "miewid-msv4.1");
+        payload.put("model_id", modelId);
         payload.put("crop_bbox", false);
-        payload.put("layer_key", "backbone.blocks.3");
+        payload.put("layer_key", layerKey);
         payload.put("image1_uris", new JSONArray().put(dto.queryImageUri));
         payload.put("image2_uris", new JSONArray().put(dto.prospectImageUri));
         payload.put("theta1", new JSONArray().put(dto.queryTheta));

--- a/src/main/java/org/ecocean/ia/MatchResult.java
+++ b/src/main/java/org/ecocean/ia/MatchResult.java
@@ -472,14 +472,24 @@ public class MatchResult implements java.io.Serializable {
         // we need this to find MLService endpoint
         Encounter enc = ann1.findEncounter(myShepherd);
         if (enc == null) return null;
+        // One IA.json read for endpoint + model id + layer key. A null block
+        // means the config is unreadable or absent: skip PairX rather than
+        // POST a default model id this deployment may not have loaded.
+        JSONObject pairxConf = _getPairxConfig(enc.getTaxonomyString());
+        if (pairxConf == null) {
+            System.out.println(
+                "[WARNING] createInspectionPairxAsset() no MLService config for tx=" +
+                enc.getTaxonomyString() + "; skipping PairX");
+            return null;
+        }
         JSONObject payload = new JSONObject();
         payload.put("algorithm", "pairx");
         payload.put("visualization_type", "only_colors");
         payload.put("k_colors", 5);
         // payload.put("k_lines", 20);
-        payload.put("model_id", "miewid-msv4.1");
+        payload.put("model_id", _pairxModelIdFromConfig(pairxConf));
         payload.put("crop_bbox", false);
-        payload.put("layer_key", "backbone.blocks.3");
+        payload.put("layer_key", _pairxLayerKeyFromConfig(pairxConf));
         payload.put("image1_uris", new JSONArray(new String[] { ma1.webURL().toString() }));
         payload.put("image2_uris", new JSONArray(new String[] { ma2.webURL().toString() }));
         payload.put("theta1", new JSONArray(new Double[] { ann1.getTheta() }));
@@ -506,7 +516,7 @@ public class MatchResult implements java.io.Serializable {
         JSONObject res = null;
         URL pairxUrl = null;
         try {
-            pairxUrl = _getPairxUrl(enc.getTaxonomyString());
+            pairxUrl = _pairxUrlFromConfig(pairxConf);
             if (pairxUrl == null) return null;
             res = RestClient.postJSON(pairxUrl, payload, null);
         } catch (Exception ex) {
@@ -614,6 +624,84 @@ public class MatchResult implements java.io.Serializable {
     static void addBboxPayload(JSONObject payload, int[] bbox1, int[] bbox2) {
         payload.put("bb1", new JSONArray().put(bboxToJsonArray(bbox1)));
         payload.put("bb2", new JSONArray().put(bboxToJsonArray(bbox2)));
+    }
+
+    /**
+     * Default PairX model id, used when the MLService config names none.
+     * Historic hardcoded value; kept as the fallback so installations that
+     * configure nothing behave exactly as before.
+     */
+    public static final String DEFAULT_PAIRX_MODEL_ID = "miewid-msv4.1";
+
+    /**
+     * Default PairX layer key. Model-architecture specific: configuring a
+     * different model id does not guarantee this layer exists, so it is
+     * configurable alongside the model id rather than hardcoded.
+     */
+    public static final String DEFAULT_PAIRX_LAYER_KEY = "backbone.blocks.3";
+
+    /**
+     * The taxonomy's first MLService config block, or {@code null}.
+     *
+     * <p>Each call constructs {@link MLService}, which re-reads and
+     * re-parses IA.json from disk ({@code JsonProperties} does not cache).
+     * Callers needing both the endpoint and the model id must therefore
+     * fetch the block once and use the {@code *FromConfig} helpers rather
+     * than resolving each one separately, which would re-read the file
+     * once per value per visualisation.
+     */
+    static JSONObject _getPairxConfig(String txStr) {
+        if (txStr == null) return null;
+        try {
+            MLService mls = new MLService();
+            List<JSONObject> confs = mls.getConfigs(txStr);
+            if (confs.size() < 1) {
+                System.out.println("[WARNING] _getPairxConfig() empty MLService configs for tx=" +
+                    txStr);
+                return null;
+            }
+            return confs.get(0);
+        } catch (Exception ex) {
+            System.out.println("[WARNING] _getPairxConfig(" + txStr + ") failed: " + ex);
+            return null;
+        }
+    }
+
+    /**
+     * PairX model id from an MLService config block.
+     *
+     * <p>Prefers an explicit {@code pairx_model_id}, else reuses
+     * {@code extract_model_id} — PairX visualises the embedding space the
+     * match was computed in, so the two must not drift — else the default.
+     *
+     * <p>ml-service registries differ per installation (kaiju loads
+     * {@code miewid-msv4_v3}, not {@code miewid-msv4.1}); sending an id the
+     * target has not loaded previously produced an HTTP 500 that Wildbook
+     * then retried indefinitely.
+     */
+    static String _pairxModelIdFromConfig(JSONObject conf) {
+        if (conf == null) return DEFAULT_PAIRX_MODEL_ID;
+        String modelId = conf.optString("pairx_model_id", null);
+        if (!Util.stringExists(modelId)) modelId = conf.optString("extract_model_id", null);
+        if (!Util.stringExists(modelId)) return DEFAULT_PAIRX_MODEL_ID;
+        return modelId;
+    }
+
+    /** PairX layer key from an MLService config block. */
+    static String _pairxLayerKeyFromConfig(JSONObject conf) {
+        if (conf == null) return DEFAULT_PAIRX_LAYER_KEY;
+        String layerKey = conf.optString("pairx_layer_key", null);
+        if (!Util.stringExists(layerKey)) return DEFAULT_PAIRX_LAYER_KEY;
+        return layerKey;
+    }
+
+    /** The {@code /explain/} endpoint from an MLService config block, or null. */
+    static URL _pairxUrlFromConfig(JSONObject conf)
+    throws IOException {
+        if (conf == null) return null;
+        String urlStr = conf.optString("api_endpoint", null);
+        if (urlStr == null) return null;
+        return new URL(urlStr + "/explain/");
     }
 
     public static URL _getPairxUrl(String txStr)

--- a/src/test/java/org/ecocean/ia/MatchInspectionPairxEnricherTest.java
+++ b/src/test/java/org/ecocean/ia/MatchInspectionPairxEnricherTest.java
@@ -33,6 +33,90 @@ class MatchInspectionPairxEnricherTest {
 
     // --- buildPayload ---------------------------------------------------
 
+    @Test void buildPayload_usesSuppliedModelId() {
+        // Registries differ per installation: kaiju loads miewid-msv4_v3,
+        // not the historic miewid-msv4.1. Sending an id the target has not
+        // loaded produced an HTTP 500 that Wildbook retried indefinitely.
+        JSONObject p = MatchInspectionPairxEnricher.buildPayload(sampleDto(), "miewid-msv4_v3", "backbone.blocks.3");
+        assertEquals("miewid-msv4_v3", p.getString("model_id"));
+    }
+
+    @Test void buildPayload_defaultOverloadUsesDefaultModelId() {
+        JSONObject p = MatchInspectionPairxEnricher.buildPayload(sampleDto());
+        assertEquals(MatchResult.DEFAULT_PAIRX_MODEL_ID, p.getString("model_id"));
+    }
+
+    @Test void buildPayload_modelIdDoesNotDisturbOtherKeys() {
+        JSONObject p = MatchInspectionPairxEnricher.buildPayload(sampleDto(), "anything", "backbone.blocks.9");
+        assertEquals("pairx", p.getString("algorithm"));
+        assertEquals("backbone.blocks.9", p.getString("layer_key"));
+        assertEquals(5, p.getInt("k_colors"));
+    }
+
+    @Test void buildPayload_usesSuppliedLayerKey() {
+        // layer_key is model-architecture specific: a configured model is
+        // not guaranteed to expose backbone.blocks.3.
+        JSONObject p = MatchInspectionPairxEnricher.buildPayload(
+            sampleDto(), "m", "backbone.blocks.1");
+        assertEquals("backbone.blocks.1", p.getString("layer_key"));
+    }
+
+    @Test void buildPayload_nullOrBlankArgsNormaliseToDefaults() {
+        // The payload must never carry a null model_id.
+        JSONObject p = MatchInspectionPairxEnricher.buildPayload(sampleDto(), null, null);
+        assertEquals(MatchResult.DEFAULT_PAIRX_MODEL_ID, p.getString("model_id"));
+        assertEquals(MatchResult.DEFAULT_PAIRX_LAYER_KEY, p.getString("layer_key"));
+        JSONObject q = MatchInspectionPairxEnricher.buildPayload(sampleDto(), "  ", "");
+        assertEquals(MatchResult.DEFAULT_PAIRX_MODEL_ID, q.getString("model_id"));
+        assertEquals(MatchResult.DEFAULT_PAIRX_LAYER_KEY, q.getString("layer_key"));
+    }
+
+    @Test void pairxModelIdFromConfig_precedence() {
+        JSONObject both = new JSONObject()
+            .put("pairx_model_id", "explicit").put("extract_model_id", "extract");
+        assertEquals("explicit", MatchResult._pairxModelIdFromConfig(both));
+        JSONObject extractOnly = new JSONObject().put("extract_model_id", "miewid-msv4_v3");
+        assertEquals("miewid-msv4_v3", MatchResult._pairxModelIdFromConfig(extractOnly));
+        assertEquals(MatchResult.DEFAULT_PAIRX_MODEL_ID,
+            MatchResult._pairxModelIdFromConfig(new JSONObject()));
+        assertEquals(MatchResult.DEFAULT_PAIRX_MODEL_ID,
+            MatchResult._pairxModelIdFromConfig(null));
+    }
+
+    @Test void pairxModelIdFromConfig_blankValuesFallThrough() {
+        // optString returns the blank, not the default: a blank
+        // pairx_model_id must fall through to extract_model_id, and a
+        // blank extract_model_id to the default -- never reach the wire.
+        JSONObject blankExplicit = new JSONObject()
+            .put("pairx_model_id", "   ").put("extract_model_id", "miewid-msv4_v3");
+        assertEquals("miewid-msv4_v3", MatchResult._pairxModelIdFromConfig(blankExplicit));
+        JSONObject bothBlank = new JSONObject()
+            .put("pairx_model_id", "").put("extract_model_id", "  ");
+        assertEquals(MatchResult.DEFAULT_PAIRX_MODEL_ID,
+            MatchResult._pairxModelIdFromConfig(bothBlank));
+    }
+
+    @Test void pairxLayerKeyFromConfig_blankFallsBackToDefault() {
+        assertEquals(MatchResult.DEFAULT_PAIRX_LAYER_KEY,
+            MatchResult._pairxLayerKeyFromConfig(new JSONObject().put("pairx_layer_key", "  ")));
+    }
+
+    @Test void pairxLayerKeyFromConfig_precedence() {
+        assertEquals("backbone.blocks.1", MatchResult._pairxLayerKeyFromConfig(
+            new JSONObject().put("pairx_layer_key", "backbone.blocks.1")));
+        assertEquals(MatchResult.DEFAULT_PAIRX_LAYER_KEY,
+            MatchResult._pairxLayerKeyFromConfig(new JSONObject()));
+        assertEquals(MatchResult.DEFAULT_PAIRX_LAYER_KEY,
+            MatchResult._pairxLayerKeyFromConfig(null));
+    }
+
+    @Test void pairxUrlFromConfig_nullConfigYieldsNullSoPairxIsSkipped() throws Exception {
+        // A config read that failed must skip PairX entirely rather than
+        // POST a default model id the deployment may not have loaded.
+        assertNull(MatchResult._pairxUrlFromConfig(null));
+        assertNull(MatchResult._pairxUrlFromConfig(new JSONObject()));
+    }
+
     @Test void buildPayload_setsAllFixedKeys() {
         JSONObject p = MatchInspectionPairxEnricher.buildPayload(sampleDto());
         assertEquals("pairx", p.getString("algorithm"));


### PR DESCRIPTION
## Problem

Both PairX POST paths hardcoded `payload.put("model_id", "miewid-msv4.1")` — `MatchResult.createInspectionPairxAsset` and `MatchInspectionPairxEnricher.buildPayload`.

ml-service model registries differ per installation. On one production host the registry holds exactly **one** MiewID model, named `miewid-msv4_v3`. Sending `miewid-msv4.1` there hit an unguarded lookup in ml-service and returned **HTTP 500**, which `MlServiceClient`'s 5xx retry policy then reissued indefinitely against an error that could never resolve. PairX was 100% broken on that host.

## Approach

PairX visualises the embedding space the match was computed in, so its model must track the model that produced the embedding rather than a literal.

- **`MatchResult._getPairxConfig()`** returns the taxonomy's MLService config block **once**. `MLService` re-reads and re-parses IA.json on every construction (`JsonProperties` opens a `FileInputStream` with no cache), so resolving endpoint, model id and layer key separately would read the file three times per visualisation.
- **`_pairxModelIdFromConfig()`** — `pairx_model_id`, else `extract_model_id`, else `DEFAULT_PAIRX_MODEL_ID`. Blank values fall through rather than reaching the wire.
- **`_pairxLayerKeyFromConfig()`** — `pairx_layer_key`, else `DEFAULT_PAIRX_LAYER_KEY`. The layer is architecture-specific; configuring a model does not guarantee `backbone.blocks.3` exists.
- **A config block that cannot be read now skips PairX entirely** on both paths, rather than POSTing a default id the deployment may not have loaded — which is the exact failure this change removes.
- `buildPayload` normalises a null or blank model id / layer key to the defaults, so the payload can never carry a null `model_id`.

`_getPairxUrl` keeps its exact prior contract and body. It is unused by the two revised paths but remains public API, so it is not removed here.

## Deployment

**Installations that already set `extract_model_id` need no config change.** Optional new keys in the `_mlservice_conf` block:

| key | purpose |
|---|---|
| `pairx_model_id` | explicit override, only for an alias or deliberately compatible explain-model |
| `pairx_layer_key` | override when the configured model does not expose `backbone.blocks.3` |

## Companion change

ml-service is fixed separately: `/explain/` now resolves the model against its registry and returns **404** (listing loaded models) or **400** for a non-MiewID model, instead of letting an `AttributeError` become a retryable 500.

## Testing

93 tests pass across `MatchResult*`, `MlServiceClient`, `MatchInspection*` — 19 in `MatchInspectionPairxEnricherTest`, including new coverage for precedence, blank-value fall-through, null normalisation, and the null-config skip.

Reviewed by codex over three rounds; converged with no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)