### PR TITLE
feat(individuals): let curators set an individual's taxonomy

### DIFF
--- a/src/main/java/org/ecocean/servlet/IndividualSetTaxonomy.java
+++ b/src/main/java/org/ecocean/servlet/IndividualSetTaxonomy.java
@@ -1,0 +1,203 @@
+package org.ecocean.servlet;
+
+import org.ecocean.MarkedIndividual;
+import org.ecocean.security.Collaboration;
+import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.Util;
+
+import org.apache.commons.lang3.StringEscapeUtils;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Set;
+
+// Set the taxonomy of an individual, either to a stated value or to whatever its encounters agree on.
+public class IndividualSetTaxonomy extends HttpServlet {
+    // A <select> submits a single value, so "copy the taxonomy from the encounters" has to travel
+    // in the same parameter as a literal taxonomy would. It is matched before anything else and
+    // never reaches setGenus()/setSpecificEpithet().
+    public static final String FROM_ENCOUNTERS = "__FROM_ENCOUNTERS__";
+
+    public void init(ServletConfig config)
+    throws ServletException {
+        super.init(config);
+    }
+
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+    throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+    throws ServletException, IOException {
+        request.setCharacterEncoding("UTF-8");
+        String context = "context0";
+        context = ServletUtilities.getContext(request);
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("IndividualSetTaxonomy.class");
+        // set up for response
+        response.setContentType("text/html; charset=UTF-8");
+        PrintWriter out = response.getWriter();
+        String indivID = request.getParameter("individual");
+        String requested = request.getParameter("taxonomy");
+        if (Util.stringIsEmptyOrNull(indivID) || (requested == null)) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            out.println(
+                "<strong>Error:</strong> I don't have enough information to complete your request.");
+            out.close();
+            return;
+        }
+        try {
+            myShepherd.beginDBTransaction();
+            MarkedIndividual changeMe = myShepherd.getMarkedIndividual(indivID);
+            if (changeMe == null) {
+                myShepherd.rollbackDBTransaction();
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                out.println(
+                    "<strong>Error:</strong> I was unable to set the taxonomy. I cannot find that individual in the database.");
+                return;
+            }
+            // Look up and authorize outside the mutation try/catch below: everything caught in
+            // there is reported as a write conflict, which would be the wrong thing to tell
+            // someone whose real problem is a bad id or missing permission. The check needs the
+            // transaction open because it walks the individual's lazily loaded encounters.
+            if (!Collaboration.canUserFullyEditMarkedIndividual(changeMe, request)) {
+                myShepherd.rollbackDBTransaction();
+                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                out.println(
+                    "<strong>Failure:</strong> You do not have permission to change the taxonomy of this individual. Taxonomy is shared by every one of its encounters, so it may only be changed by someone who can edit all of them.");
+                return;
+            }
+            String oldTaxonomy = changeMe.getTaxonomyString();
+            String displayOld = (oldTaxonomy == null) ? "none" : oldTaxonomy;
+            String newGenus = null;
+            String newEpithet = null;
+            if (FROM_ENCOUNTERS.equals(requested)) {
+                // Ask the encounters what they say before touching the individual.
+                // setTaxonomyFromEncounters() returns getTaxonomyString() from every one of its
+                // exits, so neither its return value nor a before/after comparison can separate
+                // "the encounters agreed on nothing" from "they agreed on what is already
+                // stored" -- and only the first of those is a failure worth reporting.
+                String[] derived = MarkedIndividual.unanimousTaxonomyFromEncounters(
+                    changeMe.getEncounters());
+                if (derived == null) {
+                    myShepherd.rollbackDBTransaction();
+                    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    out.println(noDerivationMessage(changeMe));
+                    return;
+                }
+                newGenus = derived[0];
+                newEpithet = derived[1];
+            } else {
+                // Normalize once, and use the same string to validate and to store.
+                // isValidTaxonomyName() maps underscores itself but neither trims nor collapses
+                // whitespace, so without this a value could be rejected here and yet, had it
+                // passed, have been stored with a space at the front of the epithet.
+                String normalized = requested.trim().replaceAll("_", " ").replaceAll("\\s+", " ");
+                if (!Util.stringExists(normalized)) {
+                    myShepherd.rollbackDBTransaction();
+                    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    out.println("<strong>Error:</strong> Please choose a taxonomy.");
+                    return;
+                }
+                // Re-submitting the stored value is a no-op, and is checked before validation on
+                // purpose: individuals.jsp offers the individual's own taxonomy even when the
+                // site's configuration no longer lists it, and refusing to save what is already
+                // saved would make that option a trap.
+                if (normalized.equals(oldTaxonomy)) {
+                    myShepherd.rollbackDBTransaction();
+                    response.setStatus(HttpServletResponse.SC_OK);
+                    out.println("<strong>Success:</strong> Taxonomy is unchanged.");
+                    return;
+                }
+                if (!myShepherd.isValidTaxonomyName(normalized)) {
+                    myShepherd.rollbackDBTransaction();
+                    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    out.println("<strong>Error:</strong> &quot;" +
+                        StringEscapeUtils.escapeHtml4(normalized) +
+                        "&quot; is not a taxonomy this site recognizes.");
+                    return;
+                }
+                // Deliberately not MarkedIndividual.setTaxonomyString(): given a single word it
+                // assigns that word as the specific epithet and leaves the genus untouched, so
+                // choosing a genus-only taxonomy would splice it onto the old genus and assert a
+                // species nobody recorded. Util splits at the first space instead, which reads a
+                // lone word as the genus and keeps a subspecies intact.
+                String[] parts = Util.stringToGenusSpecificEpithet(normalized);
+                newGenus = parts[0];
+                newEpithet = (parts.length > 1) ? parts[1] : null;
+            }
+            String newTaxonomy = Util.taxonomyString(newGenus, newEpithet);
+            if ((newTaxonomy == null) || newTaxonomy.equals(oldTaxonomy)) {
+                myShepherd.rollbackDBTransaction();
+                response.setStatus(HttpServletResponse.SC_OK);
+                out.println("<strong>Success:</strong> Taxonomy is unchanged.");
+                return;
+            }
+            boolean locked = false;
+            try {
+                // Both parts, always. A genus-only taxonomy has to clear whatever epithet was
+                // there before, or the individual is left reading as a species nobody chose.
+                changeMe.setGenus(newGenus);
+                changeMe.setSpecificEpithet(newEpithet);
+                // Comments are rendered as HTML on the individual page. This one is safe to build
+                // unescaped only because everything reaching it has either passed
+                // isValidTaxonomyName() or come from the encounters -- keep those checks above.
+                changeMe.addComments("<p><em>" + request.getRemoteUser() + " on " +
+                    (new java.util.Date()).toString() + "</em><br>Changed taxonomy from " +
+                    displayOld + " to " + newTaxonomy + ".</p>");
+            } catch (Exception le) {
+                locked = true;
+                le.printStackTrace();
+                myShepherd.rollbackDBTransaction();
+            }
+            if (!locked) {
+                myShepherd.commitDBTransaction();
+                response.setStatus(HttpServletResponse.SC_OK);
+                out.println("<strong>Success:</strong> Taxonomy has been updated from " +
+                    displayOld + " to " + newTaxonomy + ".");
+                // after the commit: this opens a Shepherd of its own, and would otherwise report
+                // the value we just replaced
+                String message = "The taxonomy for " + indivID + " has been updated from " +
+                    displayOld + " to " + newTaxonomy + ".";
+                ServletUtilities.informInterestedIndividualParties(request, indivID, message,
+                    context);
+            } else {
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                out.println(
+                    "<strong>Failure:</strong> Taxonomy was NOT updated. This record is currently being modified by another user. Please try this operation again in a few seconds.");
+            }
+        } finally {
+            out.close();
+            myShepherd.closeDBTransaction();
+        }
+    }
+
+    // The encounters settled nothing: either they disagree, or none of them states a taxonomy at
+    // all. Which of the two it is only distinctTaxonomiesFromEncounters() can say, and what they
+    // do state is the useful thing to report back.
+    private static String noDerivationMessage(MarkedIndividual indiv) {
+        Set<String> stated = MarkedIndividual.distinctTaxonomiesFromEncounters(
+            indiv.getEncounters());
+
+        if (stated.isEmpty())
+            return
+                    "<strong>Failure:</strong> None of this individual's encounters records a taxonomy, so there is nothing to copy from them.";
+        StringBuilder sb = new StringBuilder(
+            "<strong>Failure:</strong> This individual's encounters do not agree on a taxonomy: ");
+        boolean first = true;
+        for (String tax : stated) {
+            if (!first) sb.append(", ");
+            sb.append(StringEscapeUtils.escapeHtml4(tax));
+            first = false;
+        }
+        sb.append(". Correct the encounters, or choose a taxonomy directly.");
+        return sb.toString();
+    }
+}

--- a/src/main/resources/bundles/de/individuals.properties
+++ b/src/main/resources/bundles/de/individuals.properties
@@ -162,3 +162,6 @@ projects = Projektnamen:
 previousNames= Andere Werte:
 
 sightingCountLabel = Anzahl der Sichtungen
+
+taxonomyFromEncounters = aus Begegnungen
+taxonomyUseFromEncounters = Taxonomie aus Begegnungen \u00fcbernehmen

--- a/src/main/resources/bundles/en/individuals.properties
+++ b/src/main/resources/bundles/en/individuals.properties
@@ -163,3 +163,6 @@ previousNames= Other values:
 
 sightingCountLabel = Sighting count
 
+
+taxonomyFromEncounters = from encounters
+taxonomyUseFromEncounters = Use taxonomy from encounters

--- a/src/main/resources/bundles/es/individuals.properties
+++ b/src/main/resources/bundles/es/individuals.properties
@@ -163,3 +163,6 @@ projects = Nombres de proyectos:
 previousNames= Otros valores:
 
 sightingCountLabel = Recuento de avistamientos
+
+taxonomyFromEncounters = de los encuentros
+taxonomyUseFromEncounters = Usar la taxonom\u00eda de los encuentros

--- a/src/main/resources/bundles/fr/individuals.properties
+++ b/src/main/resources/bundles/fr/individuals.properties
@@ -162,3 +162,6 @@ projects = Noms des projets :
 previousNames= Autres valeurs:
 
 sightingCountLabel = Nombre d'observations
+
+taxonomyFromEncounters = d'apr\u00e8s les rencontres
+taxonomyUseFromEncounters = Utiliser la taxonomie des rencontres

--- a/src/main/resources/bundles/it/individuals.properties
+++ b/src/main/resources/bundles/it/individuals.properties
@@ -163,3 +163,6 @@ projects = Nomi dei progetti:
 previousNames= Altri valori:
 
 sightingCountLabel = Conteggio degli avvistamenti
+
+taxonomyFromEncounters = dagli avvistamenti
+taxonomyUseFromEncounters = Usa la tassonomia dagli avvistamenti

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -199,6 +199,7 @@
 				/IndividualRemoveDataFile = authc, roles[researcher]
 				/IndividualAddComment = authc, roles[researcher]
 				/IndividualSetSex = authc, roles[researcher]
+				/IndividualSetTaxonomy = authc, roles[researcher]
 				/IndividualSetYearOfBirth = authc, roles[researcher]
 				/IndividualSetYearOfDeath = authc, roles[researcher]
 				/IndividualCreateForProject = authc, roles[researcher]
@@ -965,6 +966,14 @@
 	<servlet-mapping>
 		<servlet-name>IndividualSetSex</servlet-name>
 		<url-pattern>/IndividualSetSex</url-pattern>
+	</servlet-mapping>
+	<servlet>
+		<servlet-name>IndividualSetTaxonomy</servlet-name>
+		<servlet-class>org.ecocean.servlet.IndividualSetTaxonomy</servlet-class>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>IndividualSetTaxonomy</servlet-name>
+		<url-pattern>/IndividualSetTaxonomy</url-pattern>
 	</servlet-mapping>
 	<servlet>
 		<servlet-name>IndividualRemoveDataFile</servlet-name>

--- a/src/main/webapp/css/individualStyles.css
+++ b/src/main/webapp/css/individualStyles.css
@@ -97,20 +97,25 @@ input.nameVale, input.nameKey {
     margin-bottom: 0px;
 }
 
-#nameCheck, #namerCheck, #sexCheck, #birthCheck, #deathCheck, #altIdCheck, #matchCheck {
+#nameCheck, #namerCheck, #sexCheck, #taxonomyCheck, #birthCheck, #deathCheck, #altIdCheck, #matchCheck {
     display: none;
     color: green;
     font-family: sans-serif;
 }
 
-#nameError, #namerError, #sexError, #birthError, #deathError, #altIdError, #matchError {
+#nameError, #namerError, #sexError, #taxonomyError, #birthError, #deathError, #altIdError, #matchError {
     display: none;
     color: red;
     font-family: sans-serif;
     font-weight: bold;
 }
 
-#nicknameErrorDiv, #sexErrorDiv, #birthErrorDiv, #deathErrorDiv, #altIdErrorDiv, #matchErrorDiv {
+.taxonomyInherited {
+    color: #767676;
+    font-size: 0.9em;
+}
+
+#nicknameErrorDiv, #sexErrorDiv, #taxonomyErrorDiv, #birthErrorDiv, #deathErrorDiv, #altIdErrorDiv, #matchErrorDiv {
     display: none;
 }
 

--- a/src/main/webapp/individuals.jsp
+++ b/src/main/webapp/individuals.jsp
@@ -6,7 +6,7 @@ org.datanucleus.api.rest.orgjson.JSONException,
 org.ecocean.media.MediaAsset,
 java.net.URL,
 org.datanucleus.ExecutionContext,java.text.SimpleDateFormat,
-		 org.joda.time.DateTime,org.ecocean.*,org.ecocean.social.*,org.ecocean.servlet.ServletUtilities,java.io.File, java.util.*, org.ecocean.genetics.*,org.ecocean.security.Collaboration, org.ecocean.security.HiddenEncReporter, com.google.gson.Gson,
+		 org.joda.time.DateTime,org.ecocean.*,org.ecocean.social.*,org.ecocean.servlet.ServletUtilities,org.ecocean.servlet.IndividualSetTaxonomy,org.apache.commons.lang3.StringEscapeUtils,java.io.File, java.util.*, org.ecocean.genetics.*,org.ecocean.security.Collaboration, org.ecocean.security.HiddenEncReporter, com.google.gson.Gson,
 org.datanucleus.api.rest.RESTUtils, org.datanucleus.api.jdo.JDOPersistenceManager, java.text.SimpleDateFormat, org.apache.commons.lang3.StringUtils" %>
 <%@ page import="org.ecocean.shepherd.core.Shepherd" %>
 <%@ page import="org.ecocean.shepherd.core.ShepherdProperties" %>
@@ -434,8 +434,8 @@ input.nameKey, input.nameValue {
 
     // edit button click area!!
     $("#edit").click(function() {
-      $(".noEditText, #nameCheck, #namerCheck, #sexCheck, #birthCheck, #deathCheck, #altIdCheck, #nameError, #namerError, #sexError, #birthError, #deathError, #altIdError, span.nameKey, span.nameValue,.nameValue .hidden,.namebutton .hidden, .deletename .hidden").hide();
-      $(".editForm, .clickDateText, #Name, #Add, #birthy, #deathy, #AltID, input.nameKey, input.nameValue, #NicknameColon, #defaultNameColon, input.btn.deletename, input.namebutton, div.newnameButton").show();
+      $(".noEditText, #nameCheck, #namerCheck, #sexCheck, #taxonomyCheck, #birthCheck, #deathCheck, #altIdCheck, #nameError, #namerError, #sexError, #taxonomyError, #birthError, #deathError, #altIdError, span.nameKey, span.nameValue,.nameValue .hidden,.namebutton .hidden, .deletename .hidden").hide();
+      $(".editForm, .clickDateText, #Name, #Add, #taxonomyUpdate, #birthy, #deathy, #AltID, input.nameKey, input.nameValue, #NicknameColon, #defaultNameColon, input.btn.deletename, input.namebutton, div.newnameButton").show();
       $("#nameDiv, #namerDiv, #birthDiv, #deathDiv, #altIdDiv").removeClass("has-success");
       $("#nameDiv, #namerDiv, #birthDiv, #deathDiv, #altIdDiv").removeClass("has-error");
     });
@@ -971,13 +971,117 @@ if (sharky.getNames() != null) {
           <%
             if(CommonConfiguration.showProperty("showTaxonomy",context)){
 
-            String genusSpeciesFound=props.getProperty("notAvailable");
-            if(sharky.getGenusSpeciesDeep()!=null){genusSpeciesFound=sharky.getGenusSpeciesDeep();}
+            // what the individual itself records -- this is what the editor below changes
+            String ownTaxonomy = sharky.getTaxonomyString();
+            // what gets displayed: falls back to an encounter when the individual records nothing
+            // of its own, so say when that has happened rather than passing it off as its own
+            String deepTaxonomy = sharky.getGenusSpeciesDeep();
+            boolean taxonomyIsInherited = !Util.stringExists(ownTaxonomy) && (deepTaxonomy != null);
+            String genusSpeciesFound = (deepTaxonomy != null) ? deepTaxonomy : props.getProperty("notAvailable");
+
+            // Taxonomy is shared by every encounter of this individual, so changing it takes edit
+            // rights over all of them -- stricter than the isOwner above, which gates the Edit button.
+            boolean canEditTaxonomy = CommonConfiguration.isCatalogEditable(context) &&
+                                      Collaboration.canUserFullyEditMarkedIndividual(sharky, request);
             %>
-            <p>
-              <%=props.getProperty("taxonomy")%>: <em><%=genusSpeciesFound%></em>
+            <%-- .noEditText only when there is an edit form to swap in; without one the edit-mode
+                 toggle would hide this line and leave nothing in its place --%>
+            <p<%=canEditTaxonomy ? " class=\"noEditText\"" : ""%>>
+              <%=props.getProperty("taxonomy")%>: <em><span id="displayTaxonomy"><%=genusSpeciesFound%></span></em><%if(taxonomyIsInherited){%> <span class="taxonomyInherited" id="taxonomyInheritedNote">(<%=props.getProperty("taxonomyFromEncounters")%>)</span><%}%>
             </p>
             <%
+            if(canEditTaxonomy){
+            // only walked for someone who can actually act on it
+            String[] derivable = MarkedIndividual.unanimousTaxonomyFromEncounters(sharky.getEncounters());
+            String derivedTaxonomy = (derivable == null) ? null : Util.taxonomyString(derivable[0], derivable[1]);
+            %>
+            <div class="highlight" id="taxonomyErrorDiv"></div>
+            <form name="set_taxonomy" class="editForm">
+              <div class="form-group row">
+                <div class="col-sm-4">
+                  <label><%=props.getProperty("taxonomy")%>: </label>
+                </div>
+                <div class="col-sm-7 col-xs-11 editFormInput">
+                  <select id="newTaxonomy" name="taxonomy" size="1" class="form-control">
+                    <%-- placeholder, so an untouched dropdown cannot assign the first species --%>
+                    <option value="" disabled <%=Util.stringExists(ownTaxonomy) ? "" : "selected=\"selected\""%>><%=props.getProperty("notAvailable")%></option>
+                    <%
+                    boolean ownIsListed = false;
+                    boolean showCommonNames = "true".equals(CommonConfiguration.getProperty("showCommonSpeciesNames",context));
+                    List<String> configSpecies = CommonConfiguration.getIndexedPropertyValues("genusSpecies", context);
+                    for(int tx=0; tx<configSpecies.size(); tx++){
+                      String speciesValue = configSpecies.get(tx).replaceAll("_"," ");
+                      String speciesLabel = speciesValue;
+                      if(showCommonNames){
+                        String commonName = CommonConfiguration.getProperty("commonName"+tx, context);
+                        if(Util.stringExists(commonName)) speciesLabel = speciesValue + " (" + commonName + ")";
+                      }
+                      boolean isOwn = speciesValue.equals(ownTaxonomy);
+                      if(isOwn) ownIsListed = true;
+                      // selected is emitted here rather than set in jQuery: the sex block's
+                      // option[value=...] selector is unquoted, which a value containing a space breaks
+                    %>
+                    <option value="<%=StringEscapeUtils.escapeHtml4(speciesValue)%>"<%=isOwn ? " selected=\"selected\"" : ""%>><%=StringEscapeUtils.escapeHtml4(speciesLabel)%></option>
+                    <%
+                    }
+                    // keep a stored taxonomy this site no longer configures: opening the editor
+                    // must not be able to quietly replace a value nobody chose to change
+                    if(Util.stringExists(ownTaxonomy) && !ownIsListed){
+                    %>
+                    <option value="<%=StringEscapeUtils.escapeHtml4(ownTaxonomy)%>" selected="selected"><%=StringEscapeUtils.escapeHtml4(ownTaxonomy)%></option>
+                    <%
+                    }
+                    // only worth offering when the encounters agree on something else; the servlet
+                    // checks again, since they can change while this page sits open
+                    if((derivedTaxonomy != null) && !derivedTaxonomy.equals(ownTaxonomy)){
+                    %>
+                    <option value="<%=IndividualSetTaxonomy.FROM_ENCOUNTERS%>" data-derived="<%=StringEscapeUtils.escapeHtml4(derivedTaxonomy)%>"><%=props.getProperty("taxonomyUseFromEncounters")%> (<%=StringEscapeUtils.escapeHtml4(derivedTaxonomy)%>)</option>
+                    <%
+                    }
+                    %>
+                  </select>
+                </div>
+                <input class="btn btn-sm editFormBtn" name="taxonomyUpdate" type="submit" id="taxonomyUpdate" value="<%=update%>">
+                  <span id="taxonomyCheck">&check;</span>
+                  <span id="taxonomyError">X</span>
+              </div>
+            </form>
+
+            <script type="text/javascript">
+              $(document).ready(function() {
+                $("#taxonomyUpdate").click(function(event) {
+                  event.preventDefault();
+                  var selected = $("#newTaxonomy option:selected");
+                  var chosen = $("#newTaxonomy").val();
+                  if (!chosen) return;
+                  $("#taxonomyUpdate").hide();
+
+                  // the sentinel submits an instruction rather than a value, so take what to
+                  // display from the option itself
+                  var display = selected.attr("data-derived") || chosen;
+
+                  $.post("IndividualSetTaxonomy",
+                    {"individual": "<%=sharky.getIndividualID()%>", "taxonomy": chosen},
+                  function() {
+                    $("#taxonomyErrorDiv").hide();
+                    $("#taxonomyCheck").show();
+                    $("#displayTaxonomy").text(display);
+                    $("#taxonomyInheritedNote").remove();
+                  })
+                  .fail(function(response) {
+                    $("#taxonomyError, #taxonomyErrorDiv").show();
+                    $("#taxonomyErrorDiv").html(response.responseText);
+                  });
+                });
+
+                $("#newTaxonomy").click(function() {
+                  $("#taxonomyError, #taxonomyCheck, #taxonomyErrorDiv").hide();
+                  $("#taxonomyUpdate").show();
+                });
+              });
+            </script>
+            <%
+            }
               }
               %>
                 </div>

--- a/src/test/java/org/ecocean/servlet/IndividualSetTaxonomyTest.java
+++ b/src/test/java/org/ecocean/servlet/IndividualSetTaxonomyTest.java
@@ -1,0 +1,269 @@
+package org.ecocean.servlet;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Vector;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.ecocean.Encounter;
+import org.ecocean.MarkedIndividual;
+import org.ecocean.security.Collaboration;
+import org.ecocean.shepherd.core.Shepherd;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+/**
+ * Issue #1722: taxonomy was the only field on individuals.jsp with no way to edit it, and an
+ * individual never picked up a taxonomy its encounters were corrected to afterwards.
+ *
+ * These pin the two things about this servlet that are easy to get wrong and silent when wrong:
+ * how a chosen taxonomy is split into genus and specific epithet, and the fact that the encounters
+ * have to be asked what they say *before* the individual is touched.
+ *
+ * No DB and no container: the Shepherd is mocked at construction and the individual is a real
+ * MarkedIndividual behind a spy, so the assertions read genuine field state rather than verify().
+ */
+class IndividualSetTaxonomyTest {
+    private static final String INDIV_ID = "4a5f0f34-1722-4d1e-9b41-1f0e3c2d5a67";
+
+    private HttpServletRequest mockRequest;
+    private HttpServletResponse mockResponse;
+    private StringWriter responseOut;
+    private IndividualSetTaxonomy servlet;
+    private Shepherd usedShepherd;
+
+    @BeforeEach void setUp()
+    throws Exception {
+        mockRequest = mock(HttpServletRequest.class);
+        mockResponse = mock(HttpServletResponse.class);
+        responseOut = new StringWriter();
+        when(mockResponse.getWriter()).thenReturn(new PrintWriter(responseOut));
+        when(mockRequest.getRemoteUser()).thenReturn("tester");
+        servlet = new IndividualSetTaxonomy();
+    }
+
+    private Encounter encounter(String genus, String specificEpithet) {
+        Encounter enc = new Encounter();
+
+        enc.setGenus(genus);
+        enc.setSpecificEpithet(specificEpithet);
+        return enc;
+    }
+
+    private MarkedIndividual individual(String genus, String specificEpithet, Encounter... encs) {
+        MarkedIndividual mi = spy(new MarkedIndividual());
+
+        mi.setGenus(genus);
+        mi.setSpecificEpithet(specificEpithet);
+        doReturn(new Vector<Encounter>(Arrays.asList(encs))).when(mi).getEncounters();
+        return mi;
+    }
+
+    /** Runs one request. A null individual stands for "no such individual in the database". */
+    private void post(String taxonomyParam, MarkedIndividual indiv, boolean canEdit,
+        boolean validName)
+    throws Exception {
+        when(mockRequest.getParameter("individual")).thenReturn(INDIV_ID);
+        when(mockRequest.getParameter("taxonomy")).thenReturn(taxonomyParam);
+        try (MockedStatic<ServletUtilities> utils = mockStatic(ServletUtilities.class);
+        MockedStatic<Collaboration> collab = mockStatic(Collaboration.class);
+        MockedConstruction<Shepherd> shepherds = mockConstruction(Shepherd.class,
+                (mockShepherd, ctx) -> {
+            when(mockShepherd.getMarkedIndividual(anyString())).thenReturn(indiv);
+            when(mockShepherd.isValidTaxonomyName(anyString())).thenReturn(validName);
+        })) {
+            utils.when(() -> ServletUtilities.getContext(mockRequest)).thenReturn("context0");
+            collab.when(() -> Collaboration.canUserFullyEditMarkedIndividual(any(),
+                any())).thenReturn(canEdit);
+            servlet.doPost(mockRequest, mockResponse);
+            usedShepherd = shepherds.constructed().isEmpty() ? null : shepherds.constructed().get(
+                0);
+        }
+    }
+
+    private String body() {
+        return responseOut.toString();
+    }
+
+    // ---- how a chosen taxonomy is split -------------------------------------------------------
+
+    // Anything after the genus is the specific epithet, so a subspecies survives being chosen.
+    @Test void keepsSubspeciesIntact()
+    throws Exception {
+        MarkedIndividual mi = individual(null, null);
+
+        post("Canis lupus familiaris", mi, true, true);
+        assertEquals("Canis", mi.getGenus(), "genus is everything up to the first space");
+        assertEquals("lupus familiaris", mi.getSpecificEpithet(),
+            "everything after the first space is the epithet, subspecies included");
+    }
+
+    // MarkedIndividual.setTaxonomyString() would read a lone word as the *epithet* and leave the
+    // old genus in place, leaving this individual reading "Orcinus Delphinus" -- a species nobody
+    // recorded. A genus-only choice has to clear the epithet instead.
+    @Test void genusOnlyChoiceClearsTheEpithet()
+    throws Exception {
+        MarkedIndividual mi = individual("Orcinus", "orca");
+
+        post("Delphinus", mi, true, true);
+        assertEquals("Delphinus", mi.getGenus(), "a lone word is the genus");
+        assertNull(mi.getSpecificEpithet(), "the previous epithet must not survive");
+        assertEquals("Delphinus", mi.getTaxonomyString(), "no invented species");
+    }
+
+    @Test void collapsesStrayWhitespaceBeforeStoring()
+    throws Exception {
+        MarkedIndividual mi = individual(null, null);
+
+        post("  Orcinus   orca ", mi, true, true);
+        assertEquals("Orcinus", mi.getGenus(), "genus is trimmed");
+        assertEquals("orca", mi.getSpecificEpithet(), "epithet does not keep a leading space");
+    }
+
+    @Test void treatsUnderscoresAsSpaces()
+    throws Exception {
+        MarkedIndividual mi = individual(null, null);
+
+        post("Tursiops_truncatus", mi, true, true);
+        assertEquals("Tursiops", mi.getGenus());
+        assertEquals("truncatus", mi.getSpecificEpithet());
+    }
+
+    // ---- copying the taxonomy from the encounters ---------------------------------------------
+
+    // The ordering guard. setTaxonomyFromEncounters() returns getTaxonomyString() from every one
+    // of its exits, so an implementation that inferred failure from its return value -- or from
+    // comparing the taxonomy before and after -- would report "your encounters disagree" here,
+    // where they agree perfectly and simply have nothing new to say.
+    @Test void encountersAgreeingWithTheStoredValueIsNotAFailure()
+    throws Exception {
+        MarkedIndividual mi = individual("Orcinus", "orca", encounter("Orcinus", "orca"),
+            encounter("Orcinus", "orca"));
+
+        post(IndividualSetTaxonomy.FROM_ENCOUNTERS, mi, true, true);
+        verify(mockResponse).setStatus(HttpServletResponse.SC_OK);
+        assertEquals("Orcinus orca", mi.getTaxonomyString(), "the stored value stands");
+        assertFalse(body().contains("do not agree"),
+            "encounters that agree must never be reported as disagreeing");
+    }
+
+    @Test void copiesTheTaxonomyTheEncountersAgreeOn()
+    throws Exception {
+        MarkedIndividual mi = individual("Orcinus", "orca", encounter("Delphinus", "delphis"),
+            encounter("Delphinus", "delphis"));
+
+        post(IndividualSetTaxonomy.FROM_ENCOUNTERS, mi, true, true);
+        verify(mockResponse).setStatus(HttpServletResponse.SC_OK);
+        assertEquals("Delphinus delphis", mi.getTaxonomyString());
+        verify(usedShepherd).commitDBTransaction();
+    }
+
+    @Test void reportsWhatDisagreeingEncountersActuallySay()
+    throws Exception {
+        MarkedIndividual mi = individual("Orcinus", "orca", encounter("Orcinus", "orca"),
+            encounter("Delphinus", "delphis"));
+
+        post(IndividualSetTaxonomy.FROM_ENCOUNTERS, mi, true, true);
+        verify(mockResponse).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        assertTrue(body().contains("Orcinus orca") && body().contains("Delphinus delphis"),
+            "name the conflicting values, so the curator knows what to correct");
+        assertEquals("Orcinus orca", mi.getTaxonomyString(), "nothing is written on a conflict");
+        verify(usedShepherd, never()).commitDBTransaction();
+    }
+
+    // "we could not derive one" must never be turned into "so store nothing".
+    @Test void encountersStatingNothingLeaveTheValueAlone()
+    throws Exception {
+        MarkedIndividual mi = individual("Orcinus", "orca", encounter(null, null),
+            encounter("", ""));
+
+        post(IndividualSetTaxonomy.FROM_ENCOUNTERS, mi, true, true);
+        verify(mockResponse).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        assertEquals("Orcinus orca", mi.getTaxonomyString(), "an existing taxonomy is not cleared");
+        verify(usedShepherd, never()).commitDBTransaction();
+    }
+
+    // ---- refusals -----------------------------------------------------------------------------
+
+    @Test void refusesWithoutEditRightsOverEveryEncounter()
+    throws Exception {
+        MarkedIndividual mi = individual("Orcinus", "orca");
+
+        post("Delphinus delphis", mi, false, true);
+        verify(mockResponse).setStatus(HttpServletResponse.SC_FORBIDDEN);
+        assertEquals("Orcinus orca", mi.getTaxonomyString());
+        assertFalse(mi.getComments().contains("Changed taxonomy"),
+            "a refused request leaves no audit trail");
+        verify(usedShepherd, never()).commitDBTransaction();
+    }
+
+    // IndividualSetSex looks up the individual inside its try/catch, so an id that matches nothing
+    // NPEs and the user is told the record is being edited by someone else. Say what went wrong.
+    @Test void unknownIndividualIsNotReportedAsAWriteConflict()
+    throws Exception {
+        post("Delphinus delphis", null, true, true);
+        verify(mockResponse).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        assertFalse(body().contains("another user"), "a missing individual is not a lock conflict");
+    }
+
+    // IndividualSetSex writes this message but leaves the status at 200, so the caller's .fail()
+    // handler never runs and the page reports success.
+    @Test void missingParametersActuallySetAnErrorStatus()
+    throws Exception {
+        post(null, individual("Orcinus", "orca"), true, true);
+        verify(mockResponse).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        assertFalse(body().isEmpty());
+    }
+
+    @Test void refusesATaxonomyTheSiteDoesNotRecognize()
+    throws Exception {
+        MarkedIndividual mi = individual("Orcinus", "orca");
+
+        post("Nonsuchus fictus", mi, true, false);
+        verify(mockResponse).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        assertEquals("Orcinus orca", mi.getTaxonomyString());
+        verify(usedShepherd, never()).commitDBTransaction();
+    }
+
+    // individuals.jsp offers the individual's own taxonomy even when the site no longer configures
+    // it, so that opening the editor cannot quietly replace it. Saving it back must therefore be a
+    // no-op rather than a rejection -- note validName is false here and it still succeeds.
+    @Test void savingTheStoredValueBackIsANoOpEvenWhenUnlisted()
+    throws Exception {
+        MarkedIndividual mi = individual("Giraffa", "camelopardalis rothschildi");
+
+        post("Giraffa camelopardalis rothschildi", mi, true, false);
+        verify(mockResponse).setStatus(HttpServletResponse.SC_OK);
+        assertEquals("Giraffa camelopardalis rothschildi", mi.getTaxonomyString());
+        assertFalse(mi.getComments().contains("Changed taxonomy"),
+            "an unchanged value writes no audit comment");
+        verify(usedShepherd, never()).commitDBTransaction();
+    }
+
+    // ---- the happy path -----------------------------------------------------------------------
+
+    @Test void commitsAndRecordsWhatChanged()
+    throws Exception {
+        MarkedIndividual mi = individual("Orcinus", "orca");
+
+        post("Delphinus delphis", mi, true, true);
+        verify(mockResponse).setStatus(HttpServletResponse.SC_OK);
+        verify(usedShepherd).commitDBTransaction();
+        assertNotNull(mi.getComments());
+        assertTrue(mi.getComments().contains("Orcinus orca") &&
+            mi.getComments().contains("Delphinus delphis"),
+            "the audit comment records both the old and the new value");
+    }
+}

--- a/src/test/java/org/ecocean/servlet/IndividualSetTaxonomyWiringTest.java
+++ b/src/test/java/org/ecocean/servlet/IndividualSetTaxonomyWiringTest.java
@@ -1,0 +1,94 @@
+package org.ecocean.servlet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The parts of IndividualSetTaxonomy that live outside Java, and that nothing else here would
+ * catch. A missing servlet mapping is a 404; a missing Shiro rule is worse than a 404, because the
+ * [urls] block has no catch-all and an unmatched path is left unfiltered; and a bundle key added
+ * only to en makes the page print the literal string "null" to every other locale, permanently.
+ *
+ * Static file reads only -- no DB, no container. Paths are relative to the module root, which is
+ * the working directory Maven runs tests from.
+ */
+class IndividualSetTaxonomyWiringTest {
+    private static final String PATH = "/IndividualSetTaxonomy";
+    private static final String[] LOCALES = { "en", "de", "es", "fr", "it" };
+    private static final String[] NEW_KEYS = {
+        "taxonomyFromEncounters", "taxonomyUseFromEncounters"
+    };
+
+    private List<String> webXmlLines()
+    throws Exception {
+        File webXml = new File("src/main/webapp/WEB-INF/web.xml");
+
+        assertTrue(webXml.exists(), "web.xml not found at " + webXml.getAbsolutePath());
+        return Files.readAllLines(webXml.toPath());
+    }
+
+    private String webXml()
+    throws Exception {
+        return String.join("\n", webXmlLines());
+    }
+
+    @Test void servletClassIsRegistered()
+    throws Exception {
+        assertTrue(webXml().contains(
+            "<servlet-class>org.ecocean.servlet.IndividualSetTaxonomy</servlet-class>"),
+            "web.xml must declare the IndividualSetTaxonomy servlet class");
+    }
+
+    @Test void urlPatternIsMapped()
+    throws Exception {
+        assertTrue(webXml().contains("<url-pattern>" + PATH + "</url-pattern>"),
+            "web.xml must map " + PATH);
+    }
+
+    // Without this rule the endpoint is not merely ungated but entirely unfiltered: the [urls]
+    // block ends at /interconnect/mac/Interconnect.jar with no /** catch-all behind it.
+    @Test void shiroRuleRequiresAnAuthenticatedResearcher()
+    throws Exception {
+        String rule = webXmlLines().stream()
+                .filter(l -> {
+            String t = l.stripLeading();
+            return !t.startsWith("#") && t.startsWith(PATH + " ");
+        })
+                .findFirst().orElse(null);
+
+        assertNotNull(rule, "Shiro [urls] must contain a rule line for " + PATH);
+        assertTrue(rule.contains("authc"),
+            "the " + PATH + " rule must require authentication (was: '" + rule.strip() + "')");
+        assertTrue(rule.contains("roles[researcher]"),
+            "the " + PATH + " rule must require the researcher role (was: '" + rule.strip() + "')");
+    }
+
+    // ShepherdProperties falls back to en only when a whole bundle file is missing, never for an
+    // individual key, so a key present only in en renders as the string "null" everywhere else.
+    @Test void everyLocaleDefinesTheNewLabels()
+    throws Exception {
+        for (String locale : LOCALES) {
+            File bundle = new File("src/main/resources/bundles/" + locale +
+                "/individuals.properties");
+            assertTrue(bundle.exists(), "missing bundle: " + bundle.getPath());
+            Properties props = new Properties();
+            // .properties files here are ISO-8859-1 with \\uXXXX escapes, as Properties expects
+            try (var in = Files.newInputStream(bundle.toPath())) {
+                props.load(new java.io.InputStreamReader(in, StandardCharsets.ISO_8859_1));
+            }
+            for (String key : NEW_KEYS) {
+                String value = props.getProperty(key);
+                assertNotNull(value, locale + "/individuals.properties is missing '" + key + "'");
+                assertFalse(value.trim().isEmpty(),
+                    locale + "/individuals.properties has an empty '" + key + "'");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1722.

## The problem

Taxonomy is the only field on `individuals.jsp` with no way to edit it, and an individual never picks up a taxonomy its encounters were corrected to afterwards.

## Cause

`MarkedIndividual` stores its own `genus` and `specificEpithet`, independently of its encounters. Those fields are filled in from the encounters at exactly three moments — the two encounter-taking constructors and `addEncounter()` — all through `setTaxonomyFromEncounters()`, which returns early unless the individual is still blank:

```java
if (!force && !hasNoTaxonomyOfItsOwn()) return getTaxonomyString();
```

So the taxonomy is captured once, at creation, and never revisited. `EncounterSetGenusSpecies` and the encounter patch path both write only the encounter and never touch `enc.getIndividual()`, so a later correction cannot reach the individual — and the page offered nothing to correct it by hand. `individuals.jsp` rendered it as a bare `<p>` with no `.noEditText` class, no id, and no `.editForm`, while sex, names, birth, death and alternate ID each have an `IndividualSet*` servlet behind them.

The admin backfill added for #1113 does not help here: `backfillTaxonomyFromEncounters` skips anything where `!hasNoTaxonomyOfItsOwn()`, which is exactly this population. It fills blanks; #1722 is about stale values.

## What this adds

A new `IndividualSetTaxonomy` servlet and an inline editor on the individual page — a dropdown over the site's configured `genusSpecies`, plus one extra option that copies whatever the encounters agree on, answering both halves of the issue.

## Design notes

**The encounters are asked what they say before the individual is touched.** `setTaxonomyFromEncounters()` returns `getTaxonomyString()` from every one of its four exits, so neither its return value nor a before/after comparison can separate "the encounters agreed on nothing" from "they agreed on what is already stored" — and only the first is a failure. The servlet calls `unanimousTaxonomyFromEncounters()` first and branches on that, then uses `distinctTaxonomiesFromEncounters()` to name the conflicting values in the error. There is a test that a correct implementation passes and a return-value-based one fails.

**Parsing uses `Util.stringToGenusSpecificEpithet()`, and both parts are always written.** `MarkedIndividual.setTaxonomyString()` reads a lone word as the *specific epithet* and leaves the genus untouched, so choosing a genus-only taxonomy through it would turn an individual stored as `Orcinus orca` into `Orcinus Delphinus` — a species nobody recorded, and one that would go straight into the OpenSearch `taxonomy` field. Splitting at the first space also keeps trinomials intact, matching what `statedTaxonomy()` derives from encounter fields and what the React client already does.

**Re-submitting the stored value is a no-op, checked before validation.** The dropdown offers the individual's own taxonomy even when the site no longer configures it, so that opening the editor cannot quietly replace it. That value may be in neither the config list nor the `TAXONOMY` table, so validating it first would mean refusing to save what is already saved.

**Permissions.** The servlet checks `canUserFullyEditMarkedIndividual`, and the form is rendered only under the same predicate, so a partial-rights user is not shown a control that would 403. Taxonomy is shared by every encounter of the individual and feeds search and identification, so it takes edit rights over all of them rather than the any-one-encounter rule that gates the Edit button. I did not change `individuals.jsp:503` itself, since that would silently restrict every other field too.

This is a deliberate deviation: most of the sibling individual servlets have no object-level check at all. It is worth having here because the Shiro `[urls]` block has no catch-all — it ends at `/interconnect/mac/Interconnect.jar` — so an unregistered path is left *unfiltered* rather than merely ungated, and this check is the remaining barrier if that line is ever lost or mistyped.

**Display.** The page showed `getGenusSpeciesDeep()`, which silently falls back to whichever encounter comes first in an unordered `Vector`. It now distinguishes a taxonomy the individual records from one it is only borrowing.

## Verification

Two layers: unit tests, and an end-to-end pass on a local instance built from this branch (Tomcat 9 / JRE17, Postgres, OpenSearch 3.1.0).

**Unit tests**

- `IndividualSetTaxonomyTest` — 14 cases against a real `MarkedIndividual` behind a spy with a mocked `Shepherd`, so assertions read actual field state. Covers the trinomial split, a genus-only choice clearing the epithet, whitespace and underscore normalization, encounters agreeing with the stored value, encounters agreeing on something new, disagreement, encounters stating nothing, permission denial, unknown individual, missing parameters, an unrecognized taxonomy, and the unchanged-value no-op.
- `IndividualSetTaxonomyWiringTest` — 4 cases parsing `web.xml` for the servlet class, the url-pattern and a Shiro rule carrying both `authc` and `roles[researcher]`, plus bundle-key parity across all five locales.
- The existing `MarkedIndividualTaxonomyTest` (22 cases) still passes.

**Fixture**, built through the app rather than by hand: encounters created via `POST /api/v3/encounters`, an individual assigned with `PATCH .../individualId`, a second account holding only the `researcher` role, and an `approved` collaboration with the submitter — `Collaboration.canCollaborate` grants view on `approved` while edit needs state `edit`, which produces a user who can see the individual but not edit it.

**Authorization**

| caller | result |
|---|---|
| anonymous | 302 → `/react/login` (Shiro `authc`) |
| authenticated, no `researcher` role | 302 → `/accessDenied.jsp` (Shiro `roles[researcher]`) |
| researcher with view-only access to the individual | **403** from `canUserFullyEditMarkedIndividual` |
| admin / full-edit owner | allowed |

Taxonomy unchanged in every blocked case. The view-only researcher also gets no editor rendered on the page, only the read-only value.

**Behaviour** (each row checked against the stored `GENUS`/`SPECIFICEPITHET` afterwards)

| case | result |
|---|---|
| resubmit the stored value | 200 "unchanged", no write |
| taxonomy the site doesn't recognize | 400, unchanged |
| valid change | 200, stored |
| trinomial | 200, stored as `Giraffa` / `camelopardalis rothschildi` |
| **genus-only choice** | 200, epithet cleared to NULL |
| sentinel, encounters agree and differ from stored | 200, derived value stored |
| sentinel, encounters agree *with* stored | 200 "unchanged" — **not** a false disagreement |
| sentinel, encounters disagree | 400 naming both values, unchanged |
| sentinel, encounters state nothing | 400 with a distinct message, value **not** blanked |

The dropdown also rendered as intended: disabled placeholder, current value pre-selected server-side, a stored value absent from `genusSpecies` injected as an extra selected option, and the sentinel offered only when something is actually derivable (it disappears once the encounters disagree).

**Still not verified**

- OpenSearch reindexing — I did not confirm the individual becomes findable by its new taxonomy in search.
- Visual layout. I inspected the served HTML for the controls and stored values, not a rendered page.
- The four non-English strings are machine-plausible, not native-checked. Happy to take corrections.

(Note for anyone reproducing this on Fedora/RHEL: every bind mount in `devops/development/docker-compose.yml` is blocked by SELinux — postgres exits 2 on `initdb.d` — and needs `--security-opt label=disable` or a `:z` relabel. Probably worth its own docs issue.)

## Things I want to flag

- **This adds a new way to create the drift the issue describes.** Editing the individual does not touch its encounters, so afterwards an individual can say one thing while its encounters say another. I took the view that encounters are per-sighting observations and should not be rewritten from an aggregate, but if you would rather the edit cascade, say so.
- **A hand-set taxonomy is still revertible by four unguarded writers:** `BulkImporter.java:220` runs `setTaxonomyFromEncounters(true)` per imported row on existing individuals, `StandardImport.java:2367` force-rederives when the epithet is null, `MergeIndividual.java:131`, and `WebImport.java:780-782`. Whether a curated value should be sticky against import feels like your call and its own issue.
- **Pre-existing bug, not touched:** `MergeIndividual.java:131` feeds `getGenusSpeciesDeep()` — which can be genus-only — into `setTaxonomyString()`, so merging two genus-only individuals yields `genus=""` and `specificEpithet="Giraffa"`. It is the only other UI that writes individual taxonomy. Happy to open a separate issue.
- **No way to clear a taxonomy**, unlike `EncounterSetGenusSpecies`, which accepts `unknown` → null. Deliberate, matching "never trade a taxonomy we have for one we could not derive", but the asymmetry is real.
- **No CSRF protection** — a cross-site POST from an authenticated researcher's browser succeeds. No sibling servlet has any either, so this is not a regression, but the object-level check does not help against it.
- **Possible follow-up:** the edit-mode toggle is a hardcoded id enumeration across five lists (two in the JSP, three in the CSS). This is the fifth field to go through it. A shared class on the check/error spans and the error divs would collapse all five to two selectors — I left it alone rather than bury this behind a refactor.



