### PR TITLE
fix(export): serve the annotation export as .xlsx again so WildEx works

### DIFF
--- a/src/main/java/org/ecocean/export/EncounterAnnotationExportFile.java
+++ b/src/main/java/org/ecocean/export/EncounterAnnotationExportFile.java
@@ -1,14 +1,12 @@
 package org.ecocean.export;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.ecocean.*;
 import org.ecocean.media.MediaAsset;
 import org.ecocean.security.HiddenEncReporter;
 import org.ecocean.servlet.export.ExportColumn;
+import org.ecocean.servlet.export.ExportFileFormat;
+import org.ecocean.servlet.export.ExportRowWriter;
+import org.ecocean.servlet.export.ExportValues;
 import org.ecocean.servlet.export.MultiValueExportColumn;
 import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
@@ -30,7 +28,18 @@ public class EncounterAnnotationExportFile {
     private static final String REFERENCE_KEYWORD = "Reference";
     private static final int ROW_LIMIT = 100000;
 
+    /**
+     * Format used when a caller does not name one.
+     *
+     * Deliberately CSV: other callers embed this export under a fixed name - the bulk-export ZIP
+     * writes it as "metadata.csv" - and must keep getting CSV. It is the download endpoint that
+     * defaults to .xlsx, because that is the one feeding WildEx; see
+     * {@code EncounterAnnotationExportExcelFile.DEFAULT_FORMAT}.
+     */
+    public static final ExportFileFormat DEFAULT_FORMAT = ExportFileFormat.CSV;
+
     private final String name;
+    private final ExportFileFormat format;
     private final HttpServletRequest request;
     private final Shepherd myShepherd;
 
@@ -43,41 +52,73 @@ public class EncounterAnnotationExportFile {
     private List<String> measurementColTitles = new ArrayList<String>();
 
     public EncounterAnnotationExportFile(HttpServletRequest request, Shepherd myShepherd) {
+        this(request, myShepherd, DEFAULT_FORMAT);
+    }
+
+    public EncounterAnnotationExportFile(HttpServletRequest request, Shepherd myShepherd,
+        ExportFileFormat format) {
         this.request = request;
         this.myShepherd = myShepherd;
+        this.format = (format != null) ? format : DEFAULT_FORMAT;
 
         DateTimeFormatter fmt = DateTimeFormat.forPattern("yyyy-MM-dd");
         DateTime timeNow = new DateTime();
         String formattedDate = fmt.print(timeNow);
 
         // set up the files
-        this.name = "AnnotnExp_" + formattedDate + ".csv";
+        this.name = "AnnotnExp_" + formattedDate + this.format.getExtension();
     }
 
     public String getName() { return name; }
+    public ExportFileFormat getFormat() { return format; }
+
+    public String getContentType() { return format.getContentType(); }
+
     public HiddenEncReporter writeToStream(OutputStream fileOut)
     throws NoSuchMethodException, ClassNotFoundException, InvocationTargetException,
         IllegalAccessException, IOException {
-        try (OutputStreamWriter streamWriter = new OutputStreamWriter(fileOut);
-        CSVPrinter sheet = new CSVPrinter(streamWriter, CSVFormat.EXCEL)) {
-            return writeToStream(sheet);
+        try (ExportRowWriter rowWriter = format.newWriter(fileOut)) {
+            try {
+                return writeToStream(rowWriter);
+            } catch (RuntimeException | Error | NoSuchMethodException | ClassNotFoundException |
+                InvocationTargetException | IllegalAccessException | IOException e) {
+                // Do not let close() emit a complete-looking file built from a partial run.
+                rowWriter.abort();
+                throw e;
+            }
         }
     }
 
-    private HiddenEncReporter writeToStream(CSVPrinter sheet)
+    /**
+     * Builds every row once and hands it to the supplied sink. Both the CSV and XLSX outputs run
+     * through this single method, so their contents cannot drift apart.
+     */
+    private HiddenEncReporter writeToStream(ExportRowWriter sheet)
     throws NoSuchMethodException, ClassNotFoundException, InvocationTargetException,
         IllegalAccessException, IOException {
         String context = ServletUtilities.getContext(request);
         EncounterQueryResult queryResult = EncounterQueryProcessor.processQuery(myShepherd, request,
             "year descending, month descending, day descending");
         Vector rEncounters = queryResult.getResult();
-        int numMatchingEncounters = rEncounters.size();
 
         // Security: categorize hidden encounters with the initializer
         HiddenEncReporter hiddenData = new HiddenEncReporter(rEncounters, request, myShepherd);
 
+        // Both passes below - the column-count pass and the row pass - work from this visible-only
+        // list. Sizing columns from the unfiltered results would let the shape of the export (how
+        // many mediaAsset/keyword/name/submitter/socialUnit columns it has) expose maxima taken
+        // from encounters the requesting user is not permitted to see.
+        Vector<Encounter> visibleEncounters = new Vector<Encounter>();
+
+        for (int i = 0; i < rEncounters.size() && i < ROW_LIMIT; i++) {
+            Encounter enc = (Encounter)rEncounters.get(i);
+            if (hiddenData.contains(enc)) continue;
+            visibleEncounters.add(enc);
+        }
+        int numMatchingEncounters = visibleEncounters.size();
+
         // so we know how many MA columns we need
-        setMediaAssetCounts(rEncounters, myShepherd);
+        setMediaAssetCounts(visibleEncounters, myShepherd);
 
         // so we know how many name columns we need
 
@@ -247,20 +288,21 @@ public class EncounterAnnotationExportFile {
             }
         }
         // end sorting
+        String[] headerRow = new String[columns.size()];
         for (ExportColumn exportCol : columns) {
-            exportCol.writeHeaderLabel(sheet);
+            headerRow[exportCol.colNum] = exportCol.getHeaderLabel();
         }
-        sheet.printRecord();
+        ExportValues.normalizeInPlace(headerRow);
+        sheet.writeRow(headerRow);
 
-        // CSV export =========================================================
+        // row export =========================================================
         int row = 0;
         int numColumns = columns.size();
         for (int i = 0; i < numMatchingEncounters && i < ROW_LIMIT; i++) {
             // get the Encounter and check if user
             // has permission otherwise hide the encounter
 
-            Encounter enc = (Encounter)rEncounters.get(i);
-            if (hiddenData.contains(enc)) continue;
+            Encounter enc = visibleEncounters.get(i);
             row++;
 
             // Initialize row array - each column writes to its own index
@@ -273,7 +315,8 @@ public class EncounterAnnotationExportFile {
             MultiValue names = (ind != null) ? ind.getNames() : null;
             List<String> sortedNameKeys = (names != null) ? names.getSortedKeys() : null;
             ArrayList<MediaAsset> masDuplicates = enc.getMedia();
-            ArrayList<MediaAsset> mas = new ArrayList<>(new HashSet<MediaAsset>(masDuplicates)); // remove Media Asset duplicates
+            ArrayList<MediaAsset> mas = new ArrayList<>(new LinkedHashSet<MediaAsset>(
+                masDuplicates));                                                                       // remove Media Asset duplicates, preserving order so mediaAsset0 is stable across requests
             List<User> submitters = enc.getSubmitters();
             List<SocialUnit> socialUnits = (ind !=
                 null) ? myShepherd.getAllSocialUnitsForMarkedIndividual(ind) : null;
@@ -391,13 +434,15 @@ public class EncounterAnnotationExportFile {
                     System.out.println("EncounterAnnotationExportFile: no object found for class " +
                         exportCol.getDeclaringClass());
             }
+            // Normalize once, here, so the CSV and XLSX sinks receive byte-identical arrays.
+            ExportValues.normalizeInPlace(rowData);
             // Write the complete row at once
-            sheet.printRecord((Object[])rowData);
+            sheet.writeRow(rowData);
         } // end for loop iterating encounters
 
         // Note: Don't close fileOut - let the caller manage stream lifecycle
 
-        // end CSV export and business logic ===============================================
+        // end row export and business logic ===============================================
         System.out.println("Done with EncounterAnnotationExportFile. We hid " + hiddenData.size() +
             " encounters.");
 
@@ -432,7 +477,8 @@ public class EncounterAnnotationExportFile {
             if (enc.getMeasurements().size() > maxNumMeasurements)
                 maxNumMeasurements = enc.getMeasurements().size();
             ArrayList<MediaAsset> masDuplicates = enc.getMedia();
-            ArrayList<MediaAsset> mas = new ArrayList<>(new HashSet<MediaAsset>(masDuplicates)); // remove Media Asset duplicates
+            ArrayList<MediaAsset> mas = new ArrayList<>(new LinkedHashSet<MediaAsset>(
+                masDuplicates));                                                                       // remove Media Asset duplicates, preserving order so mediaAsset0 is stable across requests
             int numMedia = mas.size();
             if (numMedia > maxNumMedia) maxNumMedia = numMedia;
             for (MediaAsset ma : mas) {

--- a/src/main/java/org/ecocean/servlet/export/CsvExportRowWriter.java
+++ b/src/main/java/org/ecocean/servlet/export/CsvExportRowWriter.java
@@ -1,0 +1,53 @@
+package org.ecocean.servlet.export;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+
+/**
+ * Writes export rows as CSV.
+ */
+public class CsvExportRowWriter implements ExportRowWriter {
+    public static final String CONTENT_TYPE = "text/csv; charset=UTF-8";
+    public static final String EXTENSION = ".csv";
+
+    private final CSVPrinter printer;
+
+    public CsvExportRowWriter(OutputStream out)
+    throws IOException {
+        // Explicit UTF-8. The JVM default charset is not guaranteed to be UTF-8 on Java 11, and
+        // the XLSX sink is always UTF-8; pinning it keeps non-ASCII values identical across the
+        // two formats.
+        Writer writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+
+        this.printer = new CSVPrinter(writer, CSVFormat.EXCEL);
+    }
+
+    @Override public void writeRow(String[] row)
+    throws IOException {
+        // Normalized here as well as in the shared producer path so that this writer and the XLSX
+        // one behave identically when used directly. ExportValues.normalize is idempotent, so the
+        // already-normalized rows the exporter sends are unaffected.
+        for (int i = 0; i < row.length; i++) {
+            printer.print(ExportValues.normalize(row[i]));
+        }
+        printer.println();
+    }
+
+    /**
+     * Flushes the encoder and CSV buffer. Does not close the caller's stream.
+     *
+     * Flushing rather than closing is safe because every value has been through
+     * {@link ExportValues#normalize}, which strips unpaired surrogates - the one input that would
+     * otherwise leave state inside the encoder that only close() finalizes.
+     */
+    @Override public void close()
+    throws IOException {
+        printer.flush();
+    }
+}

--- a/src/main/java/org/ecocean/servlet/export/EncounterAnnotationExportExcelFile.java
+++ b/src/main/java/org/ecocean/servlet/export/EncounterAnnotationExportExcelFile.java
@@ -3,13 +3,32 @@ import javax.servlet.*;
 import javax.servlet.http.*;
 
 import java.io.*;
-import java.lang.reflect.InvocationTargetException;
 
 import org.ecocean.export.EncounterAnnotationExportFile;
 import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
 
+/**
+ * Serves the encounter annotation export.
+ *
+ * Defaults to .xlsx because this export feeds the WildEx image-export app, whose file picker only
+ * accepts Excel files. Pass ?format=csv for the CSV form; both contain exactly the same rows.
+ */
 public class EncounterAnnotationExportExcelFile extends HttpServlet {
+    /**
+     * What this endpoint serves when the caller does not ask for a format.
+     *
+     * XLSX, because this download feeds the WildEx image-export app, whose file picker only accepts
+     * .xls/.xlsx. Serving CSV forces users to convert in Excel, and that conversion retypes the
+     * "true" in Annotation&lt;n&gt;.MatchAgainst as a boolean, after which WildEx discards every row
+     * and produces an empty folder with no error. CSV is still available via ?format=csv.
+     *
+     * This is the endpoint's own default and deliberately differs from
+     * {@link EncounterAnnotationExportFile#DEFAULT_FORMAT}, which stays CSV for callers that embed
+     * the export under a fixed filename.
+     */
+    public static final ExportFileFormat DEFAULT_FORMAT = ExportFileFormat.XLSX;
+
     public void init(ServletConfig config)
     throws ServletException {
         super.init(config);
@@ -22,34 +41,57 @@ public class EncounterAnnotationExportExcelFile extends HttpServlet {
 
     public void doPost(HttpServletRequest request, HttpServletResponse response)
     throws ServletException, IOException {
+        // Resolve the format before anything is written, so a bad value fails cleanly with a
+        // status code instead of part-way through a download.
+        ExportFileFormat format = ExportFileFormat.fromRequestParam(request.getParameter("format"),
+            DEFAULT_FORMAT);
+
+        if (format == null) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                "Unsupported format. Use format=xlsx or format=csv.");
+            return;
+        }
         String context = ServletUtilities.getContext(request);
         Shepherd myShepherd = new Shepherd(context);
 
         myShepherd.beginDBTransaction();
 
         try {
-            EncounterAnnotationExportFile excelFile = new EncounterAnnotationExportFile(request,
-                myShepherd);
+            EncounterAnnotationExportFile exportFile = new EncounterAnnotationExportFile(request,
+                myShepherd, format);
 
             // now write out the file
-            response.setContentType("application/msexcel");
-            response.setHeader("Content-Disposition", "attachment;filename=" + excelFile.getName());
+            response.setContentType(exportFile.getContentType());
+            // The filename is a fixed prefix plus the current date plus an extension taken from the
+            // format enum, so no request input reaches this header.
+            response.setHeader("Content-Disposition",
+                "attachment; filename=\"" + exportFile.getName() + "\"");
+            // This is per-user data, filtered by what the requester is allowed to see.
+            response.setHeader("Cache-Control", "private, no-store");
 
             OutputStream os = response.getOutputStream();
-            excelFile.writeToStream(os);
+            exportFile.writeToStream(os);
 
             os.flush();
-            os.close();
         } catch (Exception e) {
             e.printStackTrace();
-            response.setContentType("text/html");
-            PrintWriter out = response.getWriter();
-            out.println(ServletUtilities.getHeader(request));
-            out.println("<html><body><p><strong>Error encountered</strong></p>");
-            out.println(
-                "<p>Please let the webmaster know you encountered an error at: EncounterSearchExportExcelFile servlet</p></body></html>");
-            out.println(ServletUtilities.getFooter(context));
-            out.close();
+            // Once any export bytes have gone out we cannot switch to an HTML error page - doing so
+            // would append markup to a partial spreadsheet and hand the user a corrupt download.
+            if (response.isCommitted()) {
+                System.out.println(
+                    "EncounterAnnotationExportExcelFile: response already committed; truncating download.");
+            } else {
+                response.reset();
+                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                response.setContentType("text/html");
+                PrintWriter out = response.getWriter();
+                out.println(ServletUtilities.getHeader(request));
+                out.println("<html><body><p><strong>Error encountered</strong></p>");
+                out.println(
+                    "<p>Please let the webmaster know you encountered an error at: EncounterAnnotationExportExcelFile servlet</p></body></html>");
+                out.println(ServletUtilities.getFooter(context));
+                out.close();
+            }
         } finally {
             myShepherd.rollbackDBTransaction();
             myShepherd.closeDBTransaction();

--- a/src/main/java/org/ecocean/servlet/export/ExportFileFormat.java
+++ b/src/main/java/org/ecocean/servlet/export/ExportFileFormat.java
@@ -1,0 +1,60 @@
+package org.ecocean.servlet.export;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Output formats an export endpoint can serve, and the sink each one uses.
+ *
+ * Both formats are fed by the same row-production code path, so the data they contain is identical;
+ * only the serialization differs.
+ */
+public enum ExportFileFormat {
+    CSV(CsvExportRowWriter.EXTENSION, CsvExportRowWriter.CONTENT_TYPE),
+        XLSX(XlsxExportRowWriter.EXTENSION, XlsxExportRowWriter.CONTENT_TYPE);
+
+    private final String extension;
+    private final String contentType;
+
+    ExportFileFormat(String extension, String contentType) {
+        this.extension = extension;
+        this.contentType = contentType;
+    }
+
+    public String getExtension() { return extension; }
+    public String getContentType() { return contentType; }
+
+    public ExportRowWriter newWriter(OutputStream out)
+    throws IOException {
+        switch (this) {
+        case XLSX:
+            return new XlsxExportRowWriter(out);
+
+        default:
+            return new CsvExportRowWriter(out);
+        }
+    }
+
+    /**
+     * Resolves a user-supplied "format" request parameter against a strict whitelist.
+     *
+     * Absent or blank means "use the default". Anything other than an exact, known format name is
+     * rejected with null so the caller can fail the request before it starts writing bytes, rather
+     * than silently handing back a format the user did not ask for. The parameter value is never
+     * echoed into the response, so it cannot reach a header.
+     *
+     * @return the resolved format, or null if the supplied value is not a recognized format
+     */
+    public static ExportFileFormat fromRequestParam(String value, ExportFileFormat fallback) {
+        if (value == null)
+            return fallback;
+        String normalized = value.trim().toLowerCase();
+        if (normalized.isEmpty())
+            return fallback;
+        for (ExportFileFormat format : values()) {
+            if (format.name().toLowerCase().equals(normalized))
+                return format;
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/ecocean/servlet/export/ExportRowWriter.java
+++ b/src/main/java/org/ecocean/servlet/export/ExportRowWriter.java
@@ -1,0 +1,42 @@
+package org.ecocean.servlet.export;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * A sink for fully-materialized export rows.
+ *
+ * Exports build each row as a {@code String[]} indexed by {@link ExportColumn#colNum} and then hand
+ * the finished array to one of these. Keeping the row-production logic (query, access-control
+ * filtering, column construction) in a single code path and varying only the sink is what
+ * guarantees that the CSV and XLSX outputs contain identical data: there is no second traversal to
+ * keep in sync.
+ *
+ * Implementations are responsible for flushing and releasing their own resources in
+ * {@link #close()}. They do not own the underlying stream and must not close it.
+ */
+public interface ExportRowWriter extends Closeable {
+    /**
+     * Writes one row. The header row is written by calling this with the header labels.
+     *
+     * @param row one value per column, in column order. Entries are expected to be non-null;
+     *            {@link ExportColumn#writeLabel} already substitutes "" for null values.
+     */
+    void writeRow(String[] row)
+    throws IOException;
+
+    /**
+     * Abandons the export so that {@link #close()} emits nothing further.
+     *
+     * Without this, a failure part-way through would still produce a complete-looking workbook
+     * holding only the rows written so far - silent truncation, which is precisely the kind of
+     * quiet data loss this export has already been bitten by. Streaming formats such as CSV have
+     * usually put bytes on the wire by this point and cannot take them back, so the default is a
+     * no-op.
+     */
+    default void abort() {}
+
+    /** Flushes any buffered content and releases implementation resources. */
+    @Override void close()
+    throws IOException;
+}

--- a/src/main/java/org/ecocean/servlet/export/ExportValues.java
+++ b/src/main/java/org/ecocean/servlet/export/ExportValues.java
@@ -1,0 +1,111 @@
+package org.ecocean.servlet.export;
+
+/**
+ * Canonical normalization for exported cell values.
+ *
+ * CSV and XLSX do not accept the same set of strings: XLSX caps a cell at 32,767 characters and
+ * cannot carry text that XML forbids, while CSV would happily pass both through. Normalizing once
+ * here - in the shared row-production path, before either sink sees the value - is what keeps the
+ * two formats carrying identical data instead of quietly diverging at the edges.
+ *
+ * The operation is idempotent, so the sinks apply it again defensively without changing the result.
+ */
+public final class ExportValues {
+    /** Excel's hard limit on the number of characters in a single cell. */
+    public static final int MAX_CELL_CHARS = 32767;
+
+    private ExportValues() {}
+
+    /** Normalizes every entry of a row in place. */
+    public static void normalizeInPlace(String[] row) {
+        if (row == null) return;
+        for (int i = 0; i < row.length; i++) {
+            row[i] = normalize(row[i]);
+        }
+    }
+
+    /**
+     * Returns a value safe for both sinks: never null, with line endings canonicalized, free of
+     * text XML cannot carry, and no longer than a single Excel cell can hold.
+     */
+    public static String normalize(String value) {
+        if (value == null) return "";
+        String cleaned = canonicalizeLineEndings(value);
+
+        cleaned = stripTextIllegalInXml(cleaned);
+        return truncateToCellLimit(cleaned);
+    }
+
+    /**
+     * Collapses CRLF and lone CR to LF.
+     *
+     * An embedded CRLF survives an XLSX cell verbatim, but CSV readers - Excel's included -
+     * normalize it to LF on the way back in. Canonicalizing here means a value containing a line
+     * break reads back the same from both formats instead of differing by a stray CR.
+     */
+    private static String canonicalizeLineEndings(String value) {
+        if (value.indexOf('\r') < 0) return value;
+        return value.replace("\r\n", "\n").replace('\r', '\n');
+    }
+
+    /**
+     * Drops anything XML cannot represent, walking by code point.
+     *
+     * Walking by code point rather than by char matters twice over: a valid supplementary character
+     * (an emoji, say) must survive as the pair it is, and a lone unpaired surrogate - which is
+     * illegal in XML and would make the workbook unreadable - must not be mistaken for one half of
+     * a legitimate pair.
+     */
+    private static String stripTextIllegalInXml(String value) {
+        StringBuilder sb = null;
+        final int length = value.length();
+        int i = 0;
+
+        while (i < length) {
+            char c = value.charAt(i);
+            int codePoint;
+            int width;
+            if (Character.isHighSurrogate(c) && (i + 1) < length &&
+                Character.isLowSurrogate(value.charAt(i + 1))) {
+                codePoint = Character.toCodePoint(c, value.charAt(i + 1));
+                width = 2;
+            } else {
+                codePoint = c;
+                width = 1;
+            }
+            if (isLegalXmlCodePoint(codePoint)) {
+                if (sb != null) sb.append(value, i, i + width);
+            } else if (sb == null) {
+                sb = new StringBuilder(length);
+                sb.append(value, 0, i);
+            }
+            i += width;
+        }
+        return (sb == null) ? value : sb.toString();
+    }
+
+    /** The XML 1.0 Char production. Unpaired surrogates reach here as their own code point. */
+    private static boolean isLegalXmlCodePoint(int codePoint) {
+        if (codePoint == '\t' || codePoint == '\n' || codePoint == '\r') return true;
+        if (codePoint < 0x20) return false;
+        if (codePoint >= 0xD800 && codePoint <= 0xDFFF) return false; // unpaired surrogate
+        if (codePoint == 0xFFFE || codePoint == 0xFFFF) return false;
+        return codePoint <= 0x10FFFF;
+    }
+
+    /**
+     * Cuts a value down to what one Excel cell holds, never between the halves of a surrogate pair.
+     *
+     * Truncation is silent to the consumer but not to the operator: a value long enough to hit this
+     * is being altered, which is worth a line in the log.
+     */
+    private static String truncateToCellLimit(String value) {
+        if (value.length() <= MAX_CELL_CHARS) return value;
+        int end = MAX_CELL_CHARS;
+        // Cutting here would leave a high surrogate whose partner is the character being dropped.
+        if (Character.isHighSurrogate(value.charAt(end - 1))) end--;
+        System.out.println("ExportValues: truncated a " + value.length() +
+            "-character value to the " + end + "-character spreadsheet cell limit.");
+        return value.substring(0, end);
+    }
+}

--- a/src/main/java/org/ecocean/servlet/export/XlsxExportRowWriter.java
+++ b/src/main/java/org/ecocean/servlet/export/XlsxExportRowWriter.java
@@ -1,0 +1,100 @@
+package org.ecocean.servlet.export;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+
+/**
+ * Writes export rows as a streaming .xlsx workbook.
+ *
+ * Every cell is written as an explicit string cell. That is not incidental: the WildEx image-export
+ * app (WildMeOrg/WildbookExport) keeps an annotation row only when Annotation&lt;n&gt;.MatchAgainst is
+ * exactly the string "true". If the value reaches it as a boolean instead, every row is filtered
+ * out and the user gets an empty download folder with no error. Writing string-typed cells here is
+ * what the pre-CSV export did, and is what keeps that tool working.
+ */
+public class XlsxExportRowWriter implements ExportRowWriter {
+    public static final String CONTENT_TYPE =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    public static final String EXTENSION = ".xlsx";
+
+    /** Sheet name used by the pre-CSV export; WildEx reads sheet index 0 but expects this name. */
+    public static final String SHEET_NAME = "Search Results";
+
+    /** Rows held in memory before SXSSF spills them to a temp file. */
+    private static final int ROW_ACCESS_WINDOW = 100;
+
+    private final OutputStream out;
+    private final SXSSFWorkbook workbook;
+    private final Sheet sheet;
+
+    private int rowNum = 0;
+    private boolean aborted = false;
+
+    public XlsxExportRowWriter(OutputStream out) {
+        this.out = out;
+        // Streaming workbook: only ROW_ACCESS_WINDOW rows are held in memory at a time, so the
+        // workbook itself does not have to be materialized all at once. (The query result the rows
+        // are built from is still a fully materialized list; this bounds the workbook, not the
+        // whole export.)
+        this.workbook = new SXSSFWorkbook(ROW_ACCESS_WINDOW);
+        // SXSSF spills rows to temp XML that is several times larger than the finished workbook.
+        // Must be set before the sheet is created.
+        this.workbook.setCompressTempFiles(true);
+        this.sheet = workbook.createSheet(SHEET_NAME);
+    }
+
+    @Override public void writeRow(String[] row)
+    throws IOException {
+        Row sheetRow = sheet.createRow(rowNum++);
+
+        if (row.length == 0) {
+            // A row with no cells reads back as absent (getLastCellNum() == -1), whereas CSV emits
+            // an empty record that parses as a single empty field. One empty cell keeps the two
+            // formats agreeing even on this degenerate row.
+            sheetRow.createCell(0, Cell.CELL_TYPE_STRING).setCellValue("");
+            return;
+        }
+        for (int i = 0; i < row.length; i++) {
+            Cell cell = sheetRow.createCell(i, Cell.CELL_TYPE_STRING);
+            cell.setCellValue(clampToCellLimit(row[i]));
+        }
+    }
+
+    /**
+     * Defence in depth. Callers are expected to have run values through
+     * {@link ExportValues#normalize} already - that is what keeps CSV and XLSX identical - but a
+     * direct user of this writer should still not be able to blow up on Excel's cell limit.
+     */
+    static String clampToCellLimit(String value) {
+        return ExportValues.normalize(value);
+    }
+
+    /** Nothing is written on close after this; the temp files are still cleaned up. */
+    @Override public void abort() {
+        this.aborted = true;
+    }
+
+    /** Serializes the workbook to the stream, then releases both the package and the temp files. */
+    @Override public void close()
+    throws IOException {
+        try {
+            if (!aborted) {
+                workbook.write(out);
+                out.flush();
+            }
+        } finally {
+            try {
+                // Releases the underlying OOXML package; dispose() alone only clears the SXSSF
+                // sheet temp files.
+                workbook.close();
+            } finally {
+                workbook.dispose();
+            }
+        }
+    }
+}

--- a/src/test/java/org/ecocean/api/EncounterExportImagesTest.java
+++ b/src/test/java/org/ecocean/api/EncounterExportImagesTest.java
@@ -22,6 +22,10 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.http.HttpHost;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.shiro.web.servlet.IniShiroFilter;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.FilterHolder;
@@ -33,6 +37,7 @@ import org.ecocean.media.*;
 import org.ecocean.Occurrence;
 import org.ecocean.OpenSearch;
 import org.ecocean.servlet.export.EncounterSearchExportMetadataExcel;
+import org.ecocean.servlet.export.ExportFileFormat;
 import org.ecocean.servlet.ServletUtilities;
 import org.ecocean.shepherd.core.Shepherd;
 import org.jetbrains.annotations.NotNull;
@@ -398,7 +403,7 @@ import static org.mockito.Mockito.when;
         when(mockRequest.getRemoteUser()).thenReturn("test_researcher");
 
         EncounterAnnotationExportFile file = new EncounterAnnotationExportFile(mockRequest,
-            myShepherd);
+            myShepherd, ExportFileFormat.CSV);
         Path outputFilePath = tempPath.resolve(file.getName());
         try {
             System.out.println("Wrote: " + outputFilePath);
@@ -420,6 +425,19 @@ import static org.mockito.Mockito.when;
 
             // Compare CSV files
             assertCsvFilesEqual(actualRows, expectedRows);
+
+            // The same search exported as .xlsx must carry exactly the same rows. That is the
+            // format WildEx consumes, so it has to be the identical data and not a subset.
+            EncounterAnnotationExportFile xlsxExport = new EncounterAnnotationExportFile(
+                mockRequest, myShepherd, ExportFileFormat.XLSX);
+            Path xlsxPath = tempPath.resolve(xlsxExport.getName());
+            try (OutputStream os = Files.newOutputStream(xlsxPath)) {
+                xlsxExport.writeToStream(os);
+            }
+            List<String[]> xlsxRows = loadXlsx(xlsxPath.toFile());
+            assertCsvFilesEqual(xlsxRows, expectedRows);
+            assertEquals(actualRows.size(), xlsxRows.size(),
+                "CSV and XLSX exports must contain the same number of rows");
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         } catch (ClassNotFoundException e) {
@@ -433,6 +451,31 @@ import static org.mockito.Mockito.when;
         } finally {
             myShepherd.closeDBTransaction();
         }
+    }
+
+    /**
+     * Reads an .xlsx export back into the same row shape {@link #loadCsv} produces, so the two
+     * formats can be compared against one another and against the same fixture.
+     */
+    private static @NotNull List<String[]> loadXlsx(File xlsxFile)
+    throws IOException {
+        List<String[]> rows = new ArrayList<>();
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new FileInputStream(xlsxFile))) {
+            Sheet sheet = workbook.getSheetAt(0);
+            for (int r = 0; r <= sheet.getLastRowNum(); r++) {
+                Row row = sheet.getRow(r);
+                if (row == null) continue;
+                String[] values = new String[row.getLastCellNum()];
+                for (int c = 0; c < values.length; c++) {
+                    Cell cell = row.getCell(c);
+                    values[c] = (cell == null) ? "" : cell.getStringCellValue();
+                }
+                rows.add(values);
+            }
+        }
+        System.out.println("  Loaded " + rows.size() + " rows from XLSX: " + xlsxFile.toString());
+        return rows;
     }
 
     private static @NotNull List<String[]> loadCsv(File expectedCsvFile)

--- a/src/test/java/org/ecocean/servlet/export/ExportRowWriterParityTest.java
+++ b/src/test/java/org/ecocean/servlet/export/ExportRowWriterParityTest.java
@@ -1,0 +1,331 @@
+package org.ecocean.servlet.export;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The annotation export serves the same rows as either CSV or XLSX. These tests pin that the two
+ * serializations actually agree, and that the XLSX one keeps values string-typed.
+ *
+ * The string-typing matters concretely: the WildEx image-export app keeps an annotation row only
+ * when Annotation&lt;n&gt;.MatchAgainst equals the string "true". A boolean-typed cell there makes
+ * it silently discard every row and produce an empty download folder.
+ */
+public class ExportRowWriterParityTest {
+    private static final String[] HEADER = new String[] {
+        "Encounter.mediaAsset0", "Annotation0.ViewPoint", "Name0.value",
+            "Encounter.mediaAsset0.imageUrl", "Annotation0.bbox", "Annotation0.MatchAgainst"
+    };
+
+    /** Rows chosen to exercise everywhere the two formats could legitimately disagree. */
+    private static List<String[]> trickyRows() {
+        List<String[]> rows = new ArrayList<>();
+
+        rows.add(new String[] {
+            "plain.jpg", "left", "Indiv_1", "https://flukebook.org/a.jpg", "[250, 250, 500, 500]",
+            "true"
+        });
+        // empty and null values
+        rows.add(new String[] { "", null, "", "", "", "false" });
+        // separators, quotes and embedded newlines
+        rows.add(new String[] {
+            "comma,name.jpg", "he said \"left\"", "line1\nline2", "a\r\nb", "[1, 2, 3, 4]", "true"
+        });
+        // non-ASCII, which is only identical if the CSV sink is pinned to UTF-8
+        rows.add(new String[] {
+            "çaça.jpg", "左", "Niño — 鯨", "https://x/é.jpg", "[0, 0, 1, 1]", "true"
+        });
+        // control characters XML cannot represent, and values at/over Excel's cell limit
+        rows.add(new String[] {
+            "bell\u0007char.jpg", "left", repeat('a', ExportValues.MAX_CELL_CHARS),
+            repeat('b', ExportValues.MAX_CELL_CHARS + 1), "[9, 9, 9, 9]", "true"
+        });
+        return rows;
+    }
+
+    private static String repeat(char c, int n) {
+        StringBuilder sb = new StringBuilder(n);
+
+        for (int i = 0; i < n; i++)
+            sb.append(c);
+        return sb.toString();
+    }
+
+    /**
+     * Mirrors what the exporter does: normalize once, then hand the same array to whichever sink.
+     */
+    private static List<String[]> normalizedRows() {
+        List<String[]> rows = new ArrayList<>();
+
+        rows.add(HEADER.clone());
+        for (String[] row : trickyRows())
+            rows.add(row.clone());
+        for (String[] row : rows)
+            ExportValues.normalizeInPlace(row);
+        return rows;
+    }
+
+    private static byte[] writeCsv(List<String[]> rows)
+    throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        try (ExportRowWriter writer = new CsvExportRowWriter(out)) {
+            for (String[] row : rows)
+                writer.writeRow(row);
+        }
+        return out.toByteArray();
+    }
+
+    private static byte[] writeXlsx(List<String[]> rows)
+    throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        try (ExportRowWriter writer = new XlsxExportRowWriter(out)) {
+            for (String[] row : rows)
+                writer.writeRow(row);
+        }
+        return out.toByteArray();
+    }
+
+    private static List<String[]> readCsv(byte[] bytes)
+    throws Exception {
+        List<String[]> rows = new ArrayList<>();
+
+        try (CSVParser parser = CSVParser.parse(new InputStreamReader(new ByteArrayInputStream(
+                bytes), StandardCharsets.UTF_8), CSVFormat.EXCEL)) {
+            for (CSVRecord record : parser) {
+                String[] row = new String[record.size()];
+                for (int i = 0; i < record.size(); i++)
+                    row[i] = record.get(i);
+                rows.add(row);
+            }
+        }
+        return rows;
+    }
+
+    private static List<String[]> readXlsx(byte[] bytes)
+    throws Exception {
+        List<String[]> rows = new ArrayList<>();
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(bytes))) {
+            Sheet sheet = workbook.getSheetAt(0);
+            for (int r = 0; r <= sheet.getLastRowNum(); r++) {
+                Row row = sheet.getRow(r);
+                String[] values = new String[row.getLastCellNum()];
+                for (int c = 0; c < values.length; c++) {
+                    Cell cell = row.getCell(c);
+                    values[c] = (cell == null) ? "" : cell.getStringCellValue();
+                }
+                rows.add(values);
+            }
+        }
+        return rows;
+    }
+
+    @Test public void csvAndXlsxSerializeIdenticalCells()
+    throws Exception {
+        List<String[]> rows = normalizedRows();
+        List<String[]> fromCsv = readCsv(writeCsv(rows));
+        List<String[]> fromXlsx = readXlsx(writeXlsx(rows));
+
+        assertEquals(rows.size(), fromCsv.size(), "CSV row count");
+        assertEquals(rows.size(), fromXlsx.size(), "XLSX row count");
+        for (int r = 0; r < rows.size(); r++) {
+            assertArrayEquals(fromCsv.get(r), fromXlsx.get(r),
+                "row " + r + " differs between CSV and XLSX");
+            assertArrayEquals(rows.get(r), fromCsv.get(r),
+                "row " + r + " does not round-trip through CSV");
+        }
+    }
+
+    /**
+     * The actual WildEx regression: the MatchAgainst cell has to come back as the string "true",
+     * not as a boolean.
+     */
+    @Test public void xlsxWritesMatchAgainstAsAStringNotABoolean()
+    throws Exception {
+        List<String[]> rows = normalizedRows();
+        byte[] xlsx = writeXlsx(rows);
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(xlsx))) {
+            Sheet sheet = workbook.getSheetAt(0);
+            int matchAgainstCol = HEADER.length - 1;
+            Cell cell = sheet.getRow(1).getCell(matchAgainstCol);
+
+            assertEquals(Cell.CELL_TYPE_STRING, cell.getCellType(),
+                "MatchAgainst must be a string cell; a boolean cell makes WildEx drop every row");
+            assertEquals("true", cell.getStringCellValue(), "MatchAgainst value");
+        }
+    }
+
+    @Test public void xlsxUsesTheSheetNameTheOldExcelExportUsed()
+    throws Exception {
+        byte[] xlsx = writeXlsx(normalizedRows());
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(xlsx))) {
+            assertEquals(XlsxExportRowWriter.SHEET_NAME, workbook.getSheetName(0), "sheet name");
+            assertEquals(1, workbook.getNumberOfSheets(),
+                "a second sheet would put records in the XLSX that the CSV does not have");
+        }
+    }
+
+    @Test public void csvIsWrittenAsUtf8()
+    throws Exception {
+        List<String[]> rows = new ArrayList<>();
+
+        rows.add(new String[] { "Niño 鯨" });
+        byte[] csv = writeCsv(rows);
+
+        assertEquals("Niño 鯨", new String(csv, StandardCharsets.UTF_8).trim(),
+            "CSV must be UTF-8 regardless of the JVM default charset");
+    }
+
+    @Test public void normalizeTruncatesAtExcelCellLimit() {
+        String tooLong = repeat('x', ExportValues.MAX_CELL_CHARS + 10);
+
+        assertEquals(ExportValues.MAX_CELL_CHARS, ExportValues.normalize(tooLong).length(),
+            "over-long values are truncated identically for both formats");
+    }
+
+    @Test public void normalizeStripsCharactersXmlCannotCarry() {
+        assertEquals("ab", ExportValues.normalize("a\u0007b"), "BEL is stripped");
+        assertEquals("ab", ExportValues.normalize("a\u0000b"), "NUL is stripped");
+        assertEquals("a\tb", ExportValues.normalize("a\tb"), "tab is preserved");
+        assertEquals("", ExportValues.normalize(null), "null becomes empty string");
+    }
+
+    @Test public void normalizeCanonicalizesLineEndings() {
+        assertEquals("a\nb", ExportValues.normalize("a\r\nb"), "CRLF collapses to LF");
+        assertEquals("a\nb", ExportValues.normalize("a\rb"), "lone CR becomes LF");
+        assertEquals("a\nb", ExportValues.normalize("a\nb"), "LF is left alone");
+    }
+
+    /**
+     * These two defaults deliberately differ. The download endpoint serves .xlsx so WildEx works,
+     * but callers that embed this export under a fixed filename - the bulk-export ZIP writes it as
+     * "metadata.csv" - must keep getting CSV.
+     */
+    @Test public void downloadEndpointDefaultsToXlsxWhileEmbeddedCallersKeepCsv() {
+        assertEquals(ExportFileFormat.XLSX, EncounterAnnotationExportExcelFile.DEFAULT_FORMAT,
+            "the WildEx download endpoint must serve .xlsx by default");
+        assertEquals(ExportFileFormat.CSV,
+            org.ecocean.export.EncounterAnnotationExportFile.DEFAULT_FORMAT,
+            "embedded callers such as the bulk-export ZIP's metadata.csv must keep getting CSV");
+    }
+
+    @Test public void normalizeKeepsSupplementaryCharactersIntact() {
+        String whale = new String(Character.toChars(0x1F40B));
+
+        assertEquals("a" + whale + "b", ExportValues.normalize("a" + whale + "b"),
+            "a valid surrogate pair must survive as the character it encodes");
+    }
+
+    @Test public void normalizeStripsUnpairedSurrogates() {
+        assertEquals("ab", ExportValues.normalize("a\uD83Db"),
+            "an unpaired high surrogate is illegal in XML and must go");
+        assertEquals("ab", ExportValues.normalize("a\uDC0Bb"),
+            "an unpaired low surrogate is illegal in XML and must go");
+    }
+
+    @Test public void truncationNeverSplitsASurrogatePair() {
+        String whale = new String(Character.toChars(0x1F40B));
+        String value = repeat('a', ExportValues.MAX_CELL_CHARS - 1) + whale;
+        String normalized = ExportValues.normalize(value);
+
+        assertEquals(ExportValues.MAX_CELL_CHARS - 1, normalized.length(),
+            "the pair straddling the limit is dropped whole, not cut in half");
+        assertFalse(Character.isHighSurrogate(normalized.charAt(normalized.length() - 1)),
+            "the result must not end on a dangling high surrogate");
+    }
+
+    /**
+     * The exporter normalizes before handing rows to a sink, but the sinks must also agree when
+     * used directly - otherwise the parity guarantee depends on every caller remembering to
+     * normalize first.
+     */
+    @Test public void writersAgreeEvenWhenHandedRawUnnormalizedValues()
+    throws Exception {
+        List<String[]> raw = new ArrayList<>();
+
+        raw.add(HEADER.clone());
+        for (String[] row : trickyRows())
+            raw.add(row.clone());
+        List<String[]> fromCsv = readCsv(writeCsv(raw));
+        List<String[]> fromXlsx = readXlsx(writeXlsx(raw));
+
+        assertEquals(fromCsv.size(), fromXlsx.size(), "row count with raw input");
+        for (int r = 0; r < fromCsv.size(); r++) {
+            assertArrayEquals(fromCsv.get(r), fromXlsx.get(r),
+                "row " + r + " differs when raw values go straight to the writers");
+        }
+    }
+
+    /**
+     * Degenerate but worth pinning: a row with no columns must not read back as absent from one
+     * format and present in the other.
+     */
+    @Test public void aZeroColumnRowIsRepresentedTheSameWayInBothFormats()
+    throws Exception {
+        List<String[]> rows = new ArrayList<>();
+
+        rows.add(new String[] {});
+
+        List<String[]> fromCsv = readCsv(writeCsv(rows));
+        List<String[]> fromXlsx = readXlsx(writeXlsx(rows));
+
+        assertEquals(fromCsv.size(), fromXlsx.size(), "row count for a zero-column row");
+        assertArrayEquals(fromCsv.get(0), fromXlsx.get(0),
+            "a zero-column row must decode the same from CSV and XLSX");
+    }
+
+    @Test public void abortedXlsxEmitsNothingRatherThanAPartialWorkbook()
+    throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        try (ExportRowWriter writer = new XlsxExportRowWriter(out)) {
+            writer.writeRow(HEADER.clone());
+            writer.abort();
+        }
+
+        assertEquals(0, out.size(),
+            "an aborted export must not hand back a complete-looking workbook of partial rows");
+    }
+
+    @Test public void eachFormatCarriesItsOwnExtensionAndContentType() {
+        assertEquals(".xlsx", ExportFileFormat.XLSX.getExtension(), "xlsx extension");
+        assertEquals(".csv", ExportFileFormat.CSV.getExtension(), "csv extension");
+        assertTrue(ExportFileFormat.XLSX.getContentType().contains("spreadsheetml"),
+            "xlsx must not go out as the old application/msexcel type");
+        assertTrue(ExportFileFormat.CSV.getContentType().startsWith("text/csv"),
+            "csv content type");
+    }
+
+    @Test public void unknownFormatParameterIsRejected() {
+        assertEquals(ExportFileFormat.XLSX,
+            ExportFileFormat.fromRequestParam(null, ExportFileFormat.XLSX), "absent uses default");
+        assertEquals(ExportFileFormat.CSV,
+            ExportFileFormat.fromRequestParam("csv", ExportFileFormat.XLSX), "exact csv");
+        assertEquals(ExportFileFormat.XLSX,
+            ExportFileFormat.fromRequestParam("XLSX", ExportFileFormat.CSV), "case-insensitive");
+        assertNull(ExportFileFormat.fromRequestParam("xls", ExportFileFormat.XLSX),
+            "near-misses are rejected rather than silently defaulted");
+        assertNull(ExportFileFormat.fromRequestParam("../etc/passwd", ExportFileFormat.XLSX),
+            "junk is rejected");
+    }
+}


### PR DESCRIPTION
## Problem

A Flukebook user reported that after upgrading, the WildEx image-export app downloads an **empty
folder** — no error, no warning, just nothing. Reported as:

> "when I try to download the annotations from a converted .xls file, I just get an empty folder
> instead of the download. It isn't throwing an error message or anything."

## Root cause

Before #1385, the annotation export was a POI `.xlsx` in which **every cell was written as
`CELL_TYPE_STRING`**. #1385 (first shipped in 10.9.5) switched it to CSV. CSV has no cell types.

[WildEx](https://github.com/WildMeOrg/WildbookExport) only accepts `.xls/.xlsx` in its file picker
(`src/utils.ts:401`), so users are forced to convert the CSV in Excel. Excel type-infers the bare
token `true` in `Annotation<n>.MatchAgainst` into a **boolean**. WildEx then does a strict string
compare (`src/utils.ts:199`):

```js
originalRow[`Annotation${i}.MatchAgainst`] !== 'true'   // boolean true !== 'true' → continue
```

Every row is skipped. WildEx has already created the output folder (`utils.ts:280`) and returns
`{success: true, "All annotations downloaded successfully."}` (`utils.ts:391`) — hence an empty
folder and a success message.

Verified against the exact SheetJS version WildEx ships (0.20.1):

| Input | `MatchAgainst` parses as | Rows WildEx keeps |
| --- | --- | --- |
| Old `.xlsx` (POI, string-typed cells) | `"true"` (string) | **1 / 1** |
| CSV re-saved by Excel | `true` (boolean) | **0 / 1** |

## What this changes

`/EncounterAnnotationExportExcelFile` serves **`.xlsx` again by default**, with CSV still available
via `?format=csv`. The endpoint is named `...ExportExcelFile`, the React button already says
`EXPORT_EXCEL_FILE`, and the documented consumer needs Excel — the CSV default made that label
untrue.

The default change is scoped to that download endpoint only. `EncounterAnnotationExportFile`'s own
default stays CSV, because other callers embed this export under a fixed name — the bulk-export ZIP
writes it as `metadata.csv`. There is a test pinning that the two defaults differ on purpose.

### Same rows in both formats, by construction

Rather than two export paths, there is now one row-production path and two sinks
(`ExportRowWriter` → `CsvExportRowWriter` / `XlsxExportRowWriter`). The query, access-control
filtering, column construction and row building all happen once; only serialization differs. There
is no second traversal that could drift.

`ExportValues.normalize` is applied once, in the shared path, before either sink sees a value. It
pins the places the two formats could otherwise legitimately disagree:

- XLSX caps a cell at 32,767 chars; CSV does not → truncate identically for both, never between the
  halves of a surrogate pair, and log when it happens rather than losing data silently.
- XLSX cannot carry text XML forbids; CSV can → strip identically for both. The filter walks by
  code point, so a valid supplementary character (an emoji) survives intact while a lone unpaired
  surrogate — illegal in XML, and enough to make the workbook unreadable — is removed.
- An embedded CRLF survives an XLSX cell verbatim but CSV readers normalize it → canonicalize to LF.
- CSV is now written as explicit UTF-8. It was using the JVM default charset, which is not
  guaranteed to be UTF-8 on Java 11 — non-ASCII values could differ between the two formats, and
  could already be mangled today.

Both sinks apply this normalization themselves as well (it is idempotent), so parity does not
depend on every future caller remembering to normalize first.

One difference remains and cannot be removed: values that Excel auto-types when a CSV is *opened in
Excel* (`=1+1`, numeric-looking strings, and `true`) will still be reinterpreted, whereas the XLSX
carries explicit string cells. That difference is the bug this PR exists to fix — it is a property
of CSV, not of the exporter, which is exactly why the format WildEx consumes has to be XLSX.

### Also fixed along the way

- **Access-control metadata leak.** `setMediaAssetCounts` sized the columns from *all* matched
  encounters, including ones the requester is not allowed to see. The number of
  mediaAsset/keyword/name/submitter/socialUnit columns therefore exposed maxima drawn from hidden
  encounters. Both passes now run off a visible-only list.
- **Non-deterministic column assignment.** Media were deduplicated through a `HashSet`, so which
  asset landed in `mediaAsset0` was not stable between two requests for the same search. Now
  `LinkedHashSet`.
- **Silent truncation on failure.** A mid-export error would previously still emit a
  complete-looking workbook containing only the rows written so far. `abort()` now suppresses the
  write, and SXSSF temp files are still cleaned up.
- **Corrupt downloads on error.** The servlet caught any exception and wrote an HTML error page —
  even after export bytes had been committed, appending markup to a partial spreadsheet. It now
  only does that if the response is uncommitted, and validates `format` *before* opening the stream.
- **Errors returned HTTP 200.** The error page went out with a success status; it now sets 500.
- **Workbook not closed.** `dispose()` only clears SXSSF's sheet temp files; the OOXML package was
  left open. Both now run, in `finally`.
- **Bad `format` values** are rejected with 400 rather than silently defaulting.
- `Cache-Control: private, no-store`, since this is per-user, ACL-filtered data.
- Content type was `application/msexcel` on a CSV payload; now correct for each format.

## Security

`web.xml` was checked as part of this: `/EncounterAnnotationExportExcelFile = authc,
roles[researcher]` (line 154). Shiro's `[urls]` is first-match-wins and nothing before that line
matches this path, there is no duplicate rule, and the servlet/mapping are declared once. The new
`format` parameter is resolved against a strict whitelist and never reaches a response header — the
download filename is built from a fixed prefix, the date, and an extension taken from the enum. No
change to web.xml was needed; the ACL leak fixed above was in the exporter, not the URL rules.

## Testing

- `ExportRowWriterParityTest` (new) — writes the same rows through both sinks, parses both back, and
  asserts cell-for-cell equality. Covers nulls/empties, commas, quotes, embedded newlines,
  non-ASCII, XML-illegal control characters, supplementary characters, unpaired surrogates, and
  values at and over the 32,767 cell limit including a surrogate pair straddling it. Also pins that
  `MatchAgainst` is a **string** cell (the actual WildEx regression), that the workbook has exactly
  one sheet, that an aborted export emits nothing rather than a partial workbook, and that the two
  defaults differ on purpose.
- `EncounterExportImagesTest` — the existing happy path now exports the same search as **both** CSV
  and XLSX and asserts both match the same fixture, so parity is verified end-to-end against a real
  database, not just at the writer level.

Beyond the test suite, the `.xlsx` this exporter produced from the integration test's real database
rows was replayed through WildEx's actual row-filtering logic using the SheetJS version it ships
(0.20.1): 4/4 annotations kept, grouped into 3 individual folders. The same content as CSV, once
round-tripped through Excel, keeps 0.

## Notes

- Anyone who started consuming the CSV since 10.9.5 can keep it with `?format=csv` — worth calling
  out in release notes.
- The pre-#1385 "Hidden Data Report" second sheet is **not** restored here. A second sheet would put
  records in the XLSX that the CSV cannot carry, which conflicts with the parity requirement. It is
  currently emitted nowhere for this endpoint and deserves its own issue and an equivalent CSV
  sidecar.
- CSV formula injection (`=`, `+`, `-`, `@`) is deliberately not mitigated here: prefixing values
  would change the exported data and break WildEx's exact string matching. It needs its own policy
  decision.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5).

Adversarially reviewed with [Codex](https://developers.openai.com/codex/cli) (GPT-5.6) across three
rounds — on the plan before any code was written, on the implementation, and on the fixes. Findings
from those rounds are folded into the change above; see the review-provenance comment for what each
round caught.
