### PR TITLE
fix(indexing): hand OpenSearch reindexing to the queue after commit, not on JDO flush

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -1243,13 +1243,33 @@ public class Encounter extends Base implements java.io.Serializable {
     }
 
     /** Enqueue a (deep) reindex of this encounter — refreshes its individual + annotations' ACL.
-     *  Honors skipAutoIndexing so bulk import / deserialization don't storm. */
+     *  Honors skipAutoIndexing so bulk import / deserialization don't storm.
+     *
+     *  Deferred: while a transaction is open this only PARKS the request, and Shepherd releases it
+     *  after the commit. Enqueuing from inside the transaction is what let the indexing job load
+     *  and index pre-commit state. A caller that has already committed still gets an immediate
+     *  enqueue (addPendingEntry falls through when no transaction is active); a caller that is
+     *  post-commit but holding an unrelated open transaction must use enqueueAclReindexNow(). */
     public void enqueueAclReindex() {
+        if (this.getSkipAutoIndexing() || OpenSearch.skipAutoIndexing()) return;
+        try {
+            IndexingManager.addPendingEntry(javax.jdo.JDOHelper.getPersistenceManager(this), this,
+                false);
+        } catch (Exception ex) {
+            System.out.println("Encounter.enqueueAclReindex failed for " + this.getId() + ": " + ex);
+        }
+    }
+
+    /** enqueueAclReindex() for callers that are already past their commit but still hold an open
+     *  (typically read-only) transaction that will be rolled back — parking there would discard
+     *  the request. Only the background permissions pass needs this. */
+    public void enqueueAclReindexNow() {
         if (this.getSkipAutoIndexing() || OpenSearch.skipAutoIndexing()) return;
         try {
             IndexingManagerFactory.getIndexingManager().addIndexingQueueEntry(this, false);
         } catch (Exception ex) {
-            System.out.println("Encounter.enqueueAclReindex failed for " + this.getId() + ": " + ex);
+            System.out.println("Encounter.enqueueAclReindexNow failed for " + this.getId() + ": " +
+                ex);
         }
     }
 
@@ -1261,6 +1281,16 @@ public class Encounter extends Base implements java.io.Serializable {
         // and the OLD individual it left (so the departed encounter is dropped from its ACL).
         // Only enqueue when membership actually changed; a no-op set (old == indiv) changes nothing.
         if (old != indiv) {
+            // Gaining or losing an individual IS a modification, but none of the setters on this
+            // path touch `modified` -- not setIndividual(), not addComments(), not setMatchedBy().
+            // getVersion() is derived from `modified`, and the reconciler only reindexes when the
+            // DB version is strictly greater than the indexed version, so without this bump a
+            // document that went stale here could never be repaired by the background sweep.
+            // NOTE: setDWCDateLastModified() has one-second resolution, so two membership changes
+            // inside the same second still collapse to one version. That is a backstop-only gap --
+            // the post-commit drain in IndexingManager is what actually guarantees a correct
+            // document -- but it is the reason this is not a complete fix on its own.
+            this.setDWCDateLastModified();
             this.enqueueAclReindex();
             if (old != null) old.enqueueAclReindex();
         }
@@ -4410,7 +4440,9 @@ public class Encounter extends Base implements java.io.Serializable {
                 if (childReindexNeeded) {
                     try {
                         Encounter enc = myShepherd.getEncounter(id);
-                        if (enc != null) enc.enqueueAclReindex(); // refresh individual + annotations
+                        // Now-flavored: this pass's Shepherd holds a read transaction that is
+                        // rolled back at the end, so a deferred park would be discarded.
+                        if (enc != null) enc.enqueueAclReindexNow(); // refresh individual + annotations
                     } catch (Exception ex) {
                         // best-effort; reconciler / corrective reindex recovers a missed child refresh
                     }

--- a/src/main/java/org/ecocean/IndexingManager.java
+++ b/src/main/java/org/ecocean/IndexingManager.java
@@ -3,12 +3,19 @@ package org.ecocean;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import javax.jdo.JDOHelper;
+import javax.jdo.PersistenceManager;
+import javax.jdo.PersistenceManagerFactory;
 import org.ecocean.shepherd.core.Shepherd;
 import org.ecocean.shepherd.core.ShepherdProperties;
 
@@ -31,6 +38,14 @@ public class IndexingManager {
     // Stable lock for all compound (check-then-act) mutations of indexingQueue. We cannot synchronize
     // on indexingQueue itself because resetIndexingQueuehWithInitialCapacity() reassigns the field.
     private final Object queueLock = new Object();
+
+    // Objects whose state changed again while an indexing job for them was already scheduled or
+    // running. The dedupe in addIndexingQueueEntry() must NOT simply drop the later request: the
+    // in-flight job may have loaded the object BEFORE that change was committed, which is exactly
+    // the pre-commit stale read this class used to bake into the index. We instead remember the
+    // newest (class, unindex) for the id and run one more pass when the in-flight job reaches a
+    // terminal outcome. Guarded by queueLock.
+    private Map<String, PendingEntry> requeue = new HashMap<String, PendingEntry>();
 
     // Total number of attempts (the initial attempt plus retries) before giving up on an object that
     // cannot be found in the datastore. The common cause is the postStore-before-commit race: the
@@ -56,6 +71,14 @@ public class IndexingManager {
         executor = Executors.newScheduledThreadPool(numAllowedThreads);
     }
 
+    /*
+     * Test seam. Lets a test drive the scheduler deterministically -- the real constructor's pool
+     * runs jobs that open a Shepherd and hit the database, which a unit test must not do.
+     */
+    IndexingManager(ScheduledExecutorService executor) {
+        this.executor = executor;
+    }
+
     // Returns the indexing queue List of Strings
     public List<String> getIndexingQueue() { return indexingQueue; }
 
@@ -65,17 +88,58 @@ public class IndexingManager {
      * @boolean unindex Whether the object is to be indexed or unindexed.
      */
     public void addIndexingQueueEntry(Base base, boolean unindex) {
-        String objectID = base.getId();
-        Class myClass = base.getClass();
-        // Atomic check-then-add so two concurrent postStore events for the same object schedule
+        if (base == null) return;
+        addIndexingQueueEntry(base.getId(), base.getClass(), unindex);
+    }
+
+    /*
+     * Same as above, by identity rather than instance. Used by drainPendingEntries(), which runs
+     * after the writing PersistenceManager's transaction has committed and must not touch the
+     * (now potentially closed) persistent instance.
+     */
+    public void addIndexingQueueEntry(String objectID, Class myClass, boolean unindex) {
+        if ((objectID == null) || (myClass == null)) return;
+        // Atomic check-then-act so two concurrent postStore events for the same object schedule
         // only one job.
         synchronized (queueLock) {
-            if (indexingQueue.contains(objectID)) return;
+            if (indexingQueue.contains(objectID)) {
+                // A job for this id is already scheduled or running. Do NOT drop this request:
+                // that job may have loaded the object before the change behind this call was
+                // committed. Record the newest request; finishIndexingJob() runs it once the
+                // in-flight job finishes. Later requests overwrite earlier ones on purpose --
+                // the last one describes the object's final state.
+                requeue.put(objectID, new PendingEntry(objectID, myClass, unindex, null));
+                return;
+            }
             indexingQueue.add(objectID);
         }
-        // IMPORTANT - no persistent objects, such as the passed in Base, can be referenced inside the
-        // job; we carry only the (id, class) and re-fetch by id on each attempt.
+        // IMPORTANT - no persistent objects can be referenced inside the job; we carry only the
+        // (id, class) and re-fetch by id on each attempt.
         scheduleIndexingJob(objectID, myClass, unindex, 1, 0L);
+    }
+
+    /*
+     * Terminal outcome for one object's indexing job (success, give-up, or a genuine failure).
+     * If a newer request for the same id arrived while the job was scheduled, running, or
+     * retrying, consume it and run exactly one more pass -- leaving the id in indexingQueue so
+     * concurrent events keep deduping against the follow-up. Otherwise release the id.
+     *
+     * This is what makes the post-commit handoff correct even when a pre-commit caller (e.g.
+     * Encounter.enqueueAclReindex(), which business code still calls inside the transaction) has
+     * already started a job: drainPendingEntries() runs after commit() returns, so the follow-up
+     * pass it triggers is guaranteed to load committed state.
+     */
+    private void finishIndexingJob(String objectID) {
+        PendingEntry again = null;
+
+        synchronized (queueLock) {
+            again = requeue.remove(objectID);
+            if (again == null) {
+                indexingQueue.remove(objectID);
+                return;
+            }
+        }
+        scheduleIndexingJob(again.objectID, again.myClass, again.unindex, 1, 0L);
     }
 
     // GH-1514: queue deep reindex for each MarkedIndividual identified by id,
@@ -139,8 +203,8 @@ public class IndexingManager {
                     } else {
                         base.opensearchIndexDeep();
                     }
-                    // success - terminal
-                    removeIndexingQueueEntry(objectID);
+                    // success - terminal (unless a newer change landed while we were running)
+                    finishIndexingJob(objectID);
                 } catch (Exception e) {
                     // A genuine indexing failure (not the commit race), or a failure setting up the
                     // Shepherd. Make it visible rather than silently swallowing it, then drop it; the
@@ -150,7 +214,7 @@ public class IndexingManager {
                         " (attempt " + attempt + "/" + MAX_INDEXING_ATTEMPTS + "); dropping. " +
                         "Background reconciler will recover it if it exists. " + e);
                     e.printStackTrace();
-                    removeIndexingQueueEntry(objectID);
+                    finishIndexingJob(objectID);
                 } finally {
                     if (bgShepherd != null) bgShepherd.rollbackAndClose();
                 }
@@ -161,6 +225,9 @@ public class IndexingManager {
             executor.schedule(rn, delaySeconds, TimeUnit.SECONDS);
         } catch (RejectedExecutionException rex) {
             // Executor is shutting down; do not leak the queue entry.
+            // Deliberately a hard remove rather than finishIndexingJob(): the executor is gone, so
+            // re-scheduling a follow-up would only be rejected again. Anything queued for this id
+            // is dropped with it; the background reconciler is the backstop.
             System.out.println("IndexingManager: could not schedule indexing job for " + objectID +
                 " (executor shutdown?); removing from queue. " + rex);
             removeIndexingQueueEntry(objectID);
@@ -183,14 +250,19 @@ public class IndexingManager {
             System.out.println("IndexingManager: object " + objectID + " still not found after " + attempt +
                 " attempt(s); giving up (object may have been rolled back / never committed, or is an " +
                 "unindex of an already-deleted row). Background reconciler will index it if it exists.");
-            removeIndexingQueueEntry(objectID);
+            // Still a terminal outcome, so a queued follow-up request must not be swallowed: a
+            // post-commit drain may have marked this id while we were burning retries, and that
+            // request is precisely the one that CAN succeed now.
+            finishIndexingJob(objectID);
         }
     }
 
-    // Removes an object's UUID from the queue
+    // Removes an object's UUID from the queue, dropping any queued follow-up with it. This is the
+    // hard release; the job path uses finishIndexingJob() so a follow-up survives.
     public void removeIndexingQueueEntry(String objectID) {
         synchronized (queueLock) {
             indexingQueue.remove(objectID);
+            requeue.remove(objectID);
         }
     }
 
@@ -198,11 +270,234 @@ public class IndexingManager {
     public void resetIndexingQueuehWithInitialCapacity(int initialCapacity) {
         synchronized (queueLock) {
             indexingQueue = Collections.synchronizedList(new ArrayList<String>());
+            requeue = new HashMap<String, PendingEntry>();
         }
     }
 
     public void shutdown() {
         if (executor != null) executor.shutdown();
+    }
+
+    // =====================================================================================
+    // Deferred (post-commit) indexing
+    //
+    // WildbookLifecycleListener.postStore() fires on JDO flush/store, NOT on commit. Enqueuing
+    // there means the background job -- which opens its own Shepherd and therefore its own JDBC
+    // connection -- can load the row BEFORE the writing transaction commits, and index pre-change
+    // state. Nothing detects that: for a row that already exists the reload SUCCEEDS (only a
+    // brand-new row raises JDOObjectNotFoundException, which is what the retry path handles), so
+    // the job reports success and the stale document sticks. On the paths that never touch
+    // Encounter.modified it then never self-heals either, because the reconciler only reindexes
+    // when the DB version is strictly greater than the indexed version.
+    //
+    // So postStore no longer enqueues. It parks (id, class, unindex) against the PersistenceManager
+    // doing the write, and Shepherd drains the park AFTER commit() returns.
+    //
+    // The park lives in the PM's own JDO user-object map rather than a static Map keyed by PM:
+    // that is identity-scoped by construction (no reliance on PersistenceManager equals/hashCode,
+    // no pooled-PM aliasing) and it is collected together with the PM if a request dies without
+    // reaching commit or rollback.
+    // =====================================================================================
+
+    private static final String PENDING_USER_OBJECT_KEY = "org.ecocean.IndexingManager.pending";
+
+    // One deferred index request. Only identity is kept -- never the Persistable, whose
+    // PersistenceManager is typically closed by the time the entry is drained.
+    private static class PendingEntry {
+        final String objectID;
+        final Class myClass;
+        final boolean unindex;
+        // JDO identity, captured while the PM is open, used to evict the object from the
+        // level-2 cache at drain time. May be null if it could not be resolved.
+        final Object jdoObjectId;
+
+        PendingEntry(String objectID, Class myClass, boolean unindex, Object jdoObjectId) {
+            this.objectID = objectID;
+            this.myClass = myClass;
+            this.unindex = unindex;
+            this.jdoObjectId = jdoObjectId;
+        }
+
+        // identity of the REQUEST, so repeated parks of the same object collapse. jdoObjectId is
+        // derived from objectID and is deliberately excluded.
+        @Override public boolean equals(Object other) {
+            if (this == other) return true;
+            if (!(other instanceof PendingEntry)) return false;
+            PendingEntry pe = (PendingEntry)other;
+            return this.unindex == pe.unindex && this.objectID.equals(pe.objectID) &&
+                   this.myClass.equals(pe.myClass);
+        }
+
+        @Override public int hashCode() {
+            return (objectID.hashCode() * 31 + myClass.hashCode()) * 31 + (unindex ? 1 : 0);
+        }
+    }
+
+    /*
+     * The per-PersistenceManager park. Installed once by Shepherd.beginDBTransaction() so that
+     * nothing else ever has to create it, which is what lets every other operation here take the
+     * bucket's OWN monitor and never a shared static lock.
+     *
+     * Locking rule, and it matters: we must NEVER hold a lock of ours while calling into a
+     * PersistenceManager. Lifecycle callbacks (postStore) can run while DataNucleus holds
+     * PM-internal locks -- datanucleus.Multithreaded is enabled -- so a static lock held across
+     * pm.getUserObject() would give PM-lock -> ours on one thread and ours -> PM-lock on another.
+     * Every method below therefore reads the bucket from the PM first, then synchronizes only on
+     * the bucket to touch its contents.
+     */
+    private static class PendingBucket {
+        // captured while the PM is open, so drain can still reach the level-2 cache afterwards
+        final PersistenceManagerFactory pmf;
+        final Set<PendingEntry> entries = new LinkedHashSet<PendingEntry>(); // guarded by `this`
+
+        // Terminal state, guarded by `this`. addPendingEntry() checks "is the transaction active"
+        // and locks the bucket as two separate steps, so a commit can drain (or a rollback can
+        // discard) in between. Without this the late request would be added to a bucket nobody
+        // will ever look at again and silently lost -- which main did not do.
+        boolean drained = false;   // commit already took the contents: a late request must run now
+        boolean discarded = false; // transaction did not commit: a late request must be dropped
+
+        PendingBucket(PersistenceManagerFactory pmf) { this.pmf = pmf; }
+    }
+
+    /**
+     * Give this PersistenceManager somewhere to park deferred index requests. Called from
+     * Shepherd.beginDBTransaction(); idempotent, and never throws.
+     */
+    public static void installPendingBucket(PersistenceManager pm) {
+        if (pm == null) return;
+        try {
+            if (pm.isClosed()) return;
+            PendingBucket existing = (PendingBucket)pm.getUserObject(PENDING_USER_OBJECT_KEY);
+            if (existing != null) {
+                boolean terminal = false;
+                synchronized (existing) {
+                    terminal = existing.drained || existing.discarded;
+                }
+                // A live park belongs to a transaction still in progress -- beginDBTransaction()
+                // is also called for an already-active transaction. Replacing it would drop it.
+                if (!terminal) return;
+            }
+            pm.putUserObject(PENDING_USER_OBJECT_KEY,
+                new PendingBucket(pm.getPersistenceManagerFactory()));
+        } catch (Exception ex) {
+            System.out.println("IndexingManager.installPendingBucket() failed: " + ex);
+        }
+    }
+
+    // Non-throwing read of the park. Returns null when there is nothing to defer to.
+    private static PendingBucket pendingBucket(PersistenceManager pm) {
+        if (pm == null) return null;
+        try {
+            if (pm.isClosed()) return null;
+            return (PendingBucket)pm.getUserObject(PENDING_USER_OBJECT_KEY);
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    /**
+     * Park an index/unindex request until the PersistenceManager's transaction commits.
+     *
+     * Deferral only applies while a transaction is ACTIVE. A caller that has already committed
+     * (e.g. IndividualRemoveEncounter, which reindexes right after commitDBTransaction()) gets the
+     * old immediate behavior -- parking those would mean discarding them at close.
+     */
+    public static void addPendingEntry(PersistenceManager pm, Base base, boolean unindex) {
+        if (base == null) return;
+        String objectID = base.getId();
+        if (objectID == null) return;
+        Class myClass = base.getClass();
+        PendingBucket bucket = null;
+        try {
+            if ((pm != null) && !pm.isClosed() && pm.currentTransaction().isActive())
+                bucket = pendingBucket(pm);
+        } catch (Exception ex) {
+            bucket = null;
+        }
+        if (bucket == null) {
+            // no open transaction to defer to (or a PM that Shepherd did not set up)
+            enqueueNow(objectID, myClass, unindex);
+            return;
+        }
+        Object oid = null;
+        try {
+            oid = JDOHelper.getObjectId(base);
+        } catch (Exception ex) {
+            // non-fatal: we simply skip the level-2 eviction for this object
+        }
+        PendingEntry pe = new PendingEntry(objectID, myClass, unindex, oid);
+        boolean tooLate = false;
+        synchronized (bucket) {
+            if (bucket.discarded) return;      // transaction did not commit; nothing to index
+            if (bucket.drained) {
+                tooLate = true;                // commit beat us here; queue it directly instead
+            } else {
+                bucket.entries.add(pe);
+            }
+        }
+        if (tooLate) enqueueNow(objectID, myClass, unindex);
+    }
+
+    /**
+     * Enqueue everything parked against this PersistenceManager. Called by Shepherd once the
+     * transaction has ended in a way that may have persisted data (see Shepherd.commitDBTransaction()).
+     *
+     * Each object is evicted from the (PMF-wide, shared) level-2 cache immediately BEFORE its job
+     * is scheduled. DataNucleus level-2 caching is on by default (type=soft) and Wildbook does not
+     * disable it, so without this both the indexing job and any other in-flight request can read a
+     * pre-commit copy of the object out of the cache instead of the committed row. Evicting after
+     * scheduling would be too late -- the job can already be running.
+     */
+    public static void drainPendingEntries(PersistenceManager pm) {
+        PendingBucket bucket = pendingBucket(pm);
+
+        if (bucket == null) return;
+        List<PendingEntry> taken = null;
+        synchronized (bucket) {
+            bucket.drained = true; // must be set even when empty, so a late parker queues directly
+            if (bucket.entries.isEmpty()) return;
+            taken = new ArrayList<PendingEntry>(bucket.entries);
+            bucket.entries.clear();
+        }
+        for (PendingEntry pe : taken) {
+            if ((bucket.pmf != null) && (pe.jdoObjectId != null)) {
+                try {
+                    bucket.pmf.getDataStoreCache().evict(pe.jdoObjectId);
+                } catch (Exception ex) {
+                    System.out.println("IndexingManager: level-2 evict failed for " + pe.objectID +
+                        ": " + ex);
+                }
+            }
+            enqueueNow(pe.objectID, pe.myClass, pe.unindex);
+        }
+    }
+
+    /**
+     * Drop everything parked against this PersistenceManager -- the transaction did not commit,
+     * so there is nothing to index. Also used by closeDBTransaction() as pure cleanup; close is
+     * never treated as evidence that a commit happened.
+     */
+    public static void discardPendingEntries(PersistenceManager pm) {
+        PendingBucket bucket = pendingBucket(pm);
+
+        if (bucket == null) return;
+        synchronized (bucket) {
+            // Only a bucket that has NOT been drained becomes discarded: commitDBTransaction()
+            // drains and closeDBTransaction() then discards the same bucket, and that close must
+            // not turn a committed transaction's park into a "drop everything" state.
+            if (!bucket.drained) bucket.discarded = true;
+            bucket.entries.clear();
+        }
+    }
+
+    private static void enqueueNow(String objectID, Class myClass, boolean unindex) {
+        try {
+            IndexingManager im = IndexingManagerFactory.getIndexingManager();
+            if (im != null) im.addIndexingQueueEntry(objectID, myClass, unindex);
+        } catch (Exception ex) {
+            System.out.println("IndexingManager.enqueueNow() failed for " + objectID + ": " + ex);
+        }
     }
 
 }

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -466,11 +466,14 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
 
     // Adds a new encounter to this MarkedIndividual.
     /** Enqueue a (deep) reindex of this individual — refreshes the individual + its member
-     *  encounters. Honors skipAutoIndexing so bulk import / deserialization don't storm. */
+     *  encounters. Honors skipAutoIndexing so bulk import / deserialization don't storm.
+     *
+     *  Deferred while a transaction is open — see Encounter.enqueueAclReindex() for why. */
     public void enqueueAclReindex() {
         if (this.getSkipAutoIndexing() || OpenSearch.skipAutoIndexing()) return;
         try {
-            IndexingManagerFactory.getIndexingManager().addIndexingQueueEntry(this, false);
+            IndexingManager.addPendingEntry(javax.jdo.JDOHelper.getPersistenceManager(this), this,
+                false);
         } catch (Exception ex) {
             System.out.println("MarkedIndividual.enqueueAclReindex failed for " + this.getId() + ": " + ex);
         }

--- a/src/main/java/org/ecocean/WildbookLifecycleListener.java
+++ b/src/main/java/org/ecocean/WildbookLifecycleListener.java
@@ -1,6 +1,7 @@
 package org.ecocean;
 
 import java.io.IOException;
+import javax.jdo.JDOHelper;
 import javax.jdo.listener.*;
 import org.datanucleus.enhancement.Persistable;
 import org.ecocean.Base;
@@ -68,8 +69,13 @@ public class WildbookLifecycleListener implements StoreLifecycleListener, Delete
             try {
                 // base.opensearchIndexDeep();
                 // new way - put indexing in managed queue
-                IndexingManager im = IndexingManagerFactory.getIndexingManager();
-                im.addIndexingQueueEntry(base, false);
+                //
+                // ...but NOT yet. postStore fires on JDO flush/store, not on commit, and the
+                // indexing job runs on its own connection: enqueuing here let it load the row
+                // before this transaction committed and index pre-change state (silently -- an
+                // existing row reloads fine, so nothing looked wrong). Park it against this
+                // PersistenceManager instead; Shepherd drains the park once commit() returns.
+                IndexingManager.addPendingEntry(JDOHelper.getPersistenceManager(obj), base, false);
             } catch (Exception ex) {
                 ex.printStackTrace();
             }

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -68,6 +68,17 @@ public class Shepherd {
     private String action = "undefined";
     private String shepherdID = "";
 
+    // The PersistenceManager this Shepherd has already registered a WildbookLifecycleListener on.
+    // Compared by identity: beginDBTransaction() runs again on every updateDBTransaction()
+    // (= commit + begin) and used to add ANOTHER listener each time, so one store event fanned out
+    // to N duplicate callbacks. A brand-new pm (pm was null/closed) does not match and gets one.
+    private PersistenceManager listenerRegisteredOn = null;
+
+    // Serializes this Shepherd's transaction lifecycle (begin/commit/rollback/close) so the
+    // deferred-indexing park cannot be drained and discarded concurrently -- a close() racing a
+    // commit() would otherwise drop a committed object's index request.
+    private final Object txLock = new Object();
+
     // Constructor to create a new shepherd thread object
     public Shepherd(String context) { this(context, null); }
 
@@ -110,10 +121,15 @@ public class Shepherd {
         // that fails (e.g. on an already-broken connection) skips the close, leaking the
         // PersistenceManager/DB connection and leaving a stale ShepherdState entry -- exactly the
         // "rollback-failed" rows seen accumulating on dbconnections.jsp until the pool exhausts.
-        try {
-            rollbackDBTransaction();
-        } finally {
-            closeDBTransaction();
+        //
+        // Held across BOTH halves: releasing txLock in between would let another thread begin a
+        // fresh transaction in the gap, whose parked index requests this close would then discard.
+        synchronized (txLock) {
+            try {
+                rollbackDBTransactionInternal();
+            } finally {
+                closeDBTransactionInternal();
+            }
         }
     }
 
@@ -3377,17 +3393,48 @@ public class Shepherd {
      * Opens the database up for information retrieval, storage, and removal
      */
     public void beginDBTransaction() {
+        synchronized (txLock) {
+            beginDBTransactionInternal();
+        }
+    }
+
+    /*
+     * Register the store listener, install the deferred-indexing park, and only THEN activate the
+     * transaction. The order is the contract, not an accident: a store callback can only fire once
+     * the transaction is active, and by then it needs both the listener and a LIVE park already in
+     * place. Activating first leaves a window in which a callback sees an active transaction next
+     * to the PREVIOUS transaction's terminal park, and would either enqueue immediately (a drained
+     * park -- reintroducing the pre-commit stale read this whole mechanism exists to prevent) or
+     * silently drop the request (a discarded park), for a transaction that is genuinely open.
+     *
+     * Package-private and static so that ordering can be asserted against a mock PersistenceManager
+     * without standing up a datastore. Returns the pm the listener is now registered on.
+     */
+    static PersistenceManager prepareAndBeginTransaction(PersistenceManager pm,
+        PersistenceManager listenerRegisteredOn) {
+        if (pm == null) return listenerRegisteredOn;
+        // One listener per PersistenceManager (see the field of the same name).
+        if (listenerRegisteredOn != pm) {
+            pm.addInstanceLifecycleListener(new WildbookLifecycleListener(), null);
+            listenerRegisteredOn = pm;
+        }
+        IndexingManager.installPendingBucket(pm);
+        if (!pm.currentTransaction().isActive()) pm.currentTransaction().begin();
+        return listenerRegisteredOn;
+    }
+
+    private void beginDBTransactionInternal() {
         // PersistenceManagerFactory pmf = ShepherdPMF.getPMF(localContext);
         try {
-            if (pm == null || pm.isClosed()) {
+            if (pm == null || pm.isClosed())
                 pm = ShepherdPMF.getPMF(localContext).getPersistenceManager();
-                pm.currentTransaction().begin();
-            } else if (!pm.currentTransaction().isActive()) {
-                pm.currentTransaction().begin();
+            if (pm == null) {
+                System.out.println(
+                    "Shepherd.beginDBTransaction(): could not obtain a PersistenceManager");
+                return;
             }
+            listenerRegisteredOn = prepareAndBeginTransaction(pm, listenerRegisteredOn);
             ShepherdState.setShepherdState(action + "_" + shepherdID, "begin");
-
-            pm.addInstanceLifecycleListener(new WildbookLifecycleListener(), null);
         } catch (JDOUserException jdoe) {
             jdoe.printStackTrace();
         } catch (NullPointerException npe) {
@@ -3405,12 +3452,26 @@ public class Shepherd {
      */
     // TODO: Either (a) throw an exception itself or (b) return boolean of success (the latter was disabled, needs investigation)
     public void commitDBTransaction() {
+        synchronized (txLock) {
+            commitDBTransactionInternal();
+        }
+    }
+
+    private void commitDBTransactionInternal() {
+        boolean committed = false;
+        // A commit can throw AFTER the database has durably committed (e.g. the connection drops
+        // while the acknowledgement comes back). Treat that as "outcome unknown" and drain anyway:
+        // draining is safe either way, because the indexing job re-reads the object from the
+        // database -- worst case it re-indexes state that never changed.
+        boolean outcomeUnknown = false;
+
         try {
             // System.out.println("     shepherd:"+identifyMe+" is trying to commit a transaction");
             // System.out.println("Is the pm null? " + Boolean.toString(pm == null));
             if ((pm != null) && (pm.currentTransaction().isActive())) {
                 // System.out.println("     Now commiting a transaction with pm"+(String)pm.getUserObject());
                 pm.currentTransaction().commit();
+                committed = true;
 
                 // return true;
                 // System.out.println("A transaction has been successfully committed.");
@@ -3420,30 +3481,51 @@ public class Shepherd {
             }
             ShepherdState.setShepherdState(action + "_" + shepherdID, "commit");
         } catch (JDOUserException jdoe) {
+            outcomeUnknown = true;
             jdoe.printStackTrace();
             System.out.println("I failed to commit a transaction." + "\n" + jdoe.getStackTrace());
             // return false;
         } catch (JDOException jdoe2) {
+            outcomeUnknown = true;
             jdoe2.printStackTrace();
-            Throwable[] throwables = jdoe2.getNestedExceptions();
-            int numThrowables = throwables.length;
-            for (int i = 0; i < numThrowables; i++) {
-                Throwable t = throwables[i];
-                if (t instanceof java.sql.SQLException) {
-                    java.sql.SQLException exc = (java.sql.SQLException)t;
-                    java.sql.SQLException g = exc.getNextException();
-                    g.printStackTrace();
-                }
-                t.printStackTrace();
-            }
+            logNestedExceptions(jdoe2);
             // return false;
         }
         // added to prevent conflicting calls jah 1/19/04
         catch (NullPointerException npe) {
+            outcomeUnknown = true;
             System.out.println(
                 "A null pointer exception was thrown while trying to commit a transaction!");
             npe.printStackTrace();
             // return false;
+        } finally {
+            // Post-commit indexing handoff. Everything WildbookLifecycleListener parked during
+            // this transaction is only queued now, so the background indexer can no longer load
+            // and index pre-commit state.
+            //
+            // In a finally, not after the try: if anything above throws on its way out (the
+            // diagnostic logging used to be able to), a durable-but-unacknowledged commit would
+            // lose every parked request -- worse than the old behavior, which had already queued
+            // them. drainPendingEntries() is itself non-throwing.
+            if (committed || outcomeUnknown) IndexingManager.drainPendingEntries(pm);
+        }
+    }
+
+    /* Dump the nested causes of a JDOException. Null-safe at every hop: getNestedExceptions() can
+     * be null (JDOException has message-only constructors) and so can SQLException.getNextException().
+     * An NPE here used to escape the caller's catch block entirely. */
+    static void logNestedExceptions(JDOException jdoe) {
+        if (jdoe == null) return;
+        Throwable[] throwables = jdoe.getNestedExceptions();
+        if (throwables == null) return;
+        for (int i = 0; i < throwables.length; i++) {
+            Throwable t = throwables[i];
+            if (t == null) continue;
+            if (t instanceof java.sql.SQLException) {
+                java.sql.SQLException g = ((java.sql.SQLException)t).getNextException();
+                if (g != null) g.printStackTrace();
+            }
+            t.printStackTrace();
         }
     }
 
@@ -3456,18 +3538,30 @@ public class Shepherd {
      * once the encounter change is confirmed committed. (#1608)
      */
     public boolean commitDBTransactionWithStatus() {
+        synchronized (txLock) {
+            return commitDBTransactionWithStatusInternal();
+        }
+    }
+
+    private boolean commitDBTransactionWithStatusInternal() {
+        boolean handoff = false;
+
         try {
             if ((pm != null) && pm.currentTransaction().isActive()) {
                 pm.currentTransaction().commit();
+                handoff = true;
                 ShepherdState.setShepherdState(action + "_" + shepherdID, "commit");
                 return true;
             }
             System.out.println("commitDBTransactionWithStatus: transaction was not active.");
             return false;
         } catch (Exception e) {
+            handoff = true; // outcome unknown -- drain anyway; see commitDBTransactionInternal()
             System.out.println("commitDBTransactionWithStatus: commit failed: " + e);
             e.printStackTrace();
             return false;
+        } finally {
+            if (handoff) IndexingManager.drainPendingEntries(pm);
         }
     }
 
@@ -3475,15 +3569,30 @@ public class Shepherd {
      * Since we call these together all over Wildbook
      */
     public void updateDBTransaction() {
-        commitDBTransaction();
-        beginDBTransaction();
+        // one lock across commit+begin; see rollbackAndClose() for why the gap matters
+        synchronized (txLock) {
+            commitDBTransactionInternal();
+            beginDBTransactionInternal();
+        }
     }
 
     /**
      * Closes a PersistenceManager
      */
     public void closeDBTransaction() {
+        synchronized (txLock) {
+            closeDBTransactionInternal();
+        }
+    }
+
+    private void closeDBTransactionInternal() {
         boolean closed = false;
+        // Cleanup only. "Transaction not active" is NOT proof that a commit succeeded -- it is
+        // equally true after a raw rollback or a commit that threw -- so close never drains the
+        // deferred-indexing park, it only drops it. Must run BEFORE pm.close(), because the park
+        // is held in the PersistenceManager's user-object map. A successful commitDBTransaction()
+        // has already drained and removed it by this point.
+        IndexingManager.discardPendingEntries(pm);
         try {
             if ((pm != null) && (!pm.isClosed())) {
                 pm.close();
@@ -3510,7 +3619,16 @@ public class Shepherd {
      * Undoes any changes made to an open database.
      */
     public void rollbackDBTransaction() {
+        synchronized (txLock) {
+            rollbackDBTransactionInternal();
+        }
+    }
+
+    private void rollbackDBTransactionInternal() {
         boolean rolledBack = false;
+        // Nothing committed, so nothing to index. Drop the deferred-indexing park before rolling
+        // back, so a later close() cannot see it.
+        IndexingManager.discardPendingEntries(pm);
         try {
             if ((pm != null) && (pm.currentTransaction().isActive())) {
                 pm.currentTransaction().rollback();

--- a/src/test/java/org/ecocean/ChildReindexTriggerTest.java
+++ b/src/test/java/org/ecocean/ChildReindexTriggerTest.java
@@ -2,6 +2,7 @@ package org.ecocean;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -20,6 +21,11 @@ import org.mockito.MockedStatic;
  * Verifies that encounter<->individual membership changes enqueue a deep reindex of the
  * affected encounter + old/new individuals via IndexingManager, and that skipAutoIndexing
  * suppresses the enqueue (so bulk import / deserialization do not storm the queue).
+ *
+ * enqueueAclReindex() now routes through IndexingManager.addPendingEntry(), which DEFERS to
+ * after the commit when a transaction is open. These objects are transient (no PersistenceManager),
+ * so they take the immediate fallback and land on the (id, class, unindex) overload -- same
+ * request, different signature. The deferral itself is covered by IndexingDeferredEnqueueTest.
  *
  * The ACL-propagation path inside Encounter.opensearchIndexPermissions() requires a live
  * Shepherd + OpenSearch and is covered by the Task 9 integration test, not here.
@@ -50,6 +56,7 @@ class ChildReindexTriggerTest {
     @Test void setIndividual_enqueuesEncounterAndOldIndividual() throws Exception {
         Encounter enc = spy(new Encounter());
         enc.setSkipAutoIndexing(false);
+        enc.setCatalogNumber("enc-0"); // getId() must be non-null or there is nothing to enqueue
         MarkedIndividual oldInd = spy(new MarkedIndividual());
         oldInd.setSkipAutoIndexing(false);
         setIndividualField(enc, oldInd);
@@ -62,9 +69,9 @@ class ChildReindexTriggerTest {
             enc.setIndividual(newInd);
         }
         // enc (its new individual + annotations refresh via deep index)
-        verify(im).addIndexingQueueEntry(eq(enc), eq(false));
+        verify(im).addIndexingQueueEntry(eq("enc-0"), eq(Encounter.class), eq(false));
         // old individual the encounter left
-        verify(im).addIndexingQueueEntry(eq(oldInd), eq(false));
+        verify(im).addIndexingQueueEntry(eq(oldInd.getId()), eq(MarkedIndividual.class), eq(false));
     }
 
     // skipAutoIndexing on the encounter (and old individual) suppresses all enqueues.
@@ -82,7 +89,8 @@ class ChildReindexTriggerTest {
             factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
             enc.setIndividual(newInd);
         }
-        verify(im, never()).addIndexingQueueEntry(any(), anyBoolean());
+        verify(im, never()).addIndexingQueueEntry(any(Base.class), anyBoolean());
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
     }
 
     // MarkedIndividual.removeEncounter enqueues the individual AND the departed encounter.
@@ -101,8 +109,8 @@ class ChildReindexTriggerTest {
             factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
             ind.removeEncounter(enc);
         }
-        verify(im).addIndexingQueueEntry(eq(ind), eq(false));
-        verify(im).addIndexingQueueEntry(eq(enc), eq(false));
+        verify(im).addIndexingQueueEntry(eq(ind.getId()), eq(MarkedIndividual.class), eq(false));
+        verify(im).addIndexingQueueEntry(eq("enc-1"), eq(Encounter.class), eq(false));
     }
 
     // MarkedIndividual.addEncounter enqueues the joining encounter.
@@ -119,6 +127,6 @@ class ChildReindexTriggerTest {
             factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
             ind.addEncounter(enc);
         }
-        verify(im).addIndexingQueueEntry(eq(enc), eq(false));
+        verify(im).addIndexingQueueEntry(eq("enc-2"), eq(Encounter.class), eq(false));
     }
 }

--- a/src/test/java/org/ecocean/IndexingDeferredEnqueueTest.java
+++ b/src/test/java/org/ecocean/IndexingDeferredEnqueueTest.java
@@ -1,0 +1,557 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.jdo.JDOHelper;
+import javax.jdo.PersistenceManager;
+import javax.jdo.PersistenceManagerFactory;
+import javax.jdo.Transaction;
+import javax.jdo.datastore.DataStoreCache;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.MockedStatic;
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ * Unit tests for the post-commit indexing handoff (the pre-commit enqueue race) and for the
+ * generation-aware dedupe that keeps a follow-up pass alive when a job is already in flight.
+ *
+ * No Shepherd, no datastore, no OpenSearch: the IndexingManager instances here are built with the
+ * test-seam constructor and a mock scheduler, so no indexing job ever actually runs.
+ */
+class IndexingDeferredEnqueueTest {
+    // must match IndexingManager.PENDING_USER_OBJECT_KEY -- asserted on directly so a park that
+    // silently no-ops cannot make a test pass for the wrong reason
+    private static final String PENDING_KEY = "org.ecocean.IndexingManager.pending";
+
+    // OpenSearch.skipAutoIndexing() reads the host filesystem for /tmp/skipAutoIndexing, and
+    // another test in the suite creates that file and only removes it at JVM exit. Stub it, or
+    // these fail depending on ordering. (Same reason as ChildReindexTriggerTest.)
+    private static MockedStatic<OpenSearch> mockNoGlobalSkip() {
+        MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class);
+
+        os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+        return os;
+    }
+
+    /** A PersistenceManager stub whose user-object map actually behaves like one. */
+    private static PersistenceManager pmWithUserObjects(PersistenceManagerFactory pmf,
+        boolean txActive) {
+        PersistenceManager pm = mock(PersistenceManager.class);
+        Transaction tx = mock(Transaction.class);
+        final Map<Object, Object> userObjects = new HashMap<Object, Object>();
+
+        when(tx.isActive()).thenReturn(txActive);
+        when(pm.currentTransaction()).thenReturn(tx);
+        when(pm.isClosed()).thenReturn(false);
+        when(pm.getPersistenceManagerFactory()).thenReturn(pmf);
+        when(pm.getUserObject(any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.get(inv.getArgument(0)));
+        when(pm.putUserObject(any(), any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.put(inv.getArgument(0), inv.getArgument(1)));
+        when(pm.removeUserObject(any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.remove(inv.getArgument(0)));
+        return pm;
+    }
+
+    // a PM that Shepherd has already prepared: park installed, transaction open
+    private static PersistenceManager preparedPm(PersistenceManagerFactory pmf) {
+        PersistenceManager pm = pmWithUserObjects(pmf, true);
+
+        IndexingManager.installPendingBucket(pm);
+        assertNotNull(pm.getUserObject(PENDING_KEY), "precondition: park installed on the PM");
+        return pm;
+    }
+
+    private static Encounter encounterWithId(String id) {
+        Encounter enc = new Encounter();
+
+        enc.setCatalogNumber(id);
+        enc.setSkipAutoIndexing(false);
+        return enc;
+    }
+
+    // ---- park / drain / discard -------------------------------------------------------------
+
+    // Parking must NOT enqueue -- the transaction has not committed yet. The follow-up drain
+    // proves the request was really parked rather than silently dropped.
+    @Test void addPendingEntry_parksWithoutEnqueuing_thenDrainReleasesIt() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-park-1");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, enc, false);
+            verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+            verify(im, never()).addIndexingQueueEntry(any(Base.class), anyBoolean());
+
+            IndexingManager.drainPendingEntries(pm);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-park-1"), eq(Encounter.class), eq(false));
+    }
+
+    // Draining evicts from the level-2 cache BEFORE scheduling -- otherwise the job it just
+    // scheduled could read a pre-commit copy out of the cache instead of the committed row.
+    @Test void drain_evictsLevel2ThenEnqueues() {
+        DataStoreCache l2 = mock(DataStoreCache.class);
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+
+        when(pmf.getDataStoreCache()).thenReturn(l2);
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-drain-1");
+        IndexingManager im = mock(IndexingManager.class);
+        // a transient Encounter has no JDO identity, so stub one -- otherwise this test would
+        // silently assert nothing about eviction
+        Object oid = new Object();
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<JDOHelper> jdo = mockStatic(JDOHelper.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            jdo.when(() -> JDOHelper.getObjectId(any())).thenReturn(oid);
+            IndexingManager.addPendingEntry(pm, enc, false);
+            IndexingManager.drainPendingEntries(pm);
+        }
+        InOrder inOrder = inOrder(l2, im);
+
+        inOrder.verify(l2).evict(oid);
+        inOrder.verify(im).addIndexingQueueEntry(eq("enc-drain-1"), eq(Encounter.class), eq(false));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    // A level-2 cache that throws must not stop the object from being indexed.
+    @Test void drain_evictFailure_stillEnqueues() {
+        DataStoreCache l2 = mock(DataStoreCache.class);
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+
+        when(pmf.getDataStoreCache()).thenReturn(l2);
+        doThrow(new RuntimeException("boom")).when(l2).evict(any());
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-evictfail-1");
+        IndexingManager im = mock(IndexingManager.class);
+        Object oid = new Object();
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<JDOHelper> jdo = mockStatic(JDOHelper.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            jdo.when(() -> JDOHelper.getObjectId(any())).thenReturn(oid);
+            IndexingManager.addPendingEntry(pm, enc, false);
+            IndexingManager.drainPendingEntries(pm);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-evictfail-1"), eq(Encounter.class), eq(false));
+    }
+
+    // postStore fires many times per transaction; repeated parks of one object must collapse.
+    @Test void drain_collapsesDuplicateParks() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-dupe-1");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, enc, false);
+            IndexingManager.addPendingEntry(pm, enc, false);
+            IndexingManager.addPendingEntry(pm, enc, false);
+            IndexingManager.drainPendingEntries(pm);
+        }
+        verify(im, times(1)).addIndexingQueueEntry(eq("enc-dupe-1"), eq(Encounter.class), eq(false));
+    }
+
+    // commitDBTransaction() drains, then closeDBTransaction() discards the same PM: the second
+    // pass must be a no-op, not a re-enqueue.
+    @Test void drainThenDiscard_isIdempotent() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-idem-1");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, enc, false);
+            IndexingManager.drainPendingEntries(pm);
+            IndexingManager.discardPendingEntries(pm);
+            IndexingManager.drainPendingEntries(pm);
+        }
+        verify(im, times(1)).addIndexingQueueEntry(eq("enc-idem-1"), eq(Encounter.class), eq(false));
+    }
+
+    // A rolled-back transaction must index nothing. The park is asserted present first, so this
+    // cannot pass merely because nothing was ever parked.
+    @Test void discard_dropsEverything() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-discard-1");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, enc, false);
+            assertFalse(pendingEntryCount(pm) == 0, "precondition: something was actually parked");
+            IndexingManager.discardPendingEntries(pm);
+            IndexingManager.drainPendingEntries(pm);
+        }
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+    }
+
+    // With no usable PersistenceManager there is nothing to defer to, so fall back to the old
+    // immediate behavior rather than silently losing the request.
+    @Test void addPendingEntry_nullPm_enqueuesImmediately() {
+        Encounter enc = encounterWithId("enc-nopm-1");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(null, enc, false);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-nopm-1"), eq(Encounter.class), eq(false));
+    }
+
+    // A caller that has already committed (transaction no longer active) must NOT be deferred --
+    // deferring it would mean discarding it at close. This is the IndividualRemoveEncounter shape.
+    @Test void addPendingEntry_inactiveTransaction_enqueuesImmediately() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = pmWithUserObjects(pmf, false); // committed already
+
+        IndexingManager.installPendingBucket(pm);
+        Encounter enc = encounterWithId("enc-postcommit-1");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, enc, false);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-postcommit-1"), eq(Encounter.class), eq(false));
+        assertEquals(0, pendingEntryCount(pm), "nothing should have been parked");
+    }
+
+    // ---- park racing the end of the transaction ---------------------------------------------
+
+    // addPendingEntry() checks "transaction active" and locks the bucket as two separate steps, so
+    // a commit can drain in between. The late request must be queued directly, not added to a
+    // bucket nobody will read again.
+    @Test void parkAfterDrain_enqueuesImmediately() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-late-1");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.drainPendingEntries(pm); // commit happened first (park was empty)
+            IndexingManager.addPendingEntry(pm, enc, false);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-late-1"), eq(Encounter.class), eq(false));
+        assertEquals(0, pendingEntryCount(pm), "must not accumulate in a drained park");
+    }
+
+    // Same race against a rollback: the transaction did not commit, so the late request is dropped.
+    @Test void parkAfterDiscard_isDropped() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-late-2");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.discardPendingEntries(pm);
+            IndexingManager.addPendingEntry(pm, enc, false);
+        }
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+        assertEquals(0, pendingEntryCount(pm), "must not accumulate in a discarded park");
+    }
+
+    // closeDBTransaction() discards the SAME bucket a successful commitDBTransaction() just
+    // drained. That close must not flip the park into "drop everything" for a later parker.
+    @Test void discardAfterDrain_doesNotMaskTheDrainedState() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-late-3");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.drainPendingEntries(pm);   // commit
+            IndexingManager.discardPendingEntries(pm); // close
+            IndexingManager.addPendingEntry(pm, enc, false);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-late-3"), eq(Encounter.class), eq(false));
+    }
+
+    // beginDBTransaction() runs again for an already-active transaction; installing a fresh park
+    // there would drop everything the open transaction had already parked.
+    @Test void installPendingBucket_doesNotClobberALivePark() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-live-1");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, enc, false);
+            IndexingManager.installPendingBucket(pm); // a redundant begin
+            assertEquals(1, pendingEntryCount(pm), "live park must survive a redundant begin");
+            IndexingManager.drainPendingEntries(pm);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-live-1"), eq(Encounter.class), eq(false));
+    }
+
+    // ...but after the transaction ends, the next begin must get a usable (non-terminal) park.
+    @Test void installPendingBucket_replacesATerminalPark() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-cycle-1");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.drainPendingEntries(pm);  // commit ends transaction 1
+            IndexingManager.installPendingBucket(pm); // updateDBTransaction() begins transaction 2
+            IndexingManager.addPendingEntry(pm, enc, false);
+            // parked, not immediately enqueued -- this is a fresh transaction
+            verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+            assertEquals(1, pendingEntryCount(pm), "second transaction gets a live park");
+            IndexingManager.drainPendingEntries(pm);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-cycle-1"), eq(Encounter.class), eq(false));
+    }
+
+    // The reason Shepherd installs the park BEFORE activating the next transaction: a store
+    // callback that lands while the transaction is active but the park still belongs to the
+    // PREVIOUS (terminal) transaction gets the wrong answer -- immediate enqueue off a drained
+    // park (which is the pre-commit stale read again), or a silent drop off a discarded one.
+    // These two pin the IndexingManager half of that contract; the Shepherd half (install strictly
+    // before Transaction.begin()) is asserted in ShepherdCommitHandoffTest.
+    @Test void parkAgainstAStaleDrainedPark_wouldEnqueueEarly_soInstallMustPrecedeBegin() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-order-1");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.drainPendingEntries(pm);  // transaction 1 committed
+            // transaction 2 begins. Shepherd installs FIRST, so the park is live again:
+            IndexingManager.installPendingBucket(pm);
+            IndexingManager.addPendingEntry(pm, enc, false);
+        }
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+        assertEquals(1, pendingEntryCount(pm),
+            "with install before begin the request parks against the NEW transaction");
+    }
+
+    @Test void parkAgainstAStaleDiscardedPark_wouldBeDropped_soInstallMustPrecedeBegin() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        Encounter enc = encounterWithId("enc-order-2");
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.discardPendingEntries(pm); // transaction 1 rolled back
+            IndexingManager.installPendingBucket(pm);  // transaction 2 prepared before begin
+            IndexingManager.addPendingEntry(pm, enc, false);
+            assertEquals(1, pendingEntryCount(pm),
+                "a rolled-back predecessor must not swallow the new transaction's request");
+            IndexingManager.drainPendingEntries(pm);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-order-2"), eq(Encounter.class), eq(false));
+    }
+
+    // ---- generation-aware dedupe (deterministic: mock scheduler, nothing runs) ---------------
+
+    private static ScheduledExecutorService recordingExecutor() {
+        return mock(ScheduledExecutorService.class);
+    }
+
+    private static IndexingManager managerWith(ScheduledExecutorService exec) throws Exception {
+        java.lang.reflect.Constructor<IndexingManager> c =
+            IndexingManager.class.getDeclaredConstructor(ScheduledExecutorService.class);
+
+        c.setAccessible(true);
+        return c.newInstance(exec);
+    }
+
+    private static List<Runnable> scheduled(ScheduledExecutorService exec, int expected) {
+        ArgumentCaptor<Runnable> cap = ArgumentCaptor.forClass(Runnable.class);
+
+        verify(exec, times(expected)).schedule(cap.capture(), anyLong(), any(TimeUnit.class));
+        return cap.getAllValues();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, ?> requeueOf(IndexingManager im) throws Exception {
+        Field f = IndexingManager.class.getDeclaredField("requeue");
+
+        f.setAccessible(true);
+        return (Map<String, ?>)f.get(im);
+    }
+
+    private static void finishJob(IndexingManager im, String id) throws Exception {
+        Method m = IndexingManager.class.getDeclaredMethod("finishIndexingJob", String.class);
+
+        m.setAccessible(true);
+        m.invoke(im, id);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static int pendingEntryCount(PersistenceManager pm) {
+        try {
+            Object bucket = pm.getUserObject(PENDING_KEY);
+            if (bucket == null) return 0;
+            Field f = bucket.getClass().getDeclaredField("entries");
+            f.setAccessible(true);
+            return ((java.util.Collection<?>)f.get(bucket)).size();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    // The old code did `if (queue.contains(id)) return;` -- silently dropping the post-commit
+    // request whenever a pre-commit job was still in flight. It must be remembered instead, and
+    // released as one more pass when the in-flight job reaches a terminal outcome.
+    @Test void secondEnqueueWhileInFlight_runsFollowUpPassOnTerminal() throws Exception {
+        ScheduledExecutorService exec = recordingExecutor();
+        IndexingManager im = managerWith(exec);
+
+        im.addIndexingQueueEntry("enc-race-1", Encounter.class, false);
+        assertTrue(im.getIndexingQueue().contains("enc-race-1"), "first enqueue takes the slot");
+        scheduled(exec, 1);
+
+        im.addIndexingQueueEntry("enc-race-1", Encounter.class, false);
+        assertTrue(requeueOf(im).containsKey("enc-race-1"),
+            "a second request while in flight must be remembered, not dropped");
+        scheduled(exec, 1); // still only the first job scheduled
+
+        finishJob(im, "enc-race-1");
+        scheduled(exec, 2); // the follow-up pass
+        assertTrue(im.getIndexingQueue().contains("enc-race-1"),
+            "id stays queued across the follow-up so concurrent events keep deduping");
+        assertTrue(requeueOf(im).isEmpty(), "follow-up consumed");
+
+        finishJob(im, "enc-race-1");
+        scheduled(exec, 2); // nothing further
+        assertFalse(im.getIndexingQueue().contains("enc-race-1"), "id released when clean");
+    }
+
+    // The retry give-up path is terminal too: a post-commit request that arrived while the job
+    // was burning retries is exactly the one that CAN succeed, so it must not be swallowed.
+    @Test void giveUp_stillRunsFollowUpPass() throws Exception {
+        ScheduledExecutorService exec = recordingExecutor();
+        IndexingManager im = managerWith(exec);
+
+        im.addIndexingQueueEntry("enc-giveup-1", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-giveup-1", Encounter.class, false);
+        scheduled(exec, 1);
+
+        Method m = IndexingManager.class.getDeclaredMethod("handleObjectNotFound", String.class,
+            Class.class, boolean.class, int.class);
+
+        m.setAccessible(true);
+        m.invoke(im, "enc-giveup-1", Encounter.class, false, 6); // 6 == MAX_INDEXING_ATTEMPTS
+
+        scheduled(exec, 2);
+        assertTrue(requeueOf(im).isEmpty(), "follow-up consumed by the give-up path");
+    }
+
+    // A hard release drops the follow-up with it (used by reset / executor-shutdown paths).
+    @Test void removeIndexingQueueEntry_clearsFollowUp() throws Exception {
+        ScheduledExecutorService exec = recordingExecutor();
+        IndexingManager im = managerWith(exec);
+
+        im.addIndexingQueueEntry("enc-race-2", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-race-2", Encounter.class, false);
+        assertTrue(requeueOf(im).containsKey("enc-race-2"), "precondition: follow-up recorded");
+
+        im.removeIndexingQueueEntry("enc-race-2");
+        assertFalse(im.getIndexingQueue().contains("enc-race-2"), "id released from queue");
+        assertFalse(requeueOf(im).containsKey("enc-race-2"),
+            "a hard release must not leave a stale follow-up behind");
+    }
+
+    @Test void resetQueue_clearsFollowUps() throws Exception {
+        ScheduledExecutorService exec = recordingExecutor();
+        IndexingManager im = managerWith(exec);
+
+        im.addIndexingQueueEntry("enc-race-3", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-race-3", Encounter.class, false);
+        im.resetIndexingQueuehWithInitialCapacity(10);
+        assertTrue(requeueOf(im).isEmpty(), "reset must clear follow-ups too");
+    }
+
+    // ---- Encounter.setIndividual version bump ------------------------------------------------
+
+    private static void setIndividualField(Encounter enc, MarkedIndividual indiv) throws Exception {
+        Field f = Encounter.class.getDeclaredField("individual");
+
+        f.setAccessible(true);
+        f.set(enc, indiv);
+    }
+
+    // Without a version bump the reconciler can never repair a document that went stale on this
+    // path, because it only reindexes when the DB version is strictly greater.
+    @Test void setIndividual_bumpsModified() throws Exception {
+        Encounter enc = spy(new Encounter());
+
+        enc.setSkipAutoIndexing(false);
+        enc.setDWCDateLastModified("2000-01-01 00:00:00");
+        long before = enc.getVersion();
+        MarkedIndividual newInd = mock(MarkedIndividual.class);
+
+        try (MockedStatic<OpenSearch> os = mockNoGlobalSkip()) {
+            enc.setIndividual(newInd);
+        }
+        assertNotEquals(before, enc.getVersion(),
+            "assigning an individual must advance the version the reconciler compares");
+    }
+
+    // A no-op set is not a modification and must not churn the version (or the index).
+    @Test void setIndividual_noOp_doesNotBumpModified() throws Exception {
+        Encounter enc = spy(new Encounter());
+
+        enc.setSkipAutoIndexing(false);
+        MarkedIndividual ind = mock(MarkedIndividual.class);
+
+        setIndividualField(enc, ind);
+        enc.setDWCDateLastModified("2000-01-01 00:00:00");
+        long before = enc.getVersion();
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockNoGlobalSkip()) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            enc.setIndividual(ind);
+        }
+        assertEquals(before, enc.getVersion(), "a no-op set must not advance the version");
+        verify(im, never()).addIndexingQueueEntry(any(Base.class), anyBoolean());
+    }
+}

--- a/src/test/java/org/ecocean/shepherd/core/ShepherdCommitHandoffTest.java
+++ b/src/test/java/org/ecocean/shepherd/core/ShepherdCommitHandoffTest.java
@@ -1,0 +1,123 @@
+package org.ecocean.shepherd.core;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jdo.JDOException;
+import javax.jdo.PersistenceManager;
+import javax.jdo.PersistenceManagerFactory;
+import javax.jdo.Transaction;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ * commitDBTransaction() hands parked index requests to IndexingManager only after the commit has
+ * returned. That handoff runs in a finally, so nothing on the failure path may throw its way out
+ * of the method -- a durable-but-unacknowledged commit would otherwise lose every parked request.
+ *
+ * The nested-exception dump used to be the hazard: JDOException.getNestedExceptions() can be null
+ * (the message-only constructors leave it unset) and SQLException.getNextException() can be null,
+ * and both were dereferenced unguarded.
+ */
+class ShepherdCommitHandoffTest {
+    @Test void logNestedExceptions_nullException() {
+        Shepherd.logNestedExceptions(null);
+    }
+
+    @Test void logNestedExceptions_nullNestedArray() {
+        // message-only constructor: getNestedExceptions() returns null
+        Shepherd.logNestedExceptions(new JDOException("boom"));
+    }
+
+    @Test void logNestedExceptions_nullElementInNestedArray() {
+        Shepherd.logNestedExceptions(new JDOException("boom", new Throwable[] { null }));
+    }
+
+    @Test void logNestedExceptions_sqlExceptionWithNoNextException() {
+        Shepherd.logNestedExceptions(
+            new JDOException("boom", new Throwable[] { new java.sql.SQLException("x") }));
+    }
+
+    // ---- transaction-start ordering ----------------------------------------------------------
+    //
+    // The deferred-indexing park must be LIVE before the transaction is active. A store callback
+    // fires only once the transaction is active, and if it arrives while the park still belongs to
+    // the previous (terminal) transaction it either enqueues pre-commit off a drained park or is
+    // dropped off a discarded one. These tests fail if that order is ever reversed.
+
+    // must match IndexingManager.PENDING_USER_OBJECT_KEY
+    private static final String PENDING_KEY = "org.ecocean.IndexingManager.pending";
+
+    private static PersistenceManager mockPm(Transaction tx, boolean txActive) {
+        PersistenceManager pm = mock(PersistenceManager.class);
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        final Map<Object, Object> userObjects = new HashMap<Object, Object>();
+
+        when(tx.isActive()).thenReturn(txActive);
+        when(pm.currentTransaction()).thenReturn(tx);
+        when(pm.isClosed()).thenReturn(false);
+        when(pm.getPersistenceManagerFactory()).thenReturn(pmf);
+        when(pm.getUserObject(any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.get(inv.getArgument(0)));
+        when(pm.putUserObject(any(), any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.put(inv.getArgument(0), inv.getArgument(1)));
+        return pm;
+    }
+
+    @Test void prepareAndBegin_registersListenerAndInstallsParkBeforeActivating() {
+        Transaction tx = mock(Transaction.class);
+        PersistenceManager pm = mockPm(tx, false);
+
+        PersistenceManager registeredOn = Shepherd.prepareAndBeginTransaction(pm, null);
+
+        assertSame(pm, registeredOn, "listener should now be registered on this pm");
+        InOrder inOrder = inOrder(pm, tx);
+
+        inOrder.verify(pm).addInstanceLifecycleListener(any(), any());
+        inOrder.verify(pm).putUserObject(eq(PENDING_KEY), any());
+        inOrder.verify(tx).begin();
+        assertNotNull(pm.getUserObject(PENDING_KEY), "park must exist once the transaction is on");
+    }
+
+    // Recycled PM, next transaction: the listener is already registered, but the park must still
+    // be refreshed before the transaction goes active.
+    @Test void prepareAndBegin_recycledPm_doesNotReRegisterButStillInstallsBeforeBegin() {
+        Transaction tx = mock(Transaction.class);
+        PersistenceManager pm = mockPm(tx, false);
+
+        PersistenceManager registeredOn = Shepherd.prepareAndBeginTransaction(pm, pm);
+
+        assertSame(pm, registeredOn);
+        verify(pm, never()).addInstanceLifecycleListener(any(), any());
+        InOrder inOrder = inOrder(pm, tx);
+
+        inOrder.verify(pm).putUserObject(eq(PENDING_KEY), any());
+        inOrder.verify(tx).begin();
+    }
+
+    // A redundant beginDBTransaction() on an already-active transaction must not re-begin.
+    @Test void prepareAndBegin_alreadyActive_doesNotBeginAgain() {
+        Transaction tx = mock(Transaction.class);
+        PersistenceManager pm = mockPm(tx, true);
+
+        Shepherd.prepareAndBeginTransaction(pm, pm);
+        verify(tx, never()).begin();
+    }
+
+    @Test void prepareAndBegin_nullPm_isANoOp() {
+        assertNull(Shepherd.prepareAndBeginTransaction(null, null));
+    }
+}


### PR DESCRIPTION
> **Split (2026-09-02):** the match-results authorization fix that was on this branch has moved to **#1745**, which touches **no Java** and can be tested on zebra independently. This PR is now only the OpenSearch/Shepherd sync work. Recovery SHA for the combined branch, if anyone wants it: `c1f2283ef1`.
>
> **Marked draft deliberately.** The review point stands: this makes changes inside `Shepherd.beginDBTransaction()` / `commitDBTransaction()` / `rollbackDBTransaction()` / `closeDBTransaction()`, which are called from thousands of places, and it is not what users were actually hitting. Please land and test #1745 first; then decide whether this is still wanted, and in what form. Options at the bottom.

## The bug this actually fixes

Real, verified, and **separate from the zebra report**. `WildbookLifecycleListener.postStore()` fires on JDO **flush/store, not commit**. It enqueues the OpenSearch reindex there, and the indexing job opens its own `Shepherd` — its own JDBC connection — and reloads the object by id.

For a row that already exists, that reload **succeeds** and returns pre-commit state, so the job indexes the old values and reports success. Only a brand-new row raises `JDOObjectNotFoundException`, which is the one case the existing retry path handles.

Two things then keep the stale document in place:

- the queue dedupe (`if (indexingQueue.contains(id)) return;`) silently **drops** the correct post-commit request whenever the pre-commit job is still in flight;
- on the paths that never touch `Encounter.modified`, `getVersion()` never advances, so the reconciler — which only reindexes when the DB version is strictly greater — never repairs it.

## Severity, stated plainly

**Search index can be stale; no data loss.** Postgres is always correct. The affected surfaces are the OpenSearch-backed ones — encounter/individual/quick search, project encounter lists, and the annotation index that supplies the match candidate pool. The encounter page, the bulk-import task page and the match-results page all read Postgres directly and are unaffected.

Worst case is a document that never self-heals (the paths that don't bump `modified`); otherwise it resolves on a reconciler pass, default 20 minutes and longer under backlog. The one consequence with teeth is the annotation index feeding the match candidate pool, since a missed match is not retried.

That is a real bug worth fixing. It is **not** the bug in the zebra report, and I should have said so before building this much on top of it.

## What is in here

- `postStore` parks `(id, class, unindex)` against the writing `PersistenceManager` instead of enqueuing; `Shepherd` releases the park after `commit()` returns.
- The dedupe records a follow-up instead of dropping it, and every terminal path consumes it.
- Draining evicts the object from the DataNucleus level-2 cache before scheduling (L2 defaults to `soft` and is not disabled here).
- `Encounter.setIndividual()` bumps `modified` on a real membership change so the reconciler can repair.
- `Shepherd` serializes its transaction lifecycle on a per-instance lock, registers one lifecycle listener per PM instead of one per `begin()`, and drains in a `finally`.

910 tests pass, but I want to be straight about what that is worth: **the suite does not stress transaction-lifecycle concurrency**, so a green run is weak evidence for this particular change. That is the reviewer's point and I think it is correct.

## Options — reviewer's call

1. **Park it.** Land #1745, watch zebra, and re-derive this from scratch afterwards with the authorization noise removed. This is jon's suggestion and I think it is the best one.
2. **Shrink it.** Drop the `Shepherd` lifecycle changes entirely and keep only `IndexingManager` (generation-aware dedupe) plus the `Encounter.modified` bump. That does *not* close the race — the post-commit handoff is the part that actually guarantees a correct document — but it removes the high-blast-radius edits and makes stale docs self-heal via the reconciler instead of persisting forever.
3. **Take it as-is,** ideally soaked on flukebook first rather than going straight to zebra.

I'd recommend 1, or 2 if the sync symptoms are painful enough to want something now.

## Credits

Written by **Claude Opus 5** (Claude Code) and reviewed by **Codex** (`codex-cli 0.150.1`, `gpt-5.6-terra`, reasoning effort high) over four rounds. Codex found a Critical (the follow-up request being lost on the retry give-up path), a lock inversion against DataNucleus internals, a commit/close drain race, an unknown-commit-outcome drop, and a window where `begin()` ran before the fresh park was installed.
