### PR TITLE
fix(match-results): setting an individual ID silently fails for non-admins

### DIFF
--- a/frontend/src/__tests__/pages/MatchResults/matchResultsStore.test.js
+++ b/frontend/src/__tests__/pages/MatchResults/matchResultsStore.test.js
@@ -1,7 +1,11 @@
 import MatchResultsStore from "../../../pages/MatchResultsPage/stores/matchResultsStore";
 import axios from "axios";
+import { toast } from "react-toastify";
 
 jest.mock("axios");
+jest.mock("react-toastify", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -916,9 +920,95 @@ describe("MatchResultsStore — handleMatch", () => {
 
   test("resets selection on success", async () => {
     store.setSelectedMatch(true, "k1", "enc-no-ind", null, null);
-    axios.get.mockResolvedValueOnce({ data: {} });
+    // must be an explicit success:true -- a bare 200 is NOT a successful save, see below
+    axios.get.mockResolvedValueOnce({ data: { success: true } });
     await store.handleMatch();
     expect(store.selectedMatch).toEqual([]);
+  });
+
+  // iaResultsSetID.jsp answers authorization and validation refusals in the BODY, and
+  // historically did so with HTTP 200. Treating the 200 as success told the user their
+  // match was confirmed while the JSP had rolled back and written nothing -- which only
+  // non-admins ever hit, because admins bypass the encounter authorization check.
+  test("a 200 carrying success:false is a FAILURE, not a save", async () => {
+    store.setSelectedMatch(true, "k1", "enc-no-ind", null, null);
+    axios.get.mockResolvedValueOnce({
+      data: { success: false, error: "User unauthorized for encounter: enc-no-ind" },
+    });
+    const result = await store.handleMatch();
+    expect(result).toBeNull();
+    expect(store.matchRequestError).toBe("MATCH_FAILED");
+    // the user must be told, and told WHY -- a generic message would hide an auth refusal
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "User unauthorized for encounter: enc-no-ind",
+    );
+  });
+
+  test("a 200 carrying success:false does not clear the user's selection", async () => {
+    store.setSelectedMatch(true, "k1", "enc-no-ind", null, null);
+    // deep snapshot, not just keys: a failure must not mutate the entries either
+    const before = JSON.parse(JSON.stringify(store.selectedMatch));
+
+    axios.get.mockResolvedValueOnce({ data: { success: false, error: "nope" } });
+    await store.handleMatch();
+    // nothing was saved, so the exact selection must survive for the user to retry
+    expect(JSON.parse(JSON.stringify(store.selectedMatch))).toEqual(before);
+  });
+
+  // the endpoint answers success:true for a request with nothing to assign; do not send it
+  test("does not call the server when every selection already has the ID", async () => {
+    // query already has ind-query; select another encounter with the SAME individual
+    store.setSelectedMatch(true, "k1", "enc-other", "ind-query", "Query");
+    const result = await store.handleMatch();
+    expect(result).toBeNull();
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(store.matchRequestError).toBe("MATCH_NOTHING_TO_ASSIGN");
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  test("a response with no success field is treated as a failure", async () => {
+    store.setSelectedMatch(true, "k1", "enc-no-ind", null, null);
+    axios.get.mockResolvedValueOnce({ data: {} });
+    const result = await store.handleMatch();
+    expect(result).toBeNull();
+    expect(store.matchRequestError).toBe("MATCH_FAILED");
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  // the check must be strict: a truthy non-boolean is not a confirmed save
+  test("a truthy non-boolean success is treated as a failure", async () => {
+    store.setSelectedMatch(true, "k1", "enc-no-ind", null, null);
+    axios.get.mockResolvedValueOnce({ data: { success: "true" } });
+    const result = await store.handleMatch();
+    expect(result).toBeNull();
+    expect(store.matchRequestError).toBe("MATCH_FAILED");
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  // the JSP now returns 403 on an authorization refusal, so axios rejects
+  test("surfaces the server reason from a 403 rejection", async () => {
+    store.setSelectedMatch(true, "k1", "enc-no-ind", null, null);
+    axios.get.mockRejectedValueOnce({
+      response: {
+        status: 403,
+        data: { success: false, error: "User unauthorized for encounter: enc-no-ind" },
+      },
+    });
+    const result = await store.handleMatch();
+    expect(result).toBeNull();
+    expect(store.matchRequestError).toBe("MATCH_FAILED");
+    expect(toast.error).toHaveBeenCalledWith(
+      "User unauthorized for encounter: enc-no-ind",
+    );
+  });
+
+  test("still reports success when the server confirms it", async () => {
+    store.setSelectedMatch(true, "k1", "enc-no-ind", null, null);
+    axios.get.mockResolvedValueOnce({ data: { success: true } });
+    await store.handleMatch();
+    expect(toast.success).toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/pages/MatchResultsPage/stores/matchResultsStore.js
+++ b/frontend/src/pages/MatchResultsPage/stores/matchResultsStore.js
@@ -743,6 +743,15 @@ export default class MatchResultsStore {
         ),
       );
 
+      // Nothing to assign: every selected encounter, the query encounter included, already
+      // carries the target individual. iaResultsSetID.jsp answers success:true for that without
+      // writing anything, which reads to the user as a confirmed match that never happened.
+      if (unnamedEncounterIds.length === 0) {
+        this._matchRequestError = "MATCH_NOTHING_TO_ASSIGN";
+        toast.error("Nothing to confirm — the selected encounters already have this ID");
+        return null;
+      }
+
       const params = new URLSearchParams();
       if (this._encounterId) params.set("number", this._encounterId);
       if (this._taskId) params.set("taskId", this._taskId);
@@ -758,12 +767,25 @@ export default class MatchResultsStore {
         headers: { Accept: "application/json" },
       });
 
+      // iaResultsSetID.jsp reports authorization and validation failures in the BODY
+      // ({success: false, error: "..."}), and historically did so with HTTP 200 -- so a
+      // denied request resolved here and was reported to the user as a successful save
+      // while nothing had been written. The JSP now returns 403 on an authorization
+      // failure, but the body remains the source of truth for every other refusal
+      // (unknown encounter, encounters that already have an ID, ...), so check it.
+      if (res?.data?.success !== true) {
+        this._matchRequestError = "MATCH_FAILED";
+        toast.error(res?.data?.error || "Failed to confirm match");
+        return null;
+      }
+
       this.resetSelectionToQuery();
       toast.success("Match confirmed successfully!");
       return res.data;
-    } catch {
+    } catch (error) {
       this._matchRequestError = "MATCH_FAILED";
-      toast.error("Failed to confirm match");
+      // surface the server's reason (e.g. the 403 body) rather than a generic message
+      toast.error(error?.response?.data?.error || "Failed to confirm match");
       return null;
     } finally {
       this._matchRequestLoading = false;

--- a/src/main/webapp/iaResults.jsp
+++ b/src/main/webapp/iaResults.jsp
@@ -1827,7 +1827,11 @@ console.warn(' ===> approvalButtonClick(encID=%o, indivID=%o, encID2=%o, taskId=
 		},
 		error: function(x,y,z) {
 			console.warn('%o %o %o', x, y, z);
-			jQuery(msgTarget).html('<b>Error updating encounter</b>');
+			// iaResultsSetID.jsp now answers 403 (not 200) when the user is not authorized
+			// for one of the encounters, so that lands here; keep showing the server's reason.
+			var detail = (x && x.responseJSON && x.responseJSON.error) ? x.responseJSON.error : null;
+			jQuery(msgTarget).html(detail ? ('Error updating encounter: <b>' + detail + '</b>')
+			                             : '<b>Error updating encounter</b>');
 		}
 	});
 	return true;

--- a/src/main/webapp/iaResultsSetID.jsp
+++ b/src/main/webapp/iaResultsSetID.jsp
@@ -41,6 +41,28 @@ private static void setImportTaskComplete(Shepherd myShepherd, Encounter enc) {
 	catch(Exception e){e.printStackTrace();}
 }
 
+// updateDBTransaction() commits via commitDBTransaction(), which SWALLOWS commit failures --
+// so a commit that never landed would still let this page answer {"success":true} and tell the
+// user their match was saved. Commit with a status instead, then reopen for the work that
+// follows (the caller aborts with success:false when this returns false).
+// Deliberately does NOT say "not saved". commitDBTransactionWithStatus() returns false when the
+// commit THREW, and a commit can throw after the database has already made it durable (e.g. the
+// connection drops while the acknowledgement comes back). Telling the user to retry a write that
+// may have landed invites a duplicate; telling them to check is honest about what we know.
+// For the case-1 commits that run BEFORE any encounter is associated: we know for certain no
+// assignment was attempted, so say so rather than sending the user to check an encounter.
+private static final String COMMIT_UNCONFIRMED_PRE_ASSIGN_MSG =
+	"the new individual could not be confirmed as saved and no encounter was assigned -- reload the individual before trying again";
+
+private static final String COMMIT_UNCONFIRMED_MSG =
+	"the individual assignment could not be confirmed -- reload the encounter to check whether it was applied before trying again";
+
+private static boolean commitAndContinue(Shepherd myShepherd) {
+	boolean committed = myShepherd.commitDBTransactionWithStatus();
+	myShepherd.beginDBTransaction();
+	return committed;
+}
+
 
 %>
 <%
@@ -70,9 +92,17 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
 
         System.out.println("iaResultsSetID: INITIALIZED res=" + res);
 	Shepherd myShepherd = new Shepherd(request);
+
+	// Guaranteed cleanup. Only the assignment section below was guarded, so an exception in the
+	// encounter lookup, the authorization checks or refresh() escaped the page leaving the
+	// PersistenceManager open -- a leaked pool connection per occurrence. Every early return
+	// already rolls back and closes; rollbackAndClose() is safe to run again on a closed PM.
+	// NOTE: deliberately not reindenting the body, so this stays a reviewable diff.
+	// setAction/beginDBTransaction are INSIDE the try: the Shepherd constructor already opened a
+	// PersistenceManager, so a throw from begin() would otherwise leak it.
+	try {
 	myShepherd.setAction("iaResultsSetID.jsp");
 	myShepherd.beginDBTransaction();
-
 	Encounter enc = myShepherd.getEncounter(request.getParameter("number"));
 	if (enc == null) {
 		res.put("error", "no such encounter: " + request.getParameter("number"));
@@ -82,6 +112,10 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
 		return;
 	}
 	else if(!ServletUtilities.isUserAuthorizedForEncounter(enc, request,myShepherd)){
+		// 403, not the default 200. This used to answer "200 {success:false}", which the
+		// React match-results page treated as a successful save -- the user got a green
+		// confirmation while nothing was written. The body is kept for clients that read it.
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 		res.put("error", "User unauthorized for encounter: " + request.getParameter("number"));
 		out.println(res.toString());
 		myShepherd.rollbackDBTransaction();
@@ -100,7 +134,9 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
         List<MarkedIndividual> otherIndivs = new ArrayList<MarkedIndividual>();
         if (otherEncIds != null) for (String oeId : otherEncIds) {
 		Encounter oenc = myShepherd.getEncounter(oeId);
-		myShepherd.getPM().refresh(oenc);
+		// null check BEFORE refresh(): refresh(null) throws, so an unknown encOther used to
+		// produce a server error instead of the intended JSON refusal below.
+		if (oenc != null) myShepherd.getPM().refresh(oenc);
 
 		if (oenc == null) {
 			res.put("error", "no such encounter: " + oeId);
@@ -110,6 +146,10 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
 			return;
 		}
 		else if(!ServletUtilities.isUserAuthorizedForEncounter(oenc, request,myShepherd)){
+			// see note above. This branch is the common one: every selected unnamed
+			// candidate is authorized separately, so ONE candidate owned by another user
+			// refuses the whole operation.
+			response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 			res.put("error", "User unauthorized for encounter: " + oeId);
 			out.println(res.toString());
 			myShepherd.rollbackDBTransaction();
@@ -171,6 +211,10 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
 			out.println(res.toString());
 			myShepherd.rollbackDBTransaction();
 			myShepherd.closeDBTransaction();
+			// MUST return: without it the page carried on against a closed transaction and
+			// appended a second JSON object, so the response was not parseable and the client
+			// could not show this message at all.
+			return;
 		}
 	} catch (Exception e) {
 		e.printStackTrace();
@@ -219,13 +263,23 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
 						Project project = myShepherd.getProjectByProjectIdPrefix(projectId);
 						if (project!=null&&project.getNextIncrementalIndividualId().equals(individualID)) {
 							project.getNextIncrementalIndividualIdAndAdvance();
-							myShepherd.updateDBTransaction();
+							if (!commitAndContinue(myShepherd)) {
+								res.put("error", COMMIT_UNCONFIRMED_PRE_ASSIGN_MSG);
+								out.println(res.toString());
+								myShepherd.rollbackAndClose();
+								return;
+							}
 						}
 
 						indiv.addNameByKey(projectId, individualID);
 						res.put("newIncrementalId", indiv.getDisplayName(projectId));
 					}
-					myShepherd.updateDBTransaction();
+					if (!commitAndContinue(myShepherd)) {
+						res.put("error", COMMIT_UNCONFIRMED_PRE_ASSIGN_MSG);
+						out.println(res.toString());
+						myShepherd.rollbackAndClose();
+						return;
+					}
 					//res.put("newIndividualUUID", indiv.getId());
 					res.put("individualName", indiv.getDisplayName(request, myShepherd));
 					res.put("individualId", indiv.getId());
@@ -240,24 +294,52 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
 						oenc.setMatchedBy("Pattern match");
                     }
 
-					myShepherd.updateDBTransaction();
+					if (!commitAndContinue(myShepherd)) {
+						res.put("error", COMMIT_UNCONFIRMED_MSG);
+						out.println(res.toString());
+						myShepherd.rollbackAndClose();
+						return;
+					}
                     setImportTaskComplete(myShepherd, enc);
                     for (Encounter oenc : otherEncs) {
                         setImportTaskComplete(myShepherd, oenc);
                     }
-                    indiv.refreshNamesCache();
+                    // post-commit, like the email/import-task work below: a failure here must
+                    // not turn a durable assignment into success:false
+                    try {
+                        indiv.refreshNamesCache();
+                    } catch (Exception cacheEx) { cacheEx.printStackTrace(); }
 
-                    if ((indiv != null) && (enc != null)) IndividualAddEncounter.executeEmails(myShepherd, request, indiv, isNewIndiv, enc, context, langCode);
+                    // The assignment is already committed above. Notification failures must not
+                    // flip this into success:false -- that would tell the user their match did not
+                    // save when it did.
+                    try {
+                        if ((indiv != null) && (enc != null)) IndividualAddEncounter.executeEmails(myShepherd, request, indiv, isNewIndiv, enc, context, langCode);
+                    } catch (Exception emailEx) { emailEx.printStackTrace(); }
+                    // ...and one per OTHER encounter. executeEmails() notifies the recipients of
+                    // the encounter it is handed and writes that encounter's RSS/ATOM entry, so
+                    // these are distinct notifications, not repeats of the one above. Case 2 used
+                    // to emit them as a side effect of running after case 1; now that the cases
+                    // are chained, case 1 has to do it itself or they are silently lost.
+                    for (Encounter oenc : otherEncs) {
+                        try {
+                            IndividualAddEncounter.executeEmails(myShepherd, request, indiv, false, oenc, context, langCode);
+                        } catch (Exception emailEx) { emailEx.printStackTrace(); }
+                    }
 
 
 				} else {
 					res.put("error", "Please enter a new Individual ID for both encounters.");
 				}
-			}
 
 			// query enc has indy, or already stashed in URL params
 			//if (indiv!=null&&indiv2==null) {
-			if ((indiv != null) && (otherIndivs.size() < 1)) {
+			// `else if`, not `if`: case 1 leaves indiv non-null and otherIndivs empty, so this
+			// block used to run straight after it and redo the whole otherEncs loop -- appending
+			// a SECOND "Added to ..." comment to each encounter and the individual, sending the
+			// notification emails twice, and issuing a redundant commit whose failure reported
+			// "could not be confirmed" for an assignment that had already been committed.
+			} else if ((indiv != null) && (otherIndivs.size() < 1)) {
 				System.out.println("CASE 2: query enc indy is null");
                                 for (Encounter oenc : otherEncs) {
                                     oenc.setIndividual(indiv);
@@ -268,17 +350,23 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
 									oenc.setMatchedBy("Pattern match");
                                 }
 				res.put("individualName", indiv.getDisplayName(request, myShepherd));
-				myShepherd.updateDBTransaction();
+				if (!commitAndContinue(myShepherd)) {
+					res.put("error", COMMIT_UNCONFIRMED_MSG);
+					out.println(res.toString());
+					myShepherd.rollbackAndClose();
+					return;
+				}
 				// if(enc2!=null){
                                 for (Encounter oenc : otherEncs) {
-                                    IndividualAddEncounter.executeEmails(myShepherd, request, indiv, false, oenc, context, langCode);
+                                    try {
+                                        IndividualAddEncounter.executeEmails(myShepherd, request, indiv, false, oenc, context, langCode);
+                                    } catch (Exception emailEx) { emailEx.printStackTrace(); } // see note above
                                     setImportTaskComplete(myShepherd, oenc);
                                 }
-			}
 
 			// target enc has indy
 			//if (indiv==null&&indiv2!=null) {
-			if ((indiv == null) && (allEncIndivs.size() == 1)) {
+			} else if ((indiv == null) && (allEncIndivs.size() == 1)) {
 				System.out.println("CASE 3: target enc indy is null");
                                 Iterator<MarkedIndividual> it = allEncIndivs.iterator();
                                 MarkedIndividual oindiv = it.next();
@@ -291,9 +379,16 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
 				enc.setMatchedBy("Pattern match");
 				
 				res.put("individualName", oindiv.getDisplayName(request, myShepherd));
-				myShepherd.updateDBTransaction();
+				if (!commitAndContinue(myShepherd)) {
+					res.put("error", COMMIT_UNCONFIRMED_MSG);
+					out.println(res.toString());
+					myShepherd.rollbackAndClose();
+					return;
+				}
 
-				IndividualAddEncounter.executeEmails(myShepherd, request, oindiv, false, enc, context, langCode);
+				try {
+					IndividualAddEncounter.executeEmails(myShepherd, request, oindiv, false, enc, context, langCode);
+				} catch (Exception emailEx) { emailEx.printStackTrace(); } // see note above
                                 setImportTaskComplete(myShepherd, enc);
 			}
 
@@ -338,6 +433,14 @@ if ((request.getParameter("taskId") != null) && (request.getParameter("number") 
 	res.put("error", "Unknown error setting individual " + individualID);
 	out.println(res.toString());
 	return;
+	} finally {
+		// Only if the body did not already close it. Every early return closes explicitly, and
+		// rollbackDBTransaction() on a closed PersistenceManager throws internally (caught, but
+		// it prints a stack trace and publishes a bogus "rollback-failed" state that operators
+		// read on dbconnections.jsp). This keeps the guarantee without the noise.
+		if ((myShepherd.getPM() != null) && !myShepherd.getPM().isClosed())
+			myShepherd.rollbackAndClose();
+	}
 }
 
 


### PR DESCRIPTION
Split out of #1743 at review request — this is **the JSP/frontend half only. No Java sources are touched**, so it is independent of the OpenSearch/Shepherd sync work, which stays in #1743.

`commitDBTransactionWithStatus()`, `rollbackAndClose()` and `getPM()` all already exist on `main`; nothing here depends on changes in #1743. Verified by building this branch against unmodified `main`.

## The bug

Reported on zebra: setting a marked individual's ID doesn't stick. **Role-dependent** — an admin can do it and see the result everywhere; a researcher does the same and it never appears. An admin can see the researcher's broken state but cannot reproduce it.

`/react/match-results` "Confirm match" does **not** use the PATCH API. It calls `GET /iaResultsSetID.jsp`, which authorizes through `ServletUtilities.isUserAuthorizedForEncounter()` rather than the API's `Encounter.canUserEdit()`. That function returns true immediately for `request.isUserInRole("admin")` (`ServletUtilities.java:497`), so an admin passes every gate.

The JSP authorizes the query encounter **and each `encOther` separately** (`iaResultsSetID.jsp:101-118`), and `handleMatch()` sends every selected unnamed candidate as `encOther`. Since match candidates come from across the catalogue, **one candidate owned by another user refuses the whole operation.**

On refusal the JSP never set an HTTP status — it answered **200** with `{"success": false, "error": "User unauthorized for encounter: ..."}` and rolled back. `handleMatch()` never inspected that flag, and axios resolves on 200, so it showed **"Match confirmed successfully!"**. Nothing was written.

**Confirm it in 30 seconds:** reproduce as a researcher with the Network tab open — the `iaResultsSetID.jsp` response is `200` with `"User unauthorized for encounter: <id>"` in the body.

## The fix

- `handleMatch()` requires `success === true`, surfaces the server's reason on both the resolved and rejected paths, and keeps the selection so the user can retry.
- `iaResultsSetID.jsp` returns **403** on the two authorization refusals. Body unchanged.
- `iaResults.jsp` (legacy client, which already checked `success`) reads `responseJSON.error` in its error handler, so the 403 keeps its detailed message.

## Other defects on the same refusal paths

Found while reviewing the above; all in the same file, all reachable by a non-admin:

| Defect | Effect |
|---|---|
| `refresh(oenc)` ran before the null check | an unknown candidate raised a server error instead of returning its refusal |
| the conflict refusal never `return`ed | ran on against a closed transaction and appended a second JSON object, so the response was unparseable and no client could show the message |
| `executeEmails()` / `refreshNamesCache()` sat inside the broad catch | a post-commit failure reported a durable save as failed |
| assignment commits used `updateDBTransaction()` | `commitDBTransaction()` swallows commit failures, so a save that never landed still returned `success:true` — now uses the existing `commitDBTransactionWithStatus()` |
| only the assignment section was guarded | an exception in lookup/auth/refresh leaked the PersistenceManager — now `try/finally` (body deliberately **not** reindented, so the diff stays readable) |
| cases 1/2/3 were three sequential `if`s | case 1 fell through into case 2: a **second** "Added to ..." comment on each encounter and the individual, **duplicate notification emails**, and a redundant commit whose failure misreported an already-committed assignment — now `if / else if / else if`, with case 1 emitting the per-encounter notifications case 2 used to provide as a side effect |
| `handleMatch()` sent no-op requests | the endpoint answers `success:true` for a request with nothing to assign |

Failure messages deliberately do not say "could not be saved; please retry". `commitDBTransactionWithStatus()` returns false when the commit *threw*, and a commit can throw after the database has made it durable — inviting a blind retry there risks a duplicate. The message asks the user to reload and check.

## Deliberately NOT here

`Encounter.canUserEdit()` and `ServletUtilities.isUserAuthorizedForEncounter()` genuinely disagree about who may edit an encounter, **in both directions**. Reconciling them is an authorization-policy change that needs its own review — and pointing the JSP at `canUserEdit()` would *widen* write access rather than fix it. Two direct-only endpoint-contract defects (a partial case-3 request and a no-op request both reporting success) are also left; neither is reachable from `handleMatch()`.

## Testing

- `frontend/src/__tests__/pages/MatchResults/matchResultsStore.test.js`: **92 pass** — asserts the exact toast text the user sees, deep-compares that the selection survives a failure, pins that the success check is strict (a truthy `"true"` string is still a failure), and covers the 403 rejection path. The three core cases **fail if the success check is removed** (mutation-verified).
- Maven does not compile JSPs, so after every edit the scriptlet was extracted (page imports + `<%! %>` declarations + body) into a synthetic class and compiled with `javac` against the project classpath — clean, with a negative control confirming the harness catches a deliberate break. Also verified against **unmodified `main`**.
- Suggest testing on zebra with a researcher account before merging #1743.

## Credits

Written by **Claude Opus 5** (Claude Code) and reviewed by **Codex** (`codex-cli 0.150.1`, `gpt-5.6-terra`, reasoning effort high) over six rounds. Codex identified the `encOther` per-candidate authorization as the everyday trigger, the missing `return`, the pre-null-check `refresh`, the commit paths that could misreport persistence, and — importantly — a regression the case-chaining fix itself introduced: case 1 emails only the query encounter, so the per-candidate notifications had been a side effect of case 2 running after it. That is restored.