### PR TITLE
fix(match-results): scope match results and Confirm to the selected annotation's encounter (#1744)

### DIFF
--- a/frontend/src/__tests__/pages/BulkImport/BulkImportTaskClassCell.test.js
+++ b/frontend/src/__tests__/pages/BulkImport/BulkImportTaskClassCell.test.js
@@ -1,0 +1,141 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "../../../utils/utils";
+import BulkImportTask from "../../../pages/BulkImport/BulkImportTask";
+import axios from "axios";
+import useGetBulkImportTask from "../../../models/bulkImport/useGetBulkImportTask";
+import { useSiteSettings } from "../../../SiteSettingsContext";
+
+// Issue #1744: ImportTask.statsAnnotations now reports one match task per
+// matched annotation of an encounter (an encounter can hold several, e.g.
+// body + part). The Class cell must expose every one of them, not just the
+// first tuple.
+//
+// This lives in its own file (rather than BulkImportTask.test.js) because
+// that suite's jest.mock factories crash babel-plugin-jest-hoist 27 under the
+// newer @babel/types in node_modules; the mocks below use automocks and
+// require()-based factories, which hoist cleanly.
+
+jest.mock("axios");
+jest.mock("../../../models/bulkImport/useGetBulkImportTask");
+jest.mock("../../../SiteSettingsContext");
+jest.mock("antd/es/tree-select", () => {
+  const React = require("react");
+  function TreeSelect() {
+    return React.createElement("div", null, "TreeSelect");
+  }
+  return { __esModule: true, default: TreeSelect };
+});
+jest.mock("../../../components/InfoAccordion", () => {
+  const React = require("react");
+  function InfoAccordion({ title }) {
+    return React.createElement("div", null, title);
+  }
+  return { __esModule: true, default: InfoAccordion };
+});
+jest.mock("../../../components/SimpleDataTable", () => {
+  const React = require("react");
+  function SimpleDataTable({ columns = [], data = [] }) {
+    return React.createElement(
+      "table",
+      { "data-testid": "simple-table" },
+      React.createElement(
+        "tbody",
+        null,
+        data.map((row, i) =>
+          React.createElement(
+            "tr",
+            { key: i },
+            columns.map((col) =>
+              React.createElement(
+                "td",
+                { key: col.name },
+                typeof col.cell === "function" ? col.cell(row) : null,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+  return { __esModule: true, default: SimpleDataTable };
+});
+
+const baseTask = {
+  id: "12345",
+  sourceName: "upload.xlsx",
+  importPercent: 1,
+  status: "complete",
+  numberMarkedIndividuals: 0,
+  iaSummary: {
+    numberMediaAssets: 1,
+    numberAnnotations: 2,
+    detectionPercent: 1,
+    detectionStatus: "Complete",
+    identificationPercent: 1,
+    identificationStatus: "Complete",
+  },
+  encounters: [
+    {
+      id: "E123",
+      date: "2023-01-01T10:00:00Z",
+      submitter: { displayName: "John Doe" },
+      numberMediaAssets: 1,
+    },
+  ],
+};
+
+const renderWithTaskInfo = (encounterTaskInfo) => {
+  useGetBulkImportTask.mockReturnValue({
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+    task: {
+      ...baseTask,
+      iaSummary: {
+        ...baseTask.iaSummary,
+        statsAnnotations: { encounterTaskInfo },
+      },
+    },
+  });
+  renderWithProviders(<BulkImportTask />);
+};
+
+describe("BulkImportTask — Class cell match-results links (issue #1744)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useSiteSettings.mockReturnValue({
+      data: {},
+      isLoading: false,
+      error: null,
+    });
+    delete window.location;
+    window.location = new URL("http://localhost/react/?id=12345");
+    axios.get.mockResolvedValue({ data: { roles: [] } });
+  });
+
+  test("renders one link per annotation task, newest first as reported", () => {
+    renderWithTaskInfo({
+      E123: [
+        ["task-body", "completed", "dolphin_body"],
+        ["task-fin", "completed", "dolphin_fin"],
+      ],
+    });
+
+    const links = screen.getAllByRole("link", { name: /dolphin_/ });
+    expect(links.map((a) => a.getAttribute("href"))).toEqual([
+      "/react/match-results?taskId=task-body",
+      "/react/match-results?taskId=task-fin",
+    ]);
+    expect(links[0]).toHaveTextContent("dolphin_body : completed");
+  });
+
+  test("renders a dash when the encounter has no match task", () => {
+    renderWithTaskInfo({});
+    expect(
+      document.querySelector('a[href^="/react/match-results?taskId="]'),
+    ).toBeNull();
+    // the Class cell falls back to a dash (other cells may show one too)
+    expect(screen.getAllByText("-").length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/__tests__/pages/MatchResults/MatchProspectTable.selectionKey.test.jsx
+++ b/frontend/src/__tests__/pages/MatchResults/MatchProspectTable.selectionKey.test.jsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import MatchProspectTable from "../../../pages/MatchResultsPage/components/MatchProspectTable";
+
+jest.mock("../../../components/AnnotationOverlay", () => {
+  const React = require("react");
+  const Overlay = React.forwardRef(function Overlay() {
+    return React.createElement("div", { "data-testid": "annotation-overlay" });
+  });
+  Overlay.displayName = "InteractiveAnnotationOverlay";
+  return Overlay;
+});
+
+jest.mock("../../../pages/MatchResultsPage/components/InspectorModal", () => {
+  function InspectorModal() {
+    return null;
+  }
+  InspectorModal.displayName = "InspectorModal";
+  return InspectorModal;
+});
+
+jest.mock("../../../api/client", () => ({
+  client: { get: jest.fn(), post: jest.fn() },
+}));
+
+const themeColor = {
+  primaryColors: {
+    primary50: "#E5F6FF",
+    primary500: "#00ACCE",
+    primary700: "#007599",
+  },
+  wildMeColors: { teal100: "#CCF2F5", teal800: "#005A66" },
+};
+
+// The SAME prospect (annotation ann-X at rank 1) appears in two sections —
+// the shape an image-wide umbrella task produces for two annotations that
+// both match the same candidate.
+const candidate = () => ({
+  annotation: { id: "ann-X", encounter: { id: "enc-X" }, individual: null },
+  displayIndex: 1,
+  score: 0.9,
+});
+
+const renderTable = (taskId, onToggleSelected, selectedMatch = []) =>
+  render(
+    <IntlProvider locale="en" messages={{}} onError={() => {}}>
+      <MatchProspectTable
+        sectionId={`image-${taskId}`}
+        taskId={taskId}
+        columns={[[candidate()]]}
+        selectedMatch={selectedMatch}
+        onToggleSelected={onToggleSelected}
+        themeColor={themeColor}
+        numCandidates={5}
+        date="2024-06-01"
+        taskStatusOverall="completed"
+      />
+    </IntlProvider>,
+  );
+
+describe("MatchProspectTable — task-qualified selection keys (issue #1744)", () => {
+  test("the same prospect in two sections yields distinct selection keys", () => {
+    const onToggle = jest.fn();
+    renderTable("task-A", onToggle);
+    renderTable("task-B", onToggle);
+
+    const boxes = screen.getAllByTestId(/^match-prospect-select-/);
+    expect(boxes).toHaveLength(2);
+    fireEvent.click(boxes[0]);
+    fireEvent.click(boxes[1]);
+
+    expect(onToggle).toHaveBeenCalledTimes(2);
+    const [callA, callB] = onToggle.mock.calls;
+    expect(callA[0]).toBe(true);
+    expect(callA[1]).not.toBe(callB[1]);
+    expect(callA[1]).toContain("task-A");
+    expect(callB[1]).toContain("task-B");
+    expect(callA[2]).toBe("enc-X"); // candidate encounter still forwarded
+  });
+
+  test("a row reads as selected only under its own task-qualified key", () => {
+    const onToggle = jest.fn();
+    const { unmount } = renderTable("task-A", onToggle);
+    fireEvent.click(screen.getByTestId(/^match-prospect-select-/));
+    const keyA = onToggle.mock.calls[0][1];
+    unmount();
+
+    renderTable("task-B", jest.fn(), [{ key: keyA, encounterId: "enc-X" }]);
+    expect(screen.getByTestId(/^match-prospect-select-/)).not.toBeChecked();
+
+    renderTable("task-A", jest.fn(), [{ key: keyA, encounterId: "enc-X" }]);
+    const checked = screen
+      .getAllByTestId(/^match-prospect-select-/)
+      .filter((el) => el.checked);
+    expect(checked).toHaveLength(1);
+  });
+});

--- a/frontend/src/__tests__/pages/MatchResults/MatchResults.test.jsx
+++ b/frontend/src/__tests__/pages/MatchResults/MatchResults.test.jsx
@@ -11,18 +11,24 @@ import { MemoryRouter } from "react-router-dom";
 import { IntlProvider } from "react-intl";
 import axios from "axios";
 import MatchResults from "../../../pages/MatchResultsPage/MatchResults";
+import MatchResultsStore from "../../../pages/MatchResultsPage/stores/matchResultsStore";
 
 jest.mock("axios");
 
-jest.mock("../../../SiteSettingsContext", () => ({
-  useSiteSettings: () => ({
+jest.mock("../../../SiteSettingsContext", () => {
+  // One stable object: MatchResults' fetch effect lists projectsForUser as a
+  // dependency by reference, so a fresh object per render re-fires the
+  // effect (and re-fetches / clears the store) on every render and the page
+  // never settles.
+  const siteSettings = {
     projectsForUser: {
       "proj-1": { name: "Project Alpha", prefix: "PA" },
       "proj-2": { name: "Project Beta", prefix: "PB" },
     },
     identificationRemarks: ["Confirmed", "Uncertain"],
-  }),
-}));
+  };
+  return { useSiteSettings: () => siteSettings };
+});
 
 jest.mock("../../../components/FullScreenLoader", () => {
   const React = require("react");
@@ -159,8 +165,11 @@ jest.mock("../../../components/MultiSelectWithCheckbox", () => {
 const makeApiResponse = () => ({
   matchResultsRoot: {
     id: "task-1",
-    status: "complete",
-    statusOverall: "complete",
+    // "completed" is a terminal status; "complete" is not, and a non-terminal
+    // root makes the store poll with a silent refresh whose one-shot axios
+    // mock returns undefined and clears the results right after they render.
+    status: "completed",
+    statusOverall: "completed",
     dateCreated: "2024-06-01",
     method: { name: "hotspotter", description: "HotSpotter" },
     matchingSetFilter: {},
@@ -218,7 +227,9 @@ describe("MatchResults component", () => {
 
   test("shows 'no match results' message when no taskId in URL", async () => {
     renderComponent("/match-results");
-    expect(await screen.findByText(/NO_MATCH_RESULT/i)).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("match-results-empty"),
+    ).toBeInTheDocument();
   });
 
   test("renders match prospect table after successful fetch", async () => {
@@ -227,6 +238,36 @@ describe("MatchResults component", () => {
     expect(
       await screen.findByTestId("prospect-table-task-1"),
     ).toBeInTheDocument();
+  });
+
+  test("forwards the section's taskId when a prospect is toggled (issue #1744)", async () => {
+    const spy = jest.spyOn(MatchResultsStore.prototype, "setSelectedMatch");
+    try {
+      axios.get.mockResolvedValueOnce({ data: makeApiResponse() });
+      renderComponent();
+      // generous timeouts: this suite runs slowly on loaded machines
+      await screen.findByTestId(
+        "prospect-table-task-1",
+        {},
+        { timeout: 10000 },
+      );
+      const rows = await screen.findAllByTestId(
+        "prospect-row",
+        {},
+        { timeout: 10000 },
+      );
+      fireEvent.click(rows[0]);
+      expect(spy).toHaveBeenCalledWith(
+        true,
+        "key-0",
+        "enc-0",
+        "ind-0",
+        "Name0",
+        "task-1",
+      );
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   test("renders bottom bar when results are available", async () => {
@@ -382,12 +423,16 @@ describe("MatchResults component", () => {
       },
     });
     renderComponent();
-    expect(await screen.findByText(/NO_MATCH_RESULT/i)).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("match-results-empty"),
+    ).toBeInTheDocument();
   });
 
   test("does not crash when API call fails", async () => {
     axios.get.mockRejectedValueOnce(new Error("network error"));
     renderComponent();
-    expect(await screen.findByText(/NO_MATCH_RESULT/i)).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("match-results-empty"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/pages/MatchResults/MatchResultsBottomBar.test.jsx
+++ b/frontend/src/__tests__/pages/MatchResults/MatchResultsBottomBar.test.jsx
@@ -42,11 +42,16 @@ jest.mock(
   "../../../pages/MatchResultsPage/components/NewIndividualCreatedModal",
   () => {
     const React = require("react");
-    function NewIndividualCreatedModal({ show, onHide }) {
+    function NewIndividualCreatedModal({ show, onHide, encounterId }) {
       if (!show) return null;
       return React.createElement(
         "div",
         { "data-testid": "new-individual-created-modal" },
+        React.createElement(
+          "span",
+          { "data-testid": "new-individual-created-encounter" },
+          encounterId,
+        ),
         React.createElement("button", { onClick: onHide }, "Close"),
       );
     }
@@ -229,6 +234,41 @@ describe("MatchResultsBottomBar — two_individuals state", () => {
     renderBar(twoStore);
     expect(document.body).toHaveTextContent("MERGE");
     expect(screen.getByText("Willy")).toBeInTheDocument();
+  });
+});
+
+describe("MatchResultsBottomBar — multiple_query_encounters state (issue #1744)", () => {
+  test("shows CANNOT_MATCH_ACROSS_QUERY_ENCOUNTERS alert", () => {
+    renderBar({ matchingState: "multiple_query_encounters" });
+    expect(
+      screen.getByText("CANNOT_MATCH_ACROSS_QUERY_ENCOUNTERS"),
+    ).toBeInTheDocument();
+  });
+
+  test("does not render action buttons", () => {
+    renderBar({ matchingState: "multiple_query_encounters" });
+    expect(screen.queryByText("CONFIRM_MATCH")).not.toBeInTheDocument();
+    expect(screen.queryByText("MERGE_INDIVIDUALS")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("MARK_AS_NEW_INDIVIDUAL"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("MatchResultsBottomBar — create-new success reports the acted-on encounter (issue #1744)", () => {
+  test("success modal shows the encounter the store acted on, not the current default", async () => {
+    renderBar({
+      matchingState: "no_individuals",
+      encounterId: "enc-default",
+      handleCreateNewIndividual: jest
+        .fn()
+        .mockResolvedValue({ ok: true, encounterId: "enc-acted-on" }),
+    });
+    fireEvent.click(screen.getByText("MARK_AS_NEW_INDIVIDUAL"));
+    fireEvent.click(screen.getByTestId("modal-confirm"));
+    expect(
+      await screen.findByTestId("new-individual-created-encounter"),
+    ).toHaveTextContent("enc-acted-on");
   });
 });
 

--- a/frontend/src/__tests__/pages/MatchResults/matchResultsStore.multiQuery.test.js
+++ b/frontend/src/__tests__/pages/MatchResults/matchResultsStore.multiQuery.test.js
@@ -1,0 +1,267 @@
+import MatchResultsStore from "../../../pages/MatchResultsPage/stores/matchResultsStore";
+import axios from "axios";
+
+jest.mock("axios");
+
+// ---------------------------------------------------------------------------
+// Issue #1744: a task tree whose root is an image-wide umbrella with one
+// child per annotation on the image. Each child owns a MatchResult whose
+// queryAnnotation belongs to a DIFFERENT encounter, so the page shows more
+// than one "This Encounter" section. Every action must follow the section
+// the user selected from — never the arbitrary first section.
+// ---------------------------------------------------------------------------
+
+const querySection = ({ taskId, encId, individual, locationId, prospect }) => ({
+  id: taskId,
+  status: "complete",
+  statusOverall: "completed",
+  dateCreated: "2024-06-01",
+  method: { name: "miewid", description: "MiewID" },
+  matchingSetFilter: {},
+  matchResults: {
+    numberCandidates: 10,
+    queryAnnotation: {
+      id: `q-${taskId}`,
+      asset: { url: `http://img.test/${taskId}.jpg` },
+      encounter: { id: encId, locationId },
+      individual,
+    },
+    prospects: {
+      annot: [
+        {
+          annotation: {
+            id: `p-${taskId}`,
+            encounter: { id: prospect.encounterId },
+            individual: prospect.individual,
+          },
+          score: 0.9,
+        },
+      ],
+      indiv: [],
+    },
+  },
+  children: [],
+});
+
+// Section A's query encounter already has an individual; section B's does not.
+const sectionA = () =>
+  querySection({
+    taskId: "task-A",
+    encId: "enc-A",
+    individual: { id: "ind-A", displayName: "Ava" },
+    locationId: "loc-A",
+    prospect: { encounterId: "cand-A1", individual: null },
+  });
+
+const sectionB = () =>
+  querySection({
+    taskId: "task-B",
+    encId: "enc-B",
+    individual: null,
+    locationId: "loc-B",
+    prospect: { encounterId: "cand-B1", individual: null },
+  });
+
+const multiQueryResponse = () => ({
+  matchResultsRoot: {
+    id: "umbrella",
+    dateCreated: "2024-06-01",
+    children: [sectionA(), sectionB()],
+  },
+});
+
+const singleQueryResponse = () => ({ matchResultsRoot: sectionB() });
+
+describe("MatchResultsStore — multi-query trees (issue #1744)", () => {
+  let store;
+  beforeEach(() => {
+    store = new MatchResultsStore();
+    jest.clearAllMocks();
+  });
+
+  test("each section's metadata carries its own query encounter", () => {
+    store.loadData(multiQueryResponse());
+    const sections = store.processedAnnots;
+    expect(sections.map((s) => s.taskId)).toEqual(["task-A", "task-B"]);
+    expect(sections.map((s) => s.metadata.queryEncounterId)).toEqual([
+      "enc-A",
+      "enc-B",
+    ]);
+    expect(sections[0].metadata.queryIndividualId).toBe("ind-A");
+    expect(sections[1].metadata.queryIndividualId).toBeNull();
+  });
+
+  test("with nothing selected a multi-query tree has no target and mutating actions refuse", async () => {
+    store.loadData(multiQueryResponse());
+    // no default: the first-listed section must never be named by accident
+    expect(store.encounterId).toBeNull();
+    expect(store.individualId).toBeNull();
+    expect(store.querySelectionItem).toBeNull();
+    expect(store.matchingState).toBe("no_individuals");
+
+    store.setNewIndividualName("Zed");
+    const created = await store.handleCreateNewIndividual("");
+    expect(created.ok).toBe(false);
+    expect(await store.handleMatch()).toBeNull();
+    expect(axios.patch).not.toHaveBeenCalled();
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  test("selecting a candidate in section B makes B's encounter the query", () => {
+    store.loadData(multiQueryResponse());
+    store.setSelectedMatch(true, "task-B-k1", "cand-B1", null, null, "task-B");
+    expect(store.encounterId).toBe("enc-B");
+    expect(store.individualId).toBeNull();
+    expect(store.individualDisplayName).toBeNull();
+    expect(store.encounterLocationId).toBe("loc-B");
+    expect(store.querySelectionItem).toEqual({
+      encounterId: "enc-B",
+      individualId: null,
+      individualDisplayName: null,
+    });
+    expect(store.matchingState).toBe("no_individuals");
+  });
+
+  test("handleMatch names the selected section's encounter, not the first section's", async () => {
+    store.loadData(multiQueryResponse());
+    // a NAMED candidate ticked in section B → CASE 3 server-side: enc-B gets ind-X
+    store.setSelectedMatch(
+      true,
+      "task-B-k1",
+      "cand-B1",
+      "ind-X",
+      "Xena",
+      "task-B",
+    );
+    expect(store.matchingState).toBe("single_individual");
+    axios.get.mockResolvedValueOnce({ data: { success: true } });
+    await store.handleMatch();
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    const url = axios.get.mock.calls[0][0];
+    expect(url).toContain("/iaResultsSetID.jsp");
+    expect(url).toContain("number=enc-B");
+    expect(url).toContain("individualID=ind-X");
+    expect(url).not.toContain("enc-A");
+    expect(url).not.toContain("ind-A");
+  });
+
+  test("deselecting drops the query context again", () => {
+    store.loadData(multiQueryResponse());
+    store.setSelectedMatch(true, "task-B-k1", "cand-B1", null, null, "task-B");
+    expect(store.encounterId).toBe("enc-B");
+    store.setSelectedMatch(false, "task-B-k1", "cand-B1", null, null, "task-B");
+    expect(store.encounterId).toBeNull();
+    expect(store.querySelectionItem).toBeNull();
+  });
+
+  test("selections spanning two query encounters are ambiguous and every action refuses", async () => {
+    store.loadData(multiQueryResponse());
+    store.setSelectedMatch(true, "task-A-k1", "cand-A1", null, null, "task-A");
+    store.setSelectedMatch(true, "task-B-k1", "cand-B1", null, null, "task-B");
+    expect(store.matchingState).toBe("multiple_query_encounters");
+
+    expect(await store.handleMatch()).toBeNull();
+    expect(store.matchRequestError).toBe("MULTIPLE_QUERY_ENCOUNTERS");
+    expect(await store.handleMerge()).toBeNull();
+    store.setNewIndividualName("Zed");
+    const created = await store.handleCreateNewIndividual("");
+    expect(created.ok).toBe(false);
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(axios.patch).not.toHaveBeenCalled();
+    // the refusal leaves the selection intact so the user can fix it
+    expect(store.selectedMatch).toHaveLength(2);
+  });
+
+  test("a selection whose section is unknown is ambiguous in a multi-query tree", () => {
+    store.loadData(multiQueryResponse());
+    store.setSelectedMatch(true, "k1", "cand-B1", null, null); // no section
+    expect(store.matchingState).toBe("multiple_query_encounters");
+    store.clearSelection();
+    store.setSelectedMatch(true, "k2", "cand-B1", null, null, "task-gone");
+    expect(store.matchingState).toBe("multiple_query_encounters");
+  });
+
+  test("a selection without section info is harmless in a single-query tree (existing contract)", () => {
+    store.loadData(singleQueryResponse());
+    store.setSelectedMatch(true, "k1", "cand-B1", "ind-X", "Xena");
+    expect(store.encounterId).toBe("enc-B");
+    expect(store.matchingState).toBe("single_individual");
+  });
+
+  test("a silent refresh that drops the selected section makes the selection ambiguous", () => {
+    store.loadData(multiQueryResponse());
+    store.setSelectedMatch(true, "task-B-k1", "cand-B1", null, null, "task-B");
+    const refreshed = multiQueryResponse();
+    refreshed.matchResultsRoot.children[1] = querySection({
+      taskId: "task-C",
+      encId: "enc-C",
+      individual: null,
+      locationId: "loc-C",
+      prospect: { encounterId: "cand-C1", individual: null },
+    });
+    store.loadData(refreshed, { preserveSelection: true });
+    expect(store.selectedMatch).toHaveLength(1);
+    expect(store.matchingState).toBe("multiple_query_encounters");
+  });
+
+  test("a refresh that leaves only another section while B's candidate is selected refuses every action", async () => {
+    store.loadData(multiQueryResponse());
+    store.setSelectedMatch(
+      true,
+      "task-B-k1",
+      "cand-B1",
+      "ind-X",
+      "Xena",
+      "task-B",
+    );
+    // polling refresh: the tree now holds only section A (single query)
+    store.loadData(
+      { matchResultsRoot: sectionA() },
+      { preserveSelection: true },
+    );
+    expect(store.selectedMatch).toHaveLength(1);
+    expect(store.matchingState).toBe("multiple_query_encounters");
+    expect(await store.handleMatch()).toBeNull();
+    expect(await store.handleMerge()).toBeNull();
+    store.setNewIndividualName("Zed");
+    expect((await store.handleCreateNewIndividual("")).ok).toBe(false);
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(axios.patch).not.toHaveBeenCalled();
+  });
+
+  test("handleCreateNewIndividual patches the selected section's encounter and reports it", async () => {
+    store.loadData(multiQueryResponse());
+    store.setSelectedMatch(true, "task-B-k1", "cand-B1", null, null, "task-B");
+    store.setNewIndividualName("Zed");
+    axios.patch.mockResolvedValue({
+      data: { patchResults: [{ individualId: "new-uuid" }] },
+    });
+    const result = await store.handleCreateNewIndividual("");
+    expect(result.ok).toBe(true);
+    expect(result.encounterId).toBe("enc-B");
+    const patched = axios.patch.mock.calls.map((c) => c[0]);
+    expect(patched).toEqual(
+      expect.arrayContaining([
+        "/api/v3/encounters/enc-B",
+        "/api/v3/encounters/cand-B1",
+      ]),
+    );
+    expect(patched).not.toContain("/api/v3/encounters/enc-A");
+  });
+
+  test("location-based naming uses the selected section's locationId", async () => {
+    store.loadData(multiQueryResponse());
+    store.setSelectedMatch(true, "task-B-k1", "cand-B1", null, null, "task-B");
+    store.setNewIndividualName("ignored", true);
+    axios.patch.mockResolvedValue({
+      data: { patchResults: [{ individualId: "new-uuid" }] },
+    });
+    await store.handleCreateNewIndividual("");
+    const firstOps = axios.patch.mock.calls[0][1];
+    expect(firstOps[0]).toEqual({
+      op: "replace",
+      path: "individualId",
+      value: { type: "locationId", value: "loc-B" },
+    });
+  });
+});

--- a/frontend/src/locale/de.json
+++ b/frontend/src/locale/de.json
@@ -807,6 +807,7 @@
   "CONFIRM_MATCH": "Übereinstimmung bestätigen",
   "MERGE_INDIVIDUALS": "Individuen zusammenführen",
   "CANNOT_MERGE_MORE_THAN_TWO": "Es können nicht mehr als zwei Individuen zusammengeführt werden",
+  "CANNOT_MATCH_ACROSS_QUERY_ENCOUNTERS": "Die ausgewählten Kandidaten gehören zu verschiedenen Abfrage-Begegnungen. Wählen Sie Kandidaten jeweils nur aus den Ergebnissen einer Begegnung aus.",
   "MERGE": "Zusammenführen",
   "MERGE_INDIVIDUAL": "Individuum zusammenführen",
   "AND": "und",

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -805,6 +805,7 @@
     "CONFIRM_MATCH": "Confirm Match",
     "MERGE_INDIVIDUALS": "Merge Individuals",
     "CANNOT_MERGE_MORE_THAN_TWO": "Cannot merge more than two individuals",
+    "CANNOT_MATCH_ACROSS_QUERY_ENCOUNTERS": "Selected candidates belong to different query encounters. Select candidates from one encounter's results at a time.",
     "MERGE": "Merge",
     "MERGE_INDIVIDUAL": "Merge individual",
     "AND": "and",

--- a/frontend/src/locale/es.json
+++ b/frontend/src/locale/es.json
@@ -807,6 +807,7 @@
   "CONFIRM_MATCH": "Confirmar coincidencia",
   "MERGE_INDIVIDUALS": "Fusionar individuos",
   "CANNOT_MERGE_MORE_THAN_TWO": "No se pueden fusionar más de dos individuos",
+  "CANNOT_MATCH_ACROSS_QUERY_ENCOUNTERS": "Los candidatos seleccionados pertenecen a distintos encuentros de consulta. Seleccione candidatos de los resultados de un solo encuentro a la vez.",
   "MERGE": "Fusionar",
   "MERGE_INDIVIDUAL": "Fusionar individuo",
   "AND": "y",

--- a/frontend/src/locale/fr.json
+++ b/frontend/src/locale/fr.json
@@ -807,6 +807,7 @@
   "CONFIRM_MATCH": "Confirmer la correspondance",
   "MERGE_INDIVIDUALS": "Fusionner des individus",
   "CANNOT_MERGE_MORE_THAN_TWO": "Impossible de fusionner plus de deux individus",
+  "CANNOT_MATCH_ACROSS_QUERY_ENCOUNTERS": "Les candidats sélectionnés appartiennent à des rencontres de requête différentes. Sélectionnez des candidats parmi les résultats d'une seule rencontre à la fois.",
   "MERGE": "Fusionner",
   "MERGE_INDIVIDUAL": "Fusionner l’individu",
   "AND": "et",

--- a/frontend/src/locale/it.json
+++ b/frontend/src/locale/it.json
@@ -807,6 +807,7 @@
   "CONFIRM_MATCH": "Conferma corrispondenza",
   "MERGE_INDIVIDUALS": "Unisci individui",
   "CANNOT_MERGE_MORE_THAN_TWO": "Non è possibile unire più di due individui",
+  "CANNOT_MATCH_ACROSS_QUERY_ENCOUNTERS": "I candidati selezionati appartengono a incontri di query diversi. Seleziona i candidati dai risultati di un solo incontro alla volta.",
   "MERGE": "Unisci",
   "MERGE_INDIVIDUAL": "Unisci individuo",
   "AND": "e",

--- a/frontend/src/pages/BulkImport/BulkImportTask.jsx
+++ b/frontend/src/pages/BulkImport/BulkImportTask.jsx
@@ -114,8 +114,9 @@ const BulkImportTask = observer(() => {
     task?.encounters?.map((item) => {
       const taskArray =
         task?.iaSummary?.statsAnnotations?.encounterTaskInfo?.[item.id] || [];
-      const classArray =
-        Array.isArray(taskArray) && taskArray?.length > 0 ? taskArray[0] : [];
+      // Issue #1744: keep every per-annotation match task of this encounter
+      // (an encounter can hold several matched annotations, e.g. body + part).
+      const classArray = Array.isArray(taskArray) ? taskArray : [];
       return {
         encounterID: item.id,
         encounterDate: item.date,
@@ -211,17 +212,25 @@ const BulkImportTask = observer(() => {
       name: "Class",
       selector: (row) => row.class,
       cell: (row) => {
-        const arr = row.class;
-        if (Array.isArray(arr) && arr.length === 3) {
-          const link = `/react/match-results?taskId=${arr[0]}`;
-          return (
-            <a href={link} target="_blank" rel="noreferrer">
-              {arr[2]} {": "}
-              {arr[1]}
-            </a>
-          );
-        }
-        return "-";
+        const tuples = Array.isArray(row.class)
+          ? row.class.filter((arr) => Array.isArray(arr) && arr.length === 3)
+          : [];
+        if (tuples.length === 0) return "-";
+        return (
+          <div className="d-flex flex-column">
+            {tuples.map((arr) => (
+              <a
+                key={arr[0]}
+                href={`/react/match-results?taskId=${arr[0]}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {arr[2]} {": "}
+                {arr[1]}
+              </a>
+            ))}
+          </div>
+        );
       },
     },
   ];

--- a/frontend/src/pages/MatchResultsPage/MatchResults.jsx
+++ b/frontend/src/pages/MatchResultsPage/MatchResults.jsx
@@ -421,6 +421,7 @@ const MatchResults = observer(() => {
                         encounterId,
                         individualId,
                         individualDisplayName,
+                        taskId,
                       );
                     }}
                   />

--- a/frontend/src/pages/MatchResultsPage/components/MatchProspectTable.jsx
+++ b/frontend/src/pages/MatchResultsPage/components/MatchProspectTable.jsx
@@ -174,6 +174,7 @@ const styles = {
 
 const MatchProspectTable = ({
   sectionId,
+  taskId,
   numCandidates,
   date,
   selectedMatch,
@@ -463,7 +464,13 @@ const MatchProspectTable = ({
                     const canOpenIndividual = Boolean(candidateIndividualId);
 
                     const rowKey = `${candidate.annotation?.id ?? candidate.annotation?.encounter?.id ?? "no-annot"}-${candidate.displayIndex ?? "no-idx"}`;
-                    const isRowSelected = isSelected(rowKey);
+                    // Issue #1744: qualify the selection key by task so the
+                    // same prospect at the same rank in two sections (an
+                    // image-wide umbrella task with one child per
+                    // annotation) cannot collide and read as selected in
+                    // both.
+                    const selectionKey = `${taskId ?? sectionId}-${rowKey}`;
+                    const isRowSelected = isSelected(selectionKey);
                     const isRowPreviewed = rowKey === previewedRow?._rowKey;
                     const isRowHovered = rowKey === hoveredRow;
 
@@ -573,7 +580,7 @@ const MatchProspectTable = ({
                             onChange={(e) =>
                               onToggleSelected(
                                 e.target.checked,
-                                rowKey,
+                                selectionKey,
                                 candidateEncounterId,
                                 candidateIndividualId,
                                 candidateIndividualDisplayName,

--- a/frontend/src/pages/MatchResultsPage/components/MatchResultsBottomBar.jsx
+++ b/frontend/src/pages/MatchResultsPage/components/MatchResultsBottomBar.jsx
@@ -40,11 +40,16 @@ const MatchResultsBottomBar = observer(
     const [showMatchConfirmedModal, setShowMatchConfirmedModal] =
       useState(false);
     const [matchConfirmedData, setMatchConfirmedData] = useState(null);
+    const [createdEncounterId, setCreatedEncounterId] = useState(null);
 
     const handleCreateNewIndividual = async (selectedRemark) => {
       const result = await store.handleCreateNewIndividual(selectedRemark);
 
       if (result?.ok) {
+        // The store resets the selection on success, which can move
+        // store.encounterId back to the default section; show the
+        // encounter that was actually acted on (issue #1744).
+        setCreatedEncounterId(result.encounterId || store.encounterId);
         setShowCreateModal(false);
         setShowSuccessModal(true);
       }
@@ -341,6 +346,27 @@ const MatchResultsBottomBar = observer(
           };
         }
 
+        case "multiple_query_encounters":
+          return {
+            left: (
+              <div
+                className="alert alert-danger mb-0"
+                style={{
+                  whiteSpace: "nowrap",
+                  height: "40px",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  padding: "0 12px",
+                }}
+                id="match-bottombar-multiple-query-encounters"
+                data-testid="match-bottombar-multiple-query-encounters"
+              >
+                <FormattedMessage id="CANNOT_MATCH_ACROSS_QUERY_ENCOUNTERS" />
+              </div>
+            ),
+            right: null,
+          };
+
         case "too_many_individuals":
           return {
             left: (
@@ -503,7 +529,7 @@ const MatchResultsBottomBar = observer(
             setShowSuccessModal(false);
             window.location.reload();
           }}
-          encounterId={store.encounterId}
+          encounterId={createdEncounterId ?? store.encounterId}
           individualName={store.newIndividualName}
           themeColor={themeColor}
         />

--- a/frontend/src/pages/MatchResultsPage/stores/matchResultsStore.js
+++ b/frontend/src/pages/MatchResultsPage/stores/matchResultsStore.js
@@ -48,6 +48,8 @@ export default class MatchResultsStore {
   _rootStillRunning = false;
   _rootHasError = false;
   _currentRequestId = null;
+  // Issue #1744: taskId -> query context of that section (see activeQuery).
+  _queryByTaskId = new Map();
 
   constructor() {
     makeAutoObservable(this, {}, { autoBind: true });
@@ -117,6 +119,7 @@ export default class MatchResultsStore {
       this._processedAnnots = [];
       this._processedIndivs = [];
       this._encounterId = null;
+      this._queryByTaskId = new Map();
       this._matchingSetFilter = {};
       this._individualId = null;
       this._individualDisplayName = null;
@@ -170,6 +173,10 @@ export default class MatchResultsStore {
     this._rawIndivs = Array.isArray(this._indivResults)
       ? this._indivResults
       : [];
+    this._queryByTaskId = this._indexQueriesByTask([
+      ...this._rawIndivs,
+      ...this._rawAnnots,
+    ]);
     this._hasResults = this._rawAnnots.length > 0 || this._rawIndivs.length > 0;
     this._processedAnnots = this._processData(this._rawAnnots);
     this._processedIndivs = this._processData(this._rawIndivs);
@@ -234,6 +241,10 @@ export default class MatchResultsStore {
           taskStatus: first.taskStatus,
           taskStatusOverall: first.taskStatusOverall,
           algorithm: first.algorithm,
+          queryEncounterId: first.queryEncounterId ?? null,
+          queryIndividualId: first.queryIndividualId ?? null,
+          queryIndividualDisplayName: first.queryIndividualDisplayName ?? null,
+          encounterLocationId: first.encounterLocationId ?? null,
           emptyStateType: first.emptyStateType ?? null,
           errors: first.errors ?? null,
         },
@@ -241,6 +252,27 @@ export default class MatchResultsStore {
     }
 
     return sections;
+  }
+
+  // Issue #1744: one query context per section (task node). A task tree can
+  // hold several sections whose query annotations belong to DIFFERENT
+  // encounters (an image-wide umbrella task with one child per annotation),
+  // so the query encounter an action applies to must come from the section
+  // the user selected in — never from whichever section happened to be
+  // listed first.
+  _indexQueriesByTask(rows) {
+    const byTask = new Map();
+    for (const row of rows) {
+      const taskId = row?.taskId;
+      if (!taskId || byTask.has(taskId) || !row?.queryEncounterId) continue;
+      byTask.set(taskId, {
+        encounterId: row.queryEncounterId,
+        individualId: row.queryIndividualId || null,
+        individualDisplayName: row.queryIndividualDisplayName || null,
+        locationId: row.encounterLocationId || "",
+      });
+    }
+    return byTask;
   }
 
   clearResults() {
@@ -251,6 +283,7 @@ export default class MatchResultsStore {
     this._processedAnnots = [];
     this._processedIndivs = [];
     this._encounterId = null;
+    this._queryByTaskId = new Map();
     this._encounterLocationId = "";
     this._matchingSetFilter = {};
     this._individualId = null;
@@ -316,12 +349,76 @@ export default class MatchResultsStore {
     return this.currentViewData.length > 0;
   }
 
+  // Distinct query encounters across every section of the loaded tree.
+  get queryEncounterIds() {
+    const ids = new Set();
+    for (const q of this._queryByTaskId.values()) {
+      if (q?.encounterId) ids.add(q.encounterId);
+    }
+    return Array.from(ids);
+  }
+
+  // The query context every action and display element operates on.
+  // With a single query encounter in the tree this is simply that query.
+  // In a multi-query tree it is the query of the section the selected
+  // candidates came from, and there is NO context until a candidate is
+  // ticked (encounterId null hides the action bar) — the first-listed
+  // section is never a default target. The context is ambiguous, and every
+  // action refuses, when the selection spans sections with different query
+  // encounters, when a candidate's section is unknown in a multi-query tree,
+  // or when a candidate's section no longer exists (e.g. after a polling
+  // refresh changed the tree) (issue #1744).
+  get activeQuery() {
+    const fallback = {
+      encounterId: this._encounterId || null,
+      individualId: this._individualId || null,
+      individualDisplayName: this._individualDisplayName || null,
+      locationId: this._encounterLocationId || "",
+      ambiguous: false,
+    };
+    const ambiguous = { ...fallback, ambiguous: true };
+    const multiQuery = this.queryEncounterIds.length > 1;
+
+    const byEncounter = new Map();
+    for (const m of this._selectedMatch) {
+      if (m?.sectionTaskId == null) {
+        // no section recorded: only acceptable when there is a single query
+        if (multiQuery) return ambiguous;
+        continue;
+      }
+      const q = this._queryByTaskId.get(m.sectionTaskId);
+      if (!q?.encounterId) return ambiguous; // section vanished or unknown
+      byEncounter.set(q.encounterId, q);
+    }
+    if (byEncounter.size > 1) return ambiguous;
+    if (byEncounter.size === 1) {
+      const q = byEncounter.values().next().value;
+      return {
+        encounterId: q.encounterId,
+        individualId: q.individualId || null,
+        individualDisplayName: q.individualDisplayName || null,
+        locationId: q.locationId || "",
+        ambiguous: false,
+      };
+    }
+    if (multiQuery) {
+      return {
+        encounterId: null,
+        individualId: null,
+        individualDisplayName: null,
+        locationId: "",
+        ambiguous: false,
+      };
+    }
+    return fallback;
+  }
+
   get encounterId() {
-    return this._encounterId;
+    return this.activeQuery.encounterId;
   }
 
   get encounterLocationId() {
-    return this._encounterLocationId;
+    return this.activeQuery.locationId;
   }
 
   get matchingSetFilter() {
@@ -329,11 +426,11 @@ export default class MatchResultsStore {
   }
 
   get individualId() {
-    return this._individualId;
+    return this.activeQuery.individualId;
   }
 
   get individualDisplayName() {
-    return this._individualDisplayName;
+    return this.activeQuery.individualDisplayName;
   }
 
   get projectNames() {
@@ -374,9 +471,10 @@ export default class MatchResultsStore {
 
   get uniqueIndividualIds() {
     const ids = new Set();
+    const query = this.activeQuery;
 
-    if (this._individualId) {
-      ids.add(this._individualId);
+    if (query.individualId) {
+      ids.add(query.individualId);
     }
 
     this._selectedMatch.forEach((match) => {
@@ -389,11 +487,12 @@ export default class MatchResultsStore {
   }
 
   get querySelectionItem() {
-    if (!this._encounterId) return null;
+    const query = this.activeQuery;
+    if (!query.encounterId) return null;
     return {
-      encounterId: this._encounterId,
-      individualId: this._individualId || null,
-      individualDisplayName: this.individualDisplayName || null,
+      encounterId: query.encounterId,
+      individualId: query.individualId || null,
+      individualDisplayName: query.individualDisplayName || null,
     };
   }
 
@@ -536,6 +635,13 @@ export default class MatchResultsStore {
     this._matchRequestError = null;
 
     try {
+      const query = this.activeQuery;
+      if (query.ambiguous) {
+        // the bottom bar already shows the localized alert for this state
+        this._matchRequestError = "MULTIPLE_QUERY_ENCOUNTERS";
+        return { ok: false, error: "MULTIPLE_QUERY_ENCOUNTERS" };
+      }
+
       const newName = (this._newIndividualName || "").trim();
 
       if (!newName) {
@@ -567,7 +673,7 @@ export default class MatchResultsStore {
             path: "individualId",
             value: {
               type: "locationId",
-              value: this._encounterLocationId,
+              value: query.locationId,
             },
           },
         ];
@@ -666,7 +772,7 @@ export default class MatchResultsStore {
 
       this.resetSelectionToQuery();
       toast.success("New individual created successfully!");
-      return { ok: true, successes };
+      return { ok: true, successes, encounterId: query.encounterId };
     } catch {
       this._matchRequestError = "CREATE_NEW_INDIVIDUAL_FAILED";
       toast.error("Failed to create new individual");
@@ -682,6 +788,7 @@ export default class MatchResultsStore {
     encounterId,
     individualId,
     individualDisplayName,
+    sectionTaskId = null,
   ) {
     if (!key || !encounterId) return;
 
@@ -694,6 +801,8 @@ export default class MatchResultsStore {
           encounterId,
           individualId: individualId || null,
           individualDisplayName: individualDisplayName || null,
+          // task node the candidate was ticked in (issue #1744)
+          sectionTaskId: sectionTaskId || null,
         },
       ];
     } else {
@@ -720,6 +829,13 @@ export default class MatchResultsStore {
     this._matchRequestError = null;
 
     try {
+      const query = this.activeQuery;
+      if (query.ambiguous) {
+        // the bottom bar already shows the localized alert for this state
+        this._matchRequestError = "MULTIPLE_QUERY_ENCOUNTERS";
+        return null;
+      }
+
       const all = this.selectedIncludingQuery;
 
       const uniqueIndividuals = Array.from(
@@ -744,12 +860,12 @@ export default class MatchResultsStore {
       );
 
       const params = new URLSearchParams();
-      if (this._encounterId) params.set("number", this._encounterId);
+      if (query.encounterId) params.set("number", query.encounterId);
       if (this._taskId) params.set("taskId", this._taskId);
       params.set("individualID", targetIndividualId);
 
       unnamedEncounterIds
-        .filter((id) => id !== this._encounterId)
+        .filter((id) => id !== query.encounterId)
         .forEach((id) => params.append("encOther", id));
 
       const url = `/iaResultsSetID.jsp?${params.toString()}`;
@@ -776,6 +892,12 @@ export default class MatchResultsStore {
     this._matchRequestError = null;
 
     try {
+      if (this.activeQuery.ambiguous) {
+        // the bottom bar already shows the localized alert for this state
+        this._matchRequestError = "MULTIPLE_QUERY_ENCOUNTERS";
+        return null;
+      }
+
       const all = this.selectedIncludingQuery;
 
       const uniqueIndividuals = Array.from(
@@ -825,6 +947,8 @@ export default class MatchResultsStore {
   }
 
   get matchingState() {
+    if (this.activeQuery.ambiguous) return "multiple_query_encounters";
+
     const all = this.selectedIncludingQuery;
 
     const uniqueIndividuals = Array.from(

--- a/src/main/java/org/ecocean/ia/Task.java
+++ b/src/main/java/org/ecocean/ia/Task.java
@@ -699,15 +699,17 @@ public class Task implements java.io.Serializable {
     // Structural criteria mirroring ImportTask.statsAnnotations:446-461 — a
     // task is "renderable" as a match result if it is shaped like a task
     // that owns prospects: single-algo legacy WBIA task, task with child
-    // algorithm sub-tasks under a thin parent, or a 3+-children root.
+    // algorithm sub-tasks under a thin parent, or a 3+-children root — plus
+    // (issue #1744) a single-annotation identified branch under a
+    // multi-annotation parent; see isSingleAnnotationBranch.
     private static boolean isRenderableMatchTask(Task t) {
         Task parent = t.getParent();
         List<Task> children = t.getChildren();
         JSONObject params = t.getParameters();
 
-        if ((parent != null) && (parent.getChildren() != null) &&
-            (parent.getChildren().size() == 1) &&
-            (params != null) && params.has("ibeis.identification")) {
+        if ((parent != null) && (params != null) && params.has("ibeis.identification") &&
+            (((parent.getChildren() != null) && (parent.getChildren().size() == 1)) ||
+            isSingleAnnotationBranch(t, parent))) {
             return true;
         }
         if ((children != null) && !children.isEmpty() &&
@@ -719,6 +721,21 @@ public class Task implements java.io.Serializable {
             return true;
         }
         return false;
+    }
+
+    // Issue #1744: when one image holds several annotations, both pipelines put
+    // ALL of them on one umbrella task and then branch one identified child per
+    // annotation (v2: Embedding.findMatchProspects subtasks under the
+    // MlServiceProcessor.runMatchProspects match task; legacy:
+    // IAGateway._doIdentify children, IA.intakeAnnotations per-iaClass
+    // children). The child owns that annotation's MatchResult, so it — not the
+    // umbrella, whose matchResultsJson recursion would render every
+    // annotation's prospects on one page — is the task to surface for that
+    // annotation. Per-ALGORITHM siblings hold the same annotation set as their
+    // parent and therefore do not qualify, so multi-algorithm trees keep their
+    // existing selection.
+    private static boolean isSingleAnnotationBranch(Task t, Task parent) {
+        return (t.numberAnnotations() == 1) && (parent.numberAnnotations() > 1);
     }
 
     public static List<Task> getTasksFor(MediaAsset ma, Shepherd myShepherd) {

--- a/src/test/java/org/ecocean/ia/TaskSelectPreferredMatchTaskTest.java
+++ b/src/test/java/org/ecocean/ia/TaskSelectPreferredMatchTaskTest.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.ecocean.Annotation;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
@@ -130,5 +131,153 @@ class TaskSelectPreferredMatchTaskTest {
     @Test void emptyAndNullInputsReturnNull() {
         assertNull(Task.selectPreferredMatchTask(null, "IMP1"));
         assertNull(Task.selectPreferredMatchTask(Collections.<Task>emptyList(), "IMP1"));
+    }
+
+    // ---- issue #1744: per-annotation fan-out under a multi-annotation umbrella ----
+
+    private static Annotation annot(String id) {
+        Annotation a = new Annotation();
+        a.setId(id);
+        return a;
+    }
+
+    private static Task withAnnots(Task t, Annotation... anns) {
+        for (Annotation a : anns) t.addObject(a);
+        return t;
+    }
+
+    /**
+     * v2 ml-service shape (MlServiceProcessor.runMatchProspects +
+     * Embedding.findMatchProspects): detection root D -> umbrella M holding EVERY
+     * annotation on the image -> one subtask per annotation (inherits params, owns
+     * the MatchResult). For annA the newest candidate is SA, but SA's parent has two
+     * children, so the pre-fix clause rejected it and the umbrella M — which renders
+     * BOTH annotations' results — was selected. Issue #1744.
+     */
+    @Test void v2FanOutSelectsPerAnnotationSubtaskNotUmbrella() {
+        Annotation annA = annot("annA");
+        Annotation annB = annot("annB");
+        Task d = new Task();
+        Task m = withAnnots(task(null, true, true, d), annA, annB);
+        Task sa = withAnnots(new Task(m), annA); // new Task(parent) inherits params
+        Task sb = withAnnots(new Task(m), annB);
+        assertSame(sa, Task.selectPreferredMatchTask(Arrays.asList(sa, m), null));
+        assertSame(sb, Task.selectPreferredMatchTask(Arrays.asList(sb, m), null));
+    }
+
+    /** Same tree on the bulk-import (scoped) path: the import stamp is inherited down to the subtask. */
+    @Test void v2FanOutScopedSelectsStampedSubtask() {
+        Annotation annA = annot("annA");
+        Annotation annB = annot("annB");
+        Task d = task("IMP1", false, false, null);
+        Task m = withAnnots(new Task(d), annA, annB);
+        m.addParameter("ibeis.identification", new JSONObject());
+        Task sa = withAnnots(new Task(m), annA);
+        withAnnots(new Task(m), annB);
+        assertSame(sa, Task.selectPreferredMatchTask(Arrays.asList(sa, m), "IMP1"));
+    }
+
+    /** One annotation on the image: unchanged — the single subtask already won. */
+    @Test void singleAnnotationSubtaskStillSelected() {
+        Annotation annA = annot("annA");
+        Task d = new Task();
+        Task m = withAnnots(task(null, true, true, d), annA);
+        Task sa = withAnnots(new Task(m), annA);
+        assertSame(sa, Task.selectPreferredMatchTask(Arrays.asList(sa, m), null));
+    }
+
+    /**
+     * Per-ALGORITHM siblings (legacy IA.intakeAnnotations with >1 ident opt) hold the
+     * SAME annotation set as their parent, so they are not fan-out children: the
+     * umbrella still wins (unchanged behavior).
+     */
+    @Test void perAlgorithmSiblingsDoNotQualifyAsFanOut() {
+        Annotation annA = annot("annA");
+        Task root = new Task();
+        Task umbrella = withAnnots(task(null, false, false, root), annA);
+        Task algo1 = withAnnots(task(null, true, false, umbrella), annA);
+        Task algo2 = withAnnots(task(null, true, false, umbrella), annA);
+        assertSame(umbrella,
+            Task.selectPreferredMatchTask(Arrays.asList(algo2, algo1, umbrella), null));
+    }
+
+    /**
+     * Legacy WBIA fan-out (IAGateway._doIdentify): the umbrella's params are reset to
+     * null and each per-annotation child carries ibeis.identification.
+     */
+    @Test void legacyDoIdentifyFanOutSelectsChild() {
+        Annotation annA = annot("annA");
+        Annotation annB = annot("annB");
+        Task root = new Task();
+        Task umbrella = withAnnots(task(null, false, false, root), annA, annB);
+        Task childA = withAnnots(task(null, true, false, umbrella), annA);
+        withAnnots(task(null, true, false, umbrella), annB);
+        assertSame(childA, Task.selectPreferredMatchTask(Arrays.asList(childA, umbrella), null));
+    }
+
+    /** A single-annotation child WITHOUT ibeis.identification (e.g. an embedding-extraction task) is not a match task. */
+    @Test void fanOutChildWithoutIdentificationParamIsNotRenderable() {
+        Annotation annA = annot("annA");
+        Annotation annB = annot("annB");
+        Task root = new Task();
+        Task umbrella = withAnnots(task(null, true, false, root), annA, annB);
+        Task childA = withAnnots(task(null, false, false, umbrella), annA);
+        withAnnots(task(null, false, false, umbrella), annB);
+        assertSame(umbrella, Task.selectPreferredMatchTask(Arrays.asList(childA, umbrella), null));
+    }
+
+    /**
+     * Legacy umbrella as an in-memory ROOT: Task.addChild does not set the
+     * child's parent (DataNucleus completes the FK from the mapped-by children
+     * side on persist), so a freshly built _doIdentify umbrella is rootless.
+     * Pre-fix a two-child rootless umbrella was reached only via root fallback;
+     * post-fix the per-annotation child wins outright.
+     */
+    @Test void rootlessLegacyUmbrellaStillYieldsPerAnnotationChild() {
+        Annotation annA = annot("annA");
+        Annotation annB = annot("annB");
+        Task umbrella = withAnnots(new Task(), annA, annB); // parent == null
+        Task childA = withAnnots(task(null, true, false, umbrella), annA);
+        withAnnots(task(null, true, false, umbrella), annB);
+        assertSame(childA, Task.selectPreferredMatchTask(Arrays.asList(childA, umbrella), null));
+    }
+
+    /**
+     * IA.intakeAnnotations partitions by iaClass: one identified child per
+     * class under an umbrella holding every annotation. A single-annotation
+     * class branch is selected for its annotation.
+     */
+    @Test void iaClassPartitionChildIsSelected() {
+        Annotation body = annot("body");
+        Annotation fin = annot("fin");
+        Task root = new Task();
+        Task umbrella = withAnnots(task(null, false, false, root), body, fin);
+        Task bodyBranch = withAnnots(task(null, true, false, umbrella), body);
+        withAnnots(task(null, true, false, umbrella), fin);
+        assertSame(bodyBranch,
+            Task.selectPreferredMatchTask(Arrays.asList(bodyBranch, umbrella), null));
+    }
+
+    /**
+     * Documented trade-off: multi-ALGORITHM x multi-annotation. The umbrella
+     * fans out per algorithm (each child still holding every annotation) and
+     * each algorithm fans out per annotation. There is no per-annotation
+     * umbrella, so the newest per-annotation leaf (one algorithm) is selected
+     * rather than the image-wide umbrella that previously rendered everything.
+     */
+    @Test void nestedMultiAlgorithmFanOutSelectsNewestPerAnnotationLeaf() {
+        Annotation annA = annot("annA");
+        Annotation annB = annot("annB");
+        Task root = new Task();
+        Task umbrella = withAnnots(task(null, false, false, root), annA, annB);
+        Task algo1 = withAnnots(task(null, true, false, umbrella), annA, annB);
+        Task algo2 = withAnnots(task(null, true, false, umbrella), annA, annB);
+        Task algo1A = withAnnots(task(null, true, false, algo1), annA);
+        withAnnots(task(null, true, false, algo1), annB);
+        Task algo2A = withAnnots(task(null, true, false, algo2), annA);
+        withAnnots(task(null, true, false, algo2), annB);
+        // created-DESC: newest first
+        assertSame(algo2A, Task.selectPreferredMatchTask(
+            Arrays.asList(algo2A, algo1A, algo2, algo1, umbrella), null));
     }
 }


### PR DESCRIPTION
Fixes #1744

## Symptom

When one image holds two or more annotations (two animals), detection splits them into separate encounters, but the match-results page opened from either encounter showed **both** annotations' candidates, and confirming a match for one section's candidate named the **other** annotation's encounter, or offered a merge with the other annotation's individual. Reported on Flukebook for a bulk import; the same happens for any pipeline that puts several annotations on one image.

## Root cause (two layers)

**Backend — the page was linked to the image-wide umbrella task.** Both pipelines put every annotation of the image on one umbrella task and then branch one identified child per annotation (v2: `Embedding.findMatchProspects` subtasks under the `MlServiceProcessor.runMatchProspects` match task; legacy: `IAGateway._doIdentify` children and `IA.intakeAnnotations` per-iaClass children). The child owns that annotation's `MatchResult`. `Task.isRenderableMatchTask` only accepted such a child when its parent had exactly one child, so with two or more annotations the shared selector (`Task.selectPreferredMatchTask`) fell back to the umbrella, whose `matchResultsJson` recurses into every child. Single-annotation images were unaffected, which is why this only shows up on multi-animal photos. Both the encounter page (`iaTaskId`) and the bulk-import page (`ImportTask.statsAnnotations`) use this selector, so both linked to the umbrella.

**Frontend — the page assumed one query encounter per tree.** `matchResultsStore` derived a single `_encounterId` / `_individualId` from whichever section happened to be listed first, selections did not record the section they came from, and `handleMatch` sent that arbitrary encounter as `number=` to `iaResultsSetID.jsp`. `matchingState` used the arbitrary query's individual, producing the "wants to merge with the other annotation's ID" the reporter saw.

## Fix

**Backend (root cause).** A single-annotation identified branch under a multi-annotation parent is now renderable (`isSingleAnnotationBranch`), so the newest-first selection picks the per-annotation subtask for both the unscoped (encounter page) and scoped (bulk import, stamp inherited) paths. Per-algorithm siblings hold the same annotation set as their parent and keep their existing selection. No migration: selection runs at request time, so existing task trees resolve correctly immediately.

**Frontend (defense in depth for existing umbrella URLs).**
- Selections record the section (task) they were ticked in; a single `activeQuery` operation context follows that section for every action and display element (bottom bar, Confirm, Create new individual, location-based naming, modals).
- In a multi-query tree there is no default target: the action bar stays hidden until a candidate is ticked, so the first-listed section can never be named by accident.
- A selection spanning sections with different query encounters, one whose section is unknown in a multi-query tree, or one whose section no longer exists after a polling refresh, is **refused**: new bottom-bar state `multiple_query_encounters` with a translated message (en/de/es/fr/it). In a single-query tree with normal selections, behavior is unchanged.
- Selection keys are task-qualified so the same prospect at the same rank in two sections cannot collide.
- The success modal for "create new individual" shows the encounter that was actually acted on.
- Bulk-import Class cell renders every per-annotation task tuple (an encounter can hold several matched annotations, e.g. body + part) instead of only the first.

**Known trade-off.** A legacy multi-*algorithm* × multi-annotation tree has no per-annotation umbrella; it now renders the newest per-annotation leaf (one algorithm) instead of the image-wide umbrella that rendered everything. Annotation scoping (data integrity) was prioritized over algorithm completeness; multi-algorithm completeness is a separate known issue.

## Tests

- Java: 9 new hand-built graph tests in `TaskSelectPreferredMatchTaskTest` — v2 fan-out unscoped and scoped, single-annotation image unchanged, per-algorithm siblings unchanged, legacy `_doIdentify` shape both parented and rootless, iaClass partition, nested multi-algorithm (documents the trade-off), identification-less child not selected. `TaskSelectPreferredMatchTaskTest`, `ImportTaskTest`, `TaskGetStoredStatusTest`, `TaskStatusInEndStateTest`, `MatchResultIndivProspectsTest`, `MlServiceProcessorTest`: 78/78 green.
- Frontend: `matchResultsStore.multiQuery.test.js` (12: default query, selection-following query, `number=` follows the selected section, deselect, cross-section refusal in match/merge/create, unknown-section handling in multi- vs single-query trees, silent refresh dropping the selected section, create-new patches and reports the acted-on encounter, location naming), `MatchProspectTable.selectionKey.test.jsx` (2), bottom-bar new state + acted-on encounter (3), `MatchResults.test.jsx` taskId forwarding (1), `BulkImportTaskClassCell.test.js` (2).
- Test-harness note: `MatchResults.test.jsx` had five pre-existing failures at `main` (a `useSiteSettings` mock returning a fresh object per render, which re-fires the fetch effect endlessly; a fixture `statusOverall: "complete"`, which is not a terminal status, so the store polled and the one-shot axios mock cleared the results right after they rendered; and empty-state assertions on a message id that `FormattedMessage` now replaces with its `defaultMessage`). Repaired minimally here so the suite can run. `BulkImportTask.test.js` does not parse at `main` (jest 27 `babel-plugin-jest-hoist` vs newer `@babel/types`); left untouched, the new Class-cell test lives in its own file with hoist-safe mocks. `CreateNewIndividualModal` and `MatchConfirmedModal` each have one pre-existing failure, untouched.

## Verifying on an install

Open an encounter created from a multi-animal image and click Match Results: only that encounter's annotation should appear as "This Encounter". Old umbrella URLs (like the one in the issue) still open, show one section per annotation, and Confirm names the encounter of the section you selected in; selecting across sections shows the new message instead of acting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Plan and diff adversarially reviewed by Codex (GPT-5.6, `gpt-5.6-terra`) — 3 review rounds (1 plan, 2 diff; converged on diff round 2); see the review-provenance comment below.
