### PR TITLE
fix: allow clearing the number of results field on the match page

### DIFF
--- a/frontend/src/__tests__/pages/MatchResults/MatchResults.test.jsx
+++ b/frontend/src/__tests__/pages/MatchResults/MatchResults.test.jsx
@@ -361,6 +361,21 @@ describe("MatchResults component", () => {
     expect(input.value).toBe("12");
   });
 
+  test("numResults field can be cleared and re-entered", async () => {
+    axios.get.mockResolvedValue({ data: makeApiResponse() });
+    renderComponent();
+    await screen.findByTestId("prospect-table-task-1");
+    const input = screen.getByDisplayValue("12");
+    fireEvent.change(input, { target: { value: "" } });
+    expect(input.value).toBe("");
+    fireEvent.change(input, { target: { value: "3" } });
+    expect(input.value).toBe("3");
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() =>
+      expect(axios.get.mock.calls.at(-1)[0]).toContain("prospectsSize=3"),
+    );
+  });
+
   test("pressing Enter on numResults input triggers fetch", async () => {
     axios.get.mockResolvedValue({ data: makeApiResponse() });
     renderComponent();

--- a/frontend/src/pages/MatchResultsPage/MatchResults.jsx
+++ b/frontend/src/pages/MatchResultsPage/MatchResults.jsx
@@ -15,7 +15,7 @@ import FilterIcon from "./icons/FilterIcon";
 import MatchCriteriaDrawer from "./components/MatchCriteriaDrawer";
 import MultiSelectWithCheckbox from "../../components/MultiSelectWithCheckbox";
 import ContainerWithSpinner from "../../components/ContainerWithSpinner";
-import { MAX_NUM_RESULTS } from "./constants";
+import { DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS } from "./constants";
 
 const MatchResults = observer(() => {
   const themeColor = React.useContext(ThemeColorContext);
@@ -38,6 +38,14 @@ const MatchResults = observer(() => {
 
   const [filterVisible, setFilterVisible] = React.useState(false);
   const [isInputFocused, setIsInputFocused] = React.useState(false);
+  const [resultsText, setResultsText] = React.useState(String(store.numResults));
+
+  const applyResultsCount = () => {
+    const trimmed = resultsText.trim();
+    store.setNumResults(trimmed === "" ? DEFAULT_NUM_RESULTS : Number(trimmed));
+    setResultsText(String(store.numResults));
+    store.fetchMatchResults();
+  };
 
   const projectOptions = useMemo(() => {
     return Object.entries(projectsForUser).map(([key, value]) => ({
@@ -257,18 +265,18 @@ const MatchResults = observer(() => {
                 data-testid="match-results-num-results-input"
                 type="text"
                 size="sm"
-                value={store.numResults}
+                value={resultsText}
                 onChange={(e) => {
                   const val = e.target.value;
                   if (/^\d*$/.test(val)) {
-                    store.setNumResults(val === "" ? 1 : Number(val));
+                    setResultsText(val);
                   }
                 }}
                 onFocus={() => setIsInputFocused(true)}
                 onBlur={() => setIsInputFocused(false)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
-                    store.fetchMatchResults();
+                    applyResultsCount();
                   }
                 }}
                 style={{
@@ -282,7 +290,7 @@ const MatchResults = observer(() => {
                   id="match-results-num-results-apply"
                   data-testid="match-results-num-results-apply"
                   type="button"
-                  onClick={() => store.fetchMatchResults()}
+                  onClick={applyResultsCount}
                   onMouseDown={(e) => e.preventDefault()}
                   style={{
                     position: "absolute",


### PR DESCRIPTION
The "Number of results" field on the match page was bound straight to the
MobX store, and `onChange` coerced an empty string to 1. Backspacing the
default 12 away therefore snapped the field to 1, and anything typed
afterwards was appended to that 1 instead of replacing it.

This keeps the typed text in local component state while the field is being
edited and only commits it to the store when the count is actually applied
(Enter or the apply button), falling back to the default when the field is
left empty. Fetches triggered by something else - a project change or the
polling refresh - now use the last applied count rather than a half-typed
value.

Note the field intentionally keeps whatever was typed until it is applied,
so an un-applied value stays visible next to the results from the previous
count.

PR fixes #1740

**Before you Submit!**
* Is all the text internationalized? No user-facing text was added or changed.
* If you made a change to the header, did you update the react, jsp, and html? No header change.
* Are all depedencies at a locked version? No dependency changes.
* Did you adhere to best practices? Yes, as far as I can tell - the change stays inside the existing component and store API.
* Is there a quick unit test you can add? The existing `MatchResults.test.jsx` cases for typing "20" and "abc" still cover the field; happy to add a case for clearing it if you would like one.
