### PR TITLE
fix(match-results): zoom about the focal point instead of the image's corner

### DIFF
--- a/frontend/src/__tests__/components/AnnotationOverlay.zoomFocal.test.jsx
+++ b/frontend/src/__tests__/components/AnnotationOverlay.zoomFocal.test.jsx
@@ -102,9 +102,9 @@ describe("AnnotationOverlay zoom focal point", () => {
   });
 
   it("measures the cursor from the container's content box", () => {
-    // A pane that is not at the viewport origin and carries a border and padding:
-    // the focal point has to be taken from where the transformed wrapper actually
-    // starts, not from the pane's border box.
+    // A pane that is not at the viewport origin, carries a border and padding, and
+    // has been scrolled: the focal point has to be taken from where the transformed
+    // wrapper actually starts, not from the pane's border box.
     const rect = jest
       .spyOn(HTMLElement.prototype, "getBoundingClientRect")
       .mockReturnValue({
@@ -118,18 +118,18 @@ describe("AnnotationOverlay zoom focal point", () => {
         y: 18,
         toJSON: () => ({}),
       });
-    const border = [
-      Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientLeft"),
-      Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientTop"),
-    ];
+    const boxProps = { clientLeft: 5, clientTop: 5, scrollLeft: 7, scrollTop: 9 };
+    const restore = Object.entries(boxProps).map(([prop, value]) => {
+      const descriptor = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        prop,
+      );
 
-    Object.defineProperty(HTMLElement.prototype, "clientLeft", {
-      configurable: true,
-      get: () => 5,
-    });
-    Object.defineProperty(HTMLElement.prototype, "clientTop", {
-      configurable: true,
-      get: () => 5,
+      Object.defineProperty(HTMLElement.prototype, prop, {
+        configurable: true,
+        get: () => value,
+      });
+      return [prop, descriptor];
     });
 
     try {
@@ -137,22 +137,21 @@ describe("AnnotationOverlay zoom focal point", () => {
         containerStyle: { paddingLeft: 20, paddingTop: 12 },
       });
 
-      // Content box starts at 30 + 5 + 20 = 55 across, 18 + 5 + 12 = 35 down,
-      // so this cursor sits at (100, 80) in the wrapper's own frame -- the same
-      // focal point as the zero-origin case above, and the same resulting pan.
-      fireEvent.wheel(pane, { deltaY: -100, clientX: 155, clientY: 115 });
+      // The wrapper starts at 30 + 5 + 20 - 7 = 48 across and 18 + 5 + 12 - 9 = 26
+      // down, so this cursor sits at (100, 80) in the wrapper's own frame -- the
+      // same focal point as the zero-origin case above, and the same resulting pan.
+      fireEvent.wheel(pane, { deltaY: -100, clientX: 148, clientY: 106 });
 
       expect(transformed.style.transform).toBe(
         "translate(-25px, -20px) scale(1.25)",
       );
     } finally {
       rect.mockRestore();
-      if (border[0]) {
-        Object.defineProperty(HTMLElement.prototype, "clientLeft", border[0]);
-      } else delete HTMLElement.prototype.clientLeft;
-      if (border[1]) {
-        Object.defineProperty(HTMLElement.prototype, "clientTop", border[1]);
-      } else delete HTMLElement.prototype.clientTop;
+      restore.forEach(([prop, descriptor]) => {
+        if (descriptor) {
+          Object.defineProperty(HTMLElement.prototype, prop, descriptor);
+        } else delete HTMLElement.prototype[prop];
+      });
     }
   });
 

--- a/frontend/src/__tests__/components/AnnotationOverlay.zoomFocal.test.jsx
+++ b/frontend/src/__tests__/components/AnnotationOverlay.zoomFocal.test.jsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { render, fireEvent, act } from "@testing-library/react";
+import InteractiveAnnotationOverlay from "../../components/AnnotationOverlay";
+
+// Regression cover for issue #1747: zooming used to leave `pan` untouched, which
+// -- with a top-left transform origin -- anchors the image's own top-left corner
+// and slides whatever the user was looking at out of the pane.
+
+// jsdom does no layout, so every measurement the overlay takes reads 0 unless we
+// supply one. Give it a 640x480 pane showing a 4096px-wide source image, and
+// leave getBoundingClientRect at jsdom's all-zero default (pane at the viewport
+// origin) so a client coordinate is already in the pane's own frame.
+const PANE_WIDTH = 640;
+const PANE_HEIGHT = 480;
+const saved = [];
+
+const stub = (proto, prop, value) => {
+  saved.push([proto, prop, Object.getOwnPropertyDescriptor(proto, prop)]);
+  Object.defineProperty(proto, prop, { configurable: true, get: () => value });
+};
+
+beforeAll(() => {
+  stub(HTMLElement.prototype, "clientWidth", PANE_WIDTH);
+  stub(HTMLElement.prototype, "clientHeight", PANE_HEIGHT);
+  stub(HTMLImageElement.prototype, "naturalWidth", 4096);
+  stub(HTMLImageElement.prototype, "complete", true);
+});
+
+afterAll(() => {
+  saved.forEach(([proto, prop, descriptor]) => {
+    if (descriptor) Object.defineProperty(proto, prop, descriptor);
+    else delete proto[prop];
+  });
+});
+
+const renderOverlay = (props = {}) => {
+  const ref = React.createRef();
+  const { container } = render(
+    <InteractiveAnnotationOverlay
+      ref={ref}
+      imageUrl="https://example.org/whale_master.jpg"
+      originalWidth={4096}
+      originalHeight={3072}
+      annotations={[]}
+      {...props}
+    />,
+  );
+  const pane = container.firstChild;
+
+  return { ref, pane, transformed: pane.firstChild };
+};
+
+describe("AnnotationOverlay zoom focal point", () => {
+  it("anchors a wheel zoom on the cursor", () => {
+    const { pane, transformed } = renderOverlay();
+
+    expect(transformed.style.transform).toBe("translate(0px, 0px) scale(1)");
+
+    fireEvent.wheel(pane, { deltaY: -100, clientX: 100, clientY: 80 });
+
+    // pan' = focal - (focal - pan) * nextZoom / zoom
+    //      = 100 - 100 * 1.25 = -25   (and 80 - 80 * 1.25 = -20)
+    // Before the fix this stayed at translate(0px, 0px): the point under the
+    // cursor jumped 25px left and 20px up out from under it.
+    expect(transformed.style.transform).toBe(
+      "translate(-25px, -20px) scale(1.25)",
+    );
+  });
+
+  it("keeps the point under the cursor still across several notches", () => {
+    const { pane, transformed } = renderOverlay();
+    const focal = { x: 100, y: 80 };
+
+    for (let i = 0; i < 4; i += 1) {
+      fireEvent.wheel(pane, {
+        deltaY: -100,
+        clientX: focal.x,
+        clientY: focal.y,
+      });
+    }
+
+    const [, panX, panY, zoom] = transformed.style.transform
+      .match(/translate\((-?[\d.]+)px, (-?[\d.]+)px\) scale\(([\d.]+)\)/)
+      .map(Number);
+
+    expect(zoom).toBeCloseTo(1.25 ** 4, 10);
+    // The image coordinate that started under the cursor is still drawn there.
+    const u = focal.x; // pan was 0 and zoom was 1 to begin with
+    expect(panX + u * zoom).toBeCloseTo(focal.x, 6);
+    expect(panY + focal.y * zoom).toBeCloseTo(focal.y, 6);
+  });
+
+  it("anchors the toolbar buttons on the middle of the pane", () => {
+    const { ref, transformed } = renderOverlay();
+
+    act(() => ref.current.zoomIn());
+
+    // Pane centre is (320, 240): 320 - 320 * 1.25 = -80, 240 - 240 * 1.25 = -60.
+    expect(transformed.style.transform).toBe(
+      "translate(-80px, -60px) scale(1.25)",
+    );
+  });
+
+  it("returns to the whole photo when zoomed back out", () => {
+    const { ref, transformed } = renderOverlay();
+
+    act(() => ref.current.zoomIn());
+    act(() => ref.current.zoomOut());
+
+    expect(transformed.style.transform).toBe("translate(0px, 0px) scale(1)");
+  });
+});

--- a/frontend/src/__tests__/components/AnnotationOverlay.zoomFocal.test.jsx
+++ b/frontend/src/__tests__/components/AnnotationOverlay.zoomFocal.test.jsx
@@ -101,6 +101,61 @@ describe("AnnotationOverlay zoom focal point", () => {
     );
   });
 
+  it("measures the cursor from the container's content box", () => {
+    // A pane that is not at the viewport origin and carries a border and padding:
+    // the focal point has to be taken from where the transformed wrapper actually
+    // starts, not from the pane's border box.
+    const rect = jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue({
+        left: 30,
+        top: 18,
+        right: 30 + PANE_WIDTH,
+        bottom: 18 + PANE_HEIGHT,
+        width: PANE_WIDTH,
+        height: PANE_HEIGHT,
+        x: 30,
+        y: 18,
+        toJSON: () => ({}),
+      });
+    const border = [
+      Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientLeft"),
+      Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientTop"),
+    ];
+
+    Object.defineProperty(HTMLElement.prototype, "clientLeft", {
+      configurable: true,
+      get: () => 5,
+    });
+    Object.defineProperty(HTMLElement.prototype, "clientTop", {
+      configurable: true,
+      get: () => 5,
+    });
+
+    try {
+      const { pane, transformed } = renderOverlay({
+        containerStyle: { paddingLeft: 20, paddingTop: 12 },
+      });
+
+      // Content box starts at 30 + 5 + 20 = 55 across, 18 + 5 + 12 = 35 down,
+      // so this cursor sits at (100, 80) in the wrapper's own frame -- the same
+      // focal point as the zero-origin case above, and the same resulting pan.
+      fireEvent.wheel(pane, { deltaY: -100, clientX: 155, clientY: 115 });
+
+      expect(transformed.style.transform).toBe(
+        "translate(-25px, -20px) scale(1.25)",
+      );
+    } finally {
+      rect.mockRestore();
+      if (border[0]) {
+        Object.defineProperty(HTMLElement.prototype, "clientLeft", border[0]);
+      } else delete HTMLElement.prototype.clientLeft;
+      if (border[1]) {
+        Object.defineProperty(HTMLElement.prototype, "clientTop", border[1]);
+      } else delete HTMLElement.prototype.clientTop;
+    }
+  });
+
   it("returns to the whole photo when zoomed back out", () => {
     const { ref, transformed } = renderOverlay();
 

--- a/frontend/src/__tests__/utils/annotationZoom.test.js
+++ b/frontend/src/__tests__/utils/annotationZoom.test.js
@@ -228,6 +228,21 @@ describe("computeZoomAboutPoint", () => {
     ).toEqual(pan);
   });
 
+  it("keeps the pan when the arithmetic overflows", () => {
+    // Every input is finite, but the result is not: a non-finite pan would put
+    // the image nowhere at all, so the view has to stay where it was.
+    const pan = { x: -Number.MAX_VALUE, y: -Number.MAX_VALUE };
+
+    expect(
+      computeZoomAboutPoint({
+        pan,
+        zoom: Number.MIN_VALUE,
+        nextZoom: Number.MAX_VALUE,
+        focal: { x: Number.MAX_VALUE, y: Number.MAX_VALUE },
+      }),
+    ).toEqual(pan);
+  });
+
   it("falls back to the origin when the pan itself is unusable", () => {
     expect(
       computeZoomAboutPoint({

--- a/frontend/src/__tests__/utils/annotationZoom.test.js
+++ b/frontend/src/__tests__/utils/annotationZoom.test.js
@@ -2,6 +2,7 @@ import {
   annotationDisplayRect,
   computeMaxZoom,
   computeFitToAnnotation,
+  computeZoomAboutPoint,
 } from "../../utils/annotationZoom";
 
 describe("computeMaxZoom", () => {
@@ -116,5 +117,125 @@ describe("computeFitToAnnotation", () => {
     expect(
       computeFitToAnnotation({ rect: null, ...container, minZoom: 1, maxZoom: 8 }),
     ).toBeNull();
+  });
+});
+
+describe("computeZoomAboutPoint", () => {
+  // Where a point at unscaled image coordinate `u` is drawn, given the overlay's
+  // `translate(pan) scale(zoom)` about a top-left origin.
+  const screenX = (u, { pan, zoom }) => pan.x + u * zoom;
+
+  it("holds the focal point under the same screen pixel", () => {
+    const before = { pan: { x: -100, y: -50 }, zoom: 2 };
+    const focal = { x: 320, y: 240 };
+    const nextZoom = 2.5;
+
+    const pan = computeZoomAboutPoint({ ...before, nextZoom, focal });
+
+    // The image coordinate that was under the focal point before the zoom...
+    const u = (focal.x - before.pan.x) / before.zoom;
+    // ...is still drawn there after it.
+    expect(screenX(u, { pan, zoom: nextZoom })).toBeCloseTo(focal.x, 10);
+    const v = (focal.y - before.pan.y) / before.zoom;
+    expect(pan.y + v * nextZoom).toBeCloseTo(focal.y, 10);
+  });
+
+  it("works from a negative pan, which is what auto-fit produces", () => {
+    // fitToAnnotation pans the image up and to the left to centre the box, so
+    // negative pans are the normal case on the match-results page, not an edge one.
+    const before = { pan: { x: -1240.5, y: -880.25 }, zoom: 4 };
+    const focal = { x: 300, y: 200 };
+
+    const pan = computeZoomAboutPoint({ ...before, nextZoom: 5, focal });
+
+    const u = (focal.x - before.pan.x) / before.zoom;
+    expect(screenX(u, { pan, zoom: 5 })).toBeCloseTo(focal.x, 10);
+  });
+
+  it("leaves the pan alone when the focal point is the wrapper origin", () => {
+    // The old behaviour -- an unchanged pan -- is only correct for u = 0, which
+    // is exactly why every other point drifted.
+    expect(
+      computeZoomAboutPoint({
+        pan: { x: -100, y: -50 },
+        zoom: 2,
+        nextZoom: 3,
+        focal: { x: -100, y: -50 },
+      }),
+    ).toEqual({ x: -100, y: -50 });
+  });
+
+  it("is a no-op when the zoom did not actually change", () => {
+    // Zoom clamped at the ceiling: nextZoom === zoom must not nudge the image.
+    expect(
+      computeZoomAboutPoint({
+        pan: { x: -100, y: -50 },
+        zoom: 3.5,
+        nextZoom: 3.5,
+        focal: { x: 320, y: 240 },
+      }),
+    ).toEqual({ x: -100, y: -50 });
+  });
+
+  it("round-trips: zooming out about the same point undoes zooming in", () => {
+    const focal = { x: 275, y: 190 };
+    const start = { pan: { x: -60, y: -35 }, zoom: 2 };
+
+    const zoomedIn = computeZoomAboutPoint({
+      ...start,
+      nextZoom: 2.5,
+      focal,
+    });
+    const backOut = computeZoomAboutPoint({
+      pan: zoomedIn,
+      zoom: 2.5,
+      nextZoom: 2,
+      focal,
+    });
+
+    expect(backOut.x).toBeCloseTo(start.pan.x, 10);
+    expect(backOut.y).toBeCloseTo(start.pan.y, 10);
+  });
+
+  it("keeps the pan when the zoom is unusable", () => {
+    const pan = { x: -100, y: -50 };
+    const focal = { x: 10, y: 10 };
+
+    expect(computeZoomAboutPoint({ pan, zoom: 0, nextZoom: 2, focal })).toEqual(
+      pan,
+    );
+    expect(computeZoomAboutPoint({ pan, zoom: 2, nextZoom: 0, focal })).toEqual(
+      pan,
+    );
+    expect(
+      computeZoomAboutPoint({ pan, zoom: 2, nextZoom: NaN, focal }),
+    ).toEqual(pan);
+  });
+
+  it("keeps the pan when there is no focal point to anchor", () => {
+    const pan = { x: -100, y: -50 };
+
+    expect(
+      computeZoomAboutPoint({ pan, zoom: 2, nextZoom: 3, focal: null }),
+    ).toEqual(pan);
+    expect(
+      computeZoomAboutPoint({
+        pan,
+        zoom: 2,
+        nextZoom: 3,
+        focal: { x: NaN, y: 0 },
+      }),
+    ).toEqual(pan);
+  });
+
+  it("falls back to the origin when the pan itself is unusable", () => {
+    expect(
+      computeZoomAboutPoint({
+        pan: undefined,
+        zoom: 2,
+        nextZoom: 3,
+        focal: { x: 10, y: 10 },
+      }),
+    ).toEqual({ x: 0, y: 0 });
   });
 });

--- a/frontend/src/components/AnnotationOverlay.jsx
+++ b/frontend/src/components/AnnotationOverlay.jsx
@@ -254,10 +254,19 @@ const InteractiveAnnotationOverlay = forwardRef(
       // repositions the container out of the wrapper's offsetParent chain.
       const rect = container.getBoundingClientRect();
       const padding = window.getComputedStyle(container);
+      // Minus any scroll offset: the container is overflow:hidden by default, but
+      // it can still be scrolled programmatically (and containerStyle can make it
+      // scrollable), which moves the wrapper without moving the container's rect.
       const originX =
-        rect.left + container.clientLeft + (parseFloat(padding.paddingLeft) || 0);
+        rect.left +
+        container.clientLeft +
+        (parseFloat(padding.paddingLeft) || 0) -
+        container.scrollLeft;
       const originY =
-        rect.top + container.clientTop + (parseFloat(padding.paddingTop) || 0);
+        rect.top +
+        container.clientTop +
+        (parseFloat(padding.paddingTop) || 0) -
+        container.scrollTop;
 
       return { x: clientX - originX, y: clientY - originY };
     };

--- a/frontend/src/components/AnnotationOverlay.jsx
+++ b/frontend/src/components/AnnotationOverlay.jsx
@@ -52,7 +52,6 @@ const InteractiveAnnotationOverlay = forwardRef(
     ref,
   ) => {
     const outerContainerRef = useRef(null);
-    const transformRef = useRef(null);
     const imgRef = useRef(null);
 
     // Zoom and pan are one piece of state, not two. Every zoom step has to move
@@ -109,6 +108,10 @@ const InteractiveAnnotationOverlay = forwardRef(
         }
         return { zoom: nextZoom, pan: { x: 0, y: 0 } };
       });
+      // A wheel gesture on the outgoing image must not swallow the incoming
+      // one's reset/auto-fit animation.
+      if (wheelSettleRef.current) clearTimeout(wheelSettleRef.current);
+      setWheelZooming(false);
       // initialZoom is the default view, not a trigger: changing it alone should not
       // yank the image out from under the user.
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -243,22 +246,18 @@ const InteractiveAnnotationOverlay = forwardRef(
       if (!container) return null;
       if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return null;
 
-      // getBoundingClientRect gives the border box; clientLeft/clientTop step in
-      // past the border to the padding box, which is the origin offsetLeft and
-      // offsetTop are measured from.
+      // getBoundingClientRect gives the border box. Step in past the border
+      // (clientLeft/clientTop) and then the padding to reach the content box,
+      // where the wrapper -- a static, in-flow, marginless child -- has its
+      // layout origin. Taking the padding from the container itself, rather than
+      // the wrapper's offsetLeft, stays correct even if a caller's containerStyle
+      // repositions the container out of the wrapper's offsetParent chain.
       const rect = container.getBoundingClientRect();
-      let originX = rect.left + container.clientLeft;
-      let originY = rect.top + container.clientTop;
-
-      // The wrapper is a static child, so its offsetLeft/offsetTop are pure
-      // layout values -- CSS transforms do not affect them -- and they pick up
-      // any padding a caller added through containerStyle.
-      const wrapper = transformRef.current;
-
-      if (wrapper && wrapper.offsetParent === container) {
-        originX += wrapper.offsetLeft;
-        originY += wrapper.offsetTop;
-      }
+      const padding = window.getComputedStyle(container);
+      const originX =
+        rect.left + container.clientLeft + (parseFloat(padding.paddingLeft) || 0);
+      const originY =
+        rect.top + container.clientTop + (parseFloat(padding.paddingTop) || 0);
 
       return { x: clientX - originX, y: clientY - originY };
     };
@@ -278,8 +277,9 @@ const InteractiveAnnotationOverlay = forwardRef(
     };
 
     // One zoom step, anchored so `focal` stays under the same screen pixel.
-    // `focal` is resolved by the caller, before the updater runs, so the updater
-    // stays a pure function of the previous view.
+    // `focal` is measured before the updater runs, so the updater derives the
+    // whole next view from `prev` and a StrictMode double-invocation cannot
+    // apply the shift twice. (clampPan reads layout, but read-only.)
     const zoomAbout = (direction, focal) => {
       setView((prev) => {
         const nextZoom = clampZoom(
@@ -398,6 +398,11 @@ const InteractiveAnnotationOverlay = forwardRef(
       scaleX,
       scaleY,
       sourceSize.url,
+      // annotationDisplayRect draws the box in a different frame when the asset
+      // carries rotation, and minZoom is the fit's floor: if either arrives after
+      // the image, the framing has to be recomputed.
+      hasRotation,
+      minZoom,
     ]);
 
     useImperativeHandle(ref, () => ({
@@ -526,7 +531,6 @@ const InteractiveAnnotationOverlay = forwardRef(
         onMouseDown={onMouseDown}
       >
         <div
-          ref={transformRef}
           style={{
             position: "relative",
             width: "100%",

--- a/frontend/src/components/AnnotationOverlay.jsx
+++ b/frontend/src/components/AnnotationOverlay.jsx
@@ -12,11 +12,16 @@ import {
   annotationDisplayRect,
   computeFitToAnnotation,
   computeMaxZoom,
+  computeZoomAboutPoint,
 } from "../utils/annotationZoom";
 
 const VISIBLE_MARGIN_PX = 40;
 // Breathing room left around an auto-fitted annotation, as a fraction of the box.
 const ANNOTATION_FIT_MARGIN = 0.1;
+// How long after the last wheel notch the transform transition stays off. Long
+// enough to bridge the gap between notches of one scroll gesture, short enough
+// that the animation is back before the next deliberate interaction.
+const WHEEL_SETTLE_MS = 200;
 
 const InteractiveAnnotationOverlay = forwardRef(
   (
@@ -47,13 +52,26 @@ const InteractiveAnnotationOverlay = forwardRef(
     ref,
   ) => {
     const outerContainerRef = useRef(null);
+    const transformRef = useRef(null);
     const imgRef = useRef(null);
 
-    const [zoom, setZoom] = useState(
-      Number.isFinite(initialZoom) ? initialZoom : 1,
-    );
-    const [pan, setPan] = useState({ x: 0, y: 0 });
+    // Zoom and pan are one piece of state, not two. Every zoom step has to move
+    // the pan to keep the focal point still, and a single functional update is
+    // the only way to derive both from the same previous view -- two chained
+    // setState calls would compute the new pan from a zoom that may already
+    // have moved on, and a setPan nested inside a setZoom updater is an impure
+    // updater that StrictMode double-invokes.
+    const [view, setView] = useState(() => ({
+      zoom: Number.isFinite(initialZoom) ? initialZoom : 1,
+      pan: { x: 0, y: 0 },
+    }));
+    const { zoom, pan } = view;
     const [dragging, setDragging] = useState(false);
+    // While a wheel gesture is in flight the transform transition is off: the
+    // focal math is computed from committed React state, so animating toward it
+    // would leave the point under the cursor lagging behind the cursor itself.
+    const [wheelZooming, setWheelZooming] = useState(false);
+    const wheelSettleRef = useRef(null);
     const dragStartRef = useRef({ x: 0, y: 0 });
     const panStartRef = useRef({ x: 0, y: 0 });
     const [scaleX, setScaleX] = useState(1);
@@ -83,8 +101,14 @@ const InteractiveAnnotationOverlay = forwardRef(
     // run as a layout effect so a cached replacement cannot paint at the old transform
     // first. The auto-fit effect reframes once the new image has loaded.
     useLayoutEffect(() => {
-      setZoom(Number.isFinite(initialZoom) ? initialZoom : 1);
-      setPan((prev) => (prev.x === 0 && prev.y === 0 ? prev : { x: 0, y: 0 }));
+      setView((prev) => {
+        const nextZoom = Number.isFinite(initialZoom) ? initialZoom : 1;
+
+        if (prev.zoom === nextZoom && prev.pan.x === 0 && prev.pan.y === 0) {
+          return prev;
+        }
+        return { zoom: nextZoom, pan: { x: 0, y: 0 } };
+      });
       // initialZoom is the default view, not a trigger: changing it alone should not
       // yank the image out from under the user.
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -184,7 +208,7 @@ const InteractiveAnnotationOverlay = forwardRef(
 
     const clampZoom = (z) => Math.max(minZoom, Math.min(maxZoomRef.current, z));
 
-    const clampPan = (nextPan, nextZoom = zoom) => {
+    const clampPan = (nextPan, nextZoom) => {
       const container = outerContainerRef.current;
       const img = imgRef.current;
 
@@ -207,6 +231,82 @@ const InteractiveAnnotationOverlay = forwardRef(
         x: Math.max(minX, Math.min(maxX, nextPan.x)),
         y: Math.max(minY, Math.min(maxY, nextPan.y)),
       };
+    };
+
+    // Where a screen point sits in the transformed wrapper's own unscaled
+    // coordinate frame -- the frame `pan` is expressed in. Measured from the
+    // container, whose box is never transformed; the wrapper's own bounding rect
+    // reports an interpolated position mid-transition rather than committed pan.
+    const focalFromClient = (clientX, clientY) => {
+      const container = outerContainerRef.current;
+
+      if (!container) return null;
+      if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return null;
+
+      // getBoundingClientRect gives the border box; clientLeft/clientTop step in
+      // past the border to the padding box, which is the origin offsetLeft and
+      // offsetTop are measured from.
+      const rect = container.getBoundingClientRect();
+      let originX = rect.left + container.clientLeft;
+      let originY = rect.top + container.clientTop;
+
+      // The wrapper is a static child, so its offsetLeft/offsetTop are pure
+      // layout values -- CSS transforms do not affect them -- and they pick up
+      // any padding a caller added through containerStyle.
+      const wrapper = transformRef.current;
+
+      if (wrapper && wrapper.offsetParent === container) {
+        originX += wrapper.offsetLeft;
+        originY += wrapper.offsetTop;
+      }
+
+      return { x: clientX - originX, y: clientY - originY };
+    };
+
+    // Middle of the visible pane: the anchor for the toolbar zoom buttons, which
+    // have no cursor to zoom toward. Matches the legacy OpenSeadragon viewer.
+    const paneCenterFocal = () => {
+      const container = outerContainerRef.current;
+
+      if (!container) return null;
+      const rect = container.getBoundingClientRect();
+
+      return focalFromClient(
+        rect.left + container.clientLeft + container.clientWidth / 2,
+        rect.top + container.clientTop + container.clientHeight / 2,
+      );
+    };
+
+    // One zoom step, anchored so `focal` stays under the same screen pixel.
+    // `focal` is resolved by the caller, before the updater runs, so the updater
+    // stays a pure function of the previous view.
+    const zoomAbout = (direction, focal) => {
+      setView((prev) => {
+        const nextZoom = clampZoom(
+          direction > 0 ? prev.zoom * zoomFactor : prev.zoom / zoomFactor,
+        );
+
+        // Already at the ceiling or the floor: leave the view exactly as it is
+        // rather than nudging the pan for a zoom that did not happen.
+        if (nextZoom === prev.zoom) return prev;
+
+        // Zooming all the way out means "show me the whole photo", so drop the
+        // pan rather than leaving the image parked off to one side.
+        if (nextZoom <= minZoom) return { zoom: nextZoom, pan: { x: 0, y: 0 } };
+
+        const anchored = focal
+          ? computeZoomAboutPoint({
+              pan: prev.pan,
+              zoom: prev.zoom,
+              nextZoom,
+              focal,
+            })
+          : prev.pan;
+
+        // Clamping wins over anchoring: near the edges the focal point does move,
+        // but the image cannot be zoomed out of the pane.
+        return { zoom: nextZoom, pan: clampPan(anchored, nextZoom) };
+      });
     };
 
     const stateRef = useRef({ zoom, pan, showAnn, imageLoaded });
@@ -244,16 +344,29 @@ const InteractiveAnnotationOverlay = forwardRef(
       });
 
       if (!fit) return false;
-      setZoom(fit.zoom);
-      setPan(clampPan(fit.pan, fit.zoom));
+      setView({ zoom: fit.zoom, pan: clampPan(fit.pan, fit.zoom) });
       return true;
     };
 
-    // Same reason as maxZoomRef: the imperative handle needs the current closure,
-    // and it must be in place before a parent effect can call reset().
+    // The whole photo at the default zoom, panned back to the top-left.
+    const fitImageView = () => {
+      const nextZoom = clampZoom(initialZoom || 1);
+
+      setView({ zoom: nextZoom, pan: clampPan({ x: 0, y: 0 }, nextZoom) });
+    };
+
+    // Same reason as maxZoomRef: the imperative handle is built once with empty
+    // deps, so everything it calls has to be reached through a ref that holds
+    // the current render's closure (current props, current clamps).
     const fitRef = useRef(() => false);
+    const fitImageRef = useRef(() => {});
+    const zoomAboutRef = useRef(() => {});
+    const showAnnPropRef = useRef(showAnnotationsProp);
     useLayoutEffect(() => {
       fitRef.current = fitAnnotationView;
+      fitImageRef.current = fitImageView;
+      zoomAboutRef.current = zoomAbout;
+      showAnnPropRef.current = showAnnotationsProp;
     });
 
     const fitSignature = useMemo(() => {
@@ -288,43 +401,23 @@ const InteractiveAnnotationOverlay = forwardRef(
     ]);
 
     useImperativeHandle(ref, () => ({
-      zoomIn: () => {
-        setZoom((z) => {
-          const nextZoom = clampZoom(z * zoomFactor);
-          setPan((prev) => clampPan(prev, nextZoom));
-          return nextZoom;
-        });
-      },
-      zoomOut: () => {
-        setZoom((z) => {
-          const nextZoom = clampZoom(z / zoomFactor);
-          // Zooming all the way out means "show me the whole photo", so drop the
-          // pan rather than leaving the image parked off to one side.
-          setPan((prev) =>
-            nextZoom <= minZoom ? { x: 0, y: 0 } : clampPan(prev, nextZoom),
-          );
-          return nextZoom;
-        });
-      },
+      // The buttons have no cursor to zoom toward, so they anchor the middle of
+      // the pane -- whatever the user centred stays centred.
+      zoomIn: () => zoomAboutRef.current(1, paneCenterFocal()),
+      zoomOut: () => zoomAboutRef.current(-1, paneCenterFocal()),
       // The default view: the annotation when auto-fit is on, else whole image.
       reset: () => {
         if (fitRef.current()) return;
-        const nextZoom = clampZoom(initialZoom || 1);
-        setZoom(nextZoom);
-        setPan(clampPan({ x: 0, y: 0 }, nextZoom));
+        fitImageRef.current();
       },
-      fitImage: () => {
-        const nextZoom = clampZoom(initialZoom || 1);
-        setZoom(nextZoom);
-        setPan(clampPan({ x: 0, y: 0 }, nextZoom));
-      },
+      fitImage: () => fitImageRef.current(),
       fitAnnotation: () => fitRef.current(),
       toggleAnnotations: () => {
-        if (typeof showAnnotationsProp === "boolean") return;
+        if (typeof showAnnPropRef.current === "boolean") return;
         setInternalShowAnn((v) => !v);
       },
       setAnnotationsVisible: (v) => {
-        if (typeof showAnnotationsProp === "boolean") return;
+        if (typeof showAnnPropRef.current === "boolean") return;
         setInternalShowAnn(!!v);
       },
       getState: () => stateRef.current,
@@ -350,7 +443,7 @@ const InteractiveAnnotationOverlay = forwardRef(
           y: panStartRef.current.y + dy,
         };
 
-        setPan(clampPan(nextPan));
+        setView((prev) => ({ ...prev, pan: clampPan(nextPan, prev.zoom) }));
       };
 
       const onUp = () => setDragging(false);
@@ -362,14 +455,14 @@ const InteractiveAnnotationOverlay = forwardRef(
         window.removeEventListener("mousemove", onMove);
         window.removeEventListener("mouseup", onUp);
       };
-    }, [dragging, zoom]);
+    }, [dragging]);
 
     useEffect(() => {
       const img = imgRef.current;
       if (!img) return;
 
       const handleLoad = () => {
-        setPan((prev) => clampPan(prev, zoom));
+        setView((prev) => ({ ...prev, pan: clampPan(prev.pan, prev.zoom) }));
       };
 
       if (img.complete && img.naturalWidth > 0) {
@@ -378,32 +471,45 @@ const InteractiveAnnotationOverlay = forwardRef(
         img.addEventListener("load", handleLoad);
         return () => img.removeEventListener("load", handleLoad);
       }
-    }, [imageUrl, zoom]);
+    }, [imageUrl]);
 
     useEffect(() => {
       const handleResize = () => {
-        setPan((prev) => clampPan(prev, zoom));
+        setView((prev) => ({ ...prev, pan: clampPan(prev.pan, prev.zoom) }));
       };
 
       window.addEventListener("resize", handleResize);
       return () => {
         window.removeEventListener("resize", handleResize);
       };
-    }, [zoom]);
+    }, []);
 
-    // Mouse-wheel zoom mirrors the zoomIn/zoomOut imperative-handle behavior.
-    const handleWheelZoom = (direction) => {
-      setZoom((z) => {
-        const nextZoom = clampZoom(
-          direction > 0 ? z * zoomFactor : z / zoomFactor,
-        );
-        setPan((prev) =>
-          nextZoom <= minZoom ? { x: 0, y: 0 } : clampPan(prev, nextZoom),
-        );
-        return nextZoom;
-      });
+    useEffect(
+      () => () => {
+        if (wheelSettleRef.current) clearTimeout(wheelSettleRef.current);
+      },
+      [],
+    );
+
+    // Mouse-wheel zoom, anchored on the cursor.
+    const handleWheelZoom = (direction, event) => {
+      setWheelZooming(true);
+      if (wheelSettleRef.current) clearTimeout(wheelSettleRef.current);
+      wheelSettleRef.current = setTimeout(
+        () => setWheelZooming(false),
+        WHEEL_SETTLE_MS,
+      );
+
+      zoomAbout(direction, focalFromClient(event?.clientX, event?.clientY));
     };
-    useWheelZoom(outerContainerRef, handleWheelZoom, imageLoaded);
+    // Only once the measurements belong to the image currently on screen: on an
+    // image change imageLoaded stays true until the load effect runs, and a wheel
+    // event landing in that window would zoom against the outgoing image.
+    useWheelZoom(
+      outerContainerRef,
+      handleWheelZoom,
+      imageLoaded && sourceSize.url === imageUrl,
+    );
 
     const panZoomTransform = `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`;
 
@@ -420,12 +526,14 @@ const InteractiveAnnotationOverlay = forwardRef(
         onMouseDown={onMouseDown}
       >
         <div
+          ref={transformRef}
           style={{
             position: "relative",
             width: "100%",
             transform: panZoomTransform,
             transformOrigin: "top left",
-            transition: dragging ? "none" : "transform 0.15s ease",
+            transition:
+              dragging || wheelZooming ? "none" : "transform 0.15s ease",
           }}
         >
           <img

--- a/frontend/src/utils/annotationZoom.js
+++ b/frontend/src/utils/annotationZoom.js
@@ -125,3 +125,52 @@ export function computeFitToAnnotation({
     },
   };
 }
+
+/**
+ * Pan that keeps `focal` under the same screen pixel while the zoom changes
+ * from `zoom` to `nextZoom`.
+ *
+ * The overlay draws `translate(pan) scale(zoom)` about a top-left origin, so a
+ * point at image coordinate `u` lands at `pan + u * zoom`. Holding `pan` still
+ * across a zoom change therefore anchors the image's top-left corner and slides
+ * everything else away from it. Solving for the pan that anchors `focal` instead:
+ *
+ *     u = (focal - pan) / zoom   ->   pan' = focal - (focal - pan) * nextZoom / zoom
+ *
+ * `focal` and `pan` are both unscaled pixels measured from the transformed
+ * wrapper's own layout origin. Pass the zoom that will actually be applied
+ * (after clamping) as `nextZoom`: feeding it the nominal step would shift the
+ * image whenever the zoom ceiling truncates it.
+ *
+ * Only the two zooms have to be positive. Pan and focal are routinely negative
+ * -- an auto-fitted annotation pans the image up and to the left, and the
+ * cursor can sit outside the image box -- so they are merely required to be
+ * finite. Anything unusable leaves the pan alone.
+ */
+export function computeZoomAboutPoint({ pan, zoom, nextZoom, focal }) {
+  const px = Number(pan?.x);
+  const py = Number(pan?.y);
+  const safePan = {
+    x: Number.isFinite(px) ? px : 0,
+    y: Number.isFinite(py) ? py : 0,
+  };
+
+  if (!pan || !focal) return safePan;
+
+  const z = Number(zoom);
+  const nz = Number(nextZoom);
+
+  if (!isPositiveNumber(z) || !isPositiveNumber(nz)) return safePan;
+
+  const fx = Number(focal.x);
+  const fy = Number(focal.y);
+
+  if (![px, py, fx, fy].every(Number.isFinite)) return safePan;
+
+  const ratio = nz / z;
+
+  return {
+    x: fx - (fx - safePan.x) * ratio,
+    y: fy - (fy - safePan.y) * ratio,
+  };
+}

--- a/frontend/src/utils/annotationZoom.js
+++ b/frontend/src/utils/annotationZoom.js
@@ -145,7 +145,7 @@ export function computeFitToAnnotation({
  * Only the two zooms have to be positive. Pan and focal are routinely negative
  * -- an auto-fitted annotation pans the image up and to the left, and the
  * cursor can sit outside the image box -- so they are merely required to be
- * finite. Anything unusable leaves the pan alone.
+ * finite. Anything unusable, or any result that overflows, leaves the pan alone.
  */
 export function computeZoomAboutPoint({ pan, zoom, nextZoom, focal }) {
   const px = Number(pan?.x);
@@ -169,8 +169,15 @@ export function computeZoomAboutPoint({ pan, zoom, nextZoom, focal }) {
 
   const ratio = nz / z;
 
-  return {
+  if (!Number.isFinite(ratio)) return safePan;
+
+  const next = {
     x: fx - (fx - safePan.x) * ratio,
     y: fy - (fy - safePan.y) * ratio,
   };
+
+  // Extreme-magnitude inputs can overflow to Infinity even though every input
+  // was finite; a non-finite pan would put the image nowhere at all.
+  if (!Number.isFinite(next.x) || !Number.isFinite(next.y)) return safePan;
+  return next;
 }


### PR DESCRIPTION
Fixes #1747.

## The bug

The overlay draws the image as `translate(pan) scale(zoom)` about a **top-left**
transform origin, so a point at image coordinate `u` is painted at `pan + u * zoom`.
Every zoom path — the toolbar buttons and the mouse wheel — changed `zoom` and left
`pan` where it was.

That anchors `u = 0`: the image's own top-left corner, which is usually off-screen.
Everything else slides away from it by `u * (z' - z)`.

`fitToAnnotation` means the match page normally opens at 3–7x, so a single 1.25x
notch displaced a point mid-pane by **hundreds of pixels**. Hence the report: zoom,
lose the whale, re-centre, zoom, lose it again.

## The fix

Recompute the pan so the anchor stays under the same screen pixel:

```
pan' = focal - (focal - pan) * nextZoom / zoom
```

- **wheel** anchors the cursor
- **toolbar buttons** anchor the middle of the pane — what the legacy OpenSeadragon
  viewer in `iaResults.jsp` did

The ratio uses the zoom **actually applied after clamping**, so hitting the ceiling
no longer nudges the image.

### Why zoom and pan became one state

They have to move together now. The old code called `setPan` *inside* a `setZoom`
updater — an impure updater that StrictMode double-invokes. That was survivable only
because clamping is idempotent; a focal shift is not, and would have been applied
twice. A single functional update over `{zoom, pan}` is also what makes several wheel
notches compose correctly when React 18 batches them into one render.

### Also here, all in service of the same anchor

- The transform transition is suppressed for the length of a wheel gesture (and
  cleared on image change). The focal math runs off committed state, so animating
  toward it leaves the point under a moving cursor visibly lagging.
- The wheel listener waits for `sourceSize.url === imageUrl`, not just `imageLoaded`,
  which stays true across an image swap until the load effect runs.
- The imperative handle is built once with `[]` deps, so its zoom/fit/reset entry
  points now reach the current render's closure through refs instead of capturing
  the first render's props.
- The focal point is measured from the container (never transformed) rather than the
  wrapper's own rect, which reports an interpolated position mid-transition — and it
  accounts for the container's border, padding and scroll offset.
- The auto-fit effect now also depends on `hasRotation` and `minZoom`, both of which
  feed the framing.

## Files

| File | |
|---|---|
| `frontend/src/utils/annotationZoom.js` | new pure `computeZoomAboutPoint` |
| `frontend/src/components/AnnotationOverlay.jsx` | combined view state, focal anchoring, wheel-gesture transition |
| `frontend/src/__tests__/utils/annotationZoom.test.js` | +8 |
| `frontend/src/__tests__/components/AnnotationOverlay.zoomFocal.test.jsx` | new, +4 |

## Verification

- **25/25** in the two zoom suites.
- The new component test **fails on the old component** exactly as predicted — the
  point under the cursor drifts from 100px to 244px over four notches, and the
  button-zoom transform stays at `translate(0px, 0px)`.
- Full frontend suite run on this branch *and* on its unmodified base with the same
  `node_modules`: **identical** 101 failed suites / 136 failed tests either way
  (pre-existing Babel transform errors in a fresh install, unrelated to this change).
  This branch adds +12 passing tests and no failures.
- Not visually verified in a browser — no Chrome binary available on this box. The
  geometry is pinned by the tests instead.

## Deliberately not in this PR

- `ImageModal.jsx` (encounter) and `ImageGalleryModal.jsx` (search gallery) have the
  same defect class in a milder form: a **centre** origin with an unchanged pan, so
  they anchor the image's centre and still drift once the user has panned. Different
  pages, and they belong with the owed pan/zoom consolidation.
- `reset()` fits the annotation whenever there is exactly one, regardless of the
  `fitToAnnotation` prop, and does not require the measurements to belong to the
  current image. Pre-existing on the base commit.
- `scaleX`/`scaleY`, the zoom ceiling and the fit are measured only on image load,
  never on resize, and none of them account for `InspectorModal`'s
  `objectFit: contain` letterboxing. Fixing that means a `ResizeObserver` and a
  contained-content rect, which moves the drawn annotation boxes — far wider than
  this bug. Pre-existing.
- `ctrlKey` wheel (trackpad pinch) is intercepted by the shared `useWheelZoom` hook
  and converted to a fixed 1.25x step. Pre-existing, and changing it would touch
  three pages.

## Review

Reviewed by **Codex (gpt-5.1-codex)** — the plan first, then three implementation
rounds, to converged.

On the plan it caught that the helper's input validation as specified would have
rejected **negative pans**, which is precisely what auto-fit produces — the fix would
have been a silent no-op on the exact page it targets. It also caught the incomplete
zoom/pan migration checklist, the stale-closure hazards in the `[]`-deps imperative
handle, and the padding gap in the focal frame.

On the implementation it caught arithmetic that could overflow to a non-finite pan,
that the `offsetParent`-based focal origin was only ever exercised through its
jsdom fallback by the tests, the missing `hasRotation`/`minZoom` fit dependencies,
the wheel-settle timer leaking across an image change, and finally the unhandled
container scroll offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
