### PR TITLE
fix(indexing): hand OpenSearch reindexing to the queue from the JDO transaction's completion callback

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -1247,9 +1247,31 @@ public class Encounter extends Base implements java.io.Serializable {
     public void enqueueAclReindex() {
         if (this.getSkipAutoIndexing() || OpenSearch.skipAutoIndexing()) return;
         try {
-            IndexingManagerFactory.getIndexingManager().addIndexingQueueEntry(this, false);
+            // Deferred: while this object's PersistenceManager has an active transaction the
+            // request is PARKED and released when that transaction completes (committed -> queued,
+            // rolled back -> dropped). Enqueuing from inside the transaction is what let the
+            // indexing job load and index pre-commit state. A transient object, or a caller that
+            // has already committed, falls through to an immediate enqueue. A caller whose open
+            // transaction will be rolled back must use enqueueAclReindexNow().
+            IndexingManager.addPendingEntry(javax.jdo.JDOHelper.getPersistenceManager(this), this,
+                false);
         } catch (Exception ex) {
             System.out.println("Encounter.enqueueAclReindex failed for " + this.getId() + ": " + ex);
+        }
+    }
+
+    /** enqueueAclReindex() for a caller whose open transaction will be ROLLED BACK, not committed
+     *  -- parking there would drop the request, so this enqueues immediately. Only the background
+     *  permissions pass needs it: it reads inside a transaction it rolls back at the end, and the
+     *  objects it asks to reindex were committed by someone else long before. */
+    public void enqueueAclReindexNow() {
+        if (this.getSkipAutoIndexing() || OpenSearch.skipAutoIndexing()) return;
+        try {
+            IndexingManager im = IndexingManagerFactory.getIndexingManager();
+            if (im != null) im.addIndexingQueueEntry(this.getId(), this.getClass(), false);
+        } catch (Exception ex) {
+            System.out.println("Encounter.enqueueAclReindexNow failed for " + this.getId() + ": " +
+                ex);
         }
     }
 
@@ -4411,7 +4433,9 @@ public class Encounter extends Base implements java.io.Serializable {
                 if (childReindexNeeded) {
                     try {
                         Encounter enc = myShepherd.getEncounter(id);
-                        if (enc != null) enc.enqueueAclReindex(); // refresh individual + annotations
+                        // Now-flavored: this pass's Shepherd holds a read transaction that is
+                        // rolled back at the end, so a deferred park would be discarded.
+                        if (enc != null) enc.enqueueAclReindexNow(); // refresh individual + annotations
                     } catch (Exception ex) {
                         // best-effort; reconciler / corrective reindex recovers a missed child refresh
                     }

--- a/src/main/java/org/ecocean/IndexingManager.java
+++ b/src/main/java/org/ecocean/IndexingManager.java
@@ -315,8 +315,9 @@ public class IndexingManager {
                 // A genuine indexing failure (not the commit race), or a failure setting up the
                 // Shepherd. Make it visible rather than silently swallowing it, then drop it. The
                 // background reconciler (OpenSearch.opensearchSyncIndex) re-indexes the row on a later
-                // pass only if its database version is strictly greater than the indexed one, so this
-                // is best-effort, not guaranteed recovery.
+                // pass if its document is missing, or if the document exists with a version and the
+                // database version is strictly greater -- so this is best-effort, not guaranteed
+                // recovery.
                 System.out.println("IndexingManager: WARNING - indexing failed for " + objectID +
                     " (attempt " + attempt + "/" + MAX_INDEXING_ATTEMPTS + "); dropping. " +
                     "Background reconciler may recover it if its version advanced. " + e);
@@ -344,7 +345,8 @@ public class IndexingManager {
         } else {
             System.out.println("IndexingManager: object " + objectID + " still not found after " + attempt +
                 " attempt(s); giving up (object may have been rolled back / never committed, or is an " +
-                "unindex of an already-deleted row). Background reconciler will index it if it exists.");
+                "unindex of an already-deleted row). Background reconciler may pick it up if it exists " +
+                "and its document is missing or behind.");
             // Still a terminal outcome, so a remembered follow-up must not be swallowed: a request
             // that arrived while we were burning retries is precisely the one that CAN succeed now.
             finishIndexingJob(objectID);
@@ -635,17 +637,18 @@ public class IndexingManager {
 
     /**
      * Step two of completion: hand each captured request to the queue. Each object is first evicted
-     * from the (PMF-wide, shared) level-2 cache by its DataNucleus identity. That eviction is shared
-     * invalidation -- the next reader goes to the database -- not read isolation; see
-     * ShepherdIndexingWork for what the reader does and does not bypass. Every step is isolated per
-     * entry: one failure never takes the rest of the snapshot down, and nothing here throws.
-     * Independent of the PM, which may be closed.
+     * from the (PMF-wide, shared) level-2 cache by its DataNucleus identity. That eviction removes
+     * the current shared entry -- it is invalidation, not read isolation: a reader's level-1 cache
+     * or a concurrent repopulation can still serve a copy. See ShepherdIndexingWork for what the
+     * reader does and does not bypass. Every step is isolated per entry: one failure never takes
+     * the rest of the snapshot down, and nothing here throws. Independent of the PM, which may be
+     * closed.
      *
      * Delivery is best-effort. A handoff that fails here (no IndexingManager, or the queue throws)
      * is logged and dropped; there is no durable retry. The background reconciler re-indexes a row
-     * only when its database version is strictly greater than the indexed one, so a dropped request
-     * for a change that did not advance the version leaves the document stale until something else
-     * touches it.
+     * whose document is missing, or whose existing document carries a version and the database
+     * version is strictly greater -- so a dropped request for a change that did not advance the
+     * version leaves an existing document stale until something else touches it.
      */
     static void drainCaptured(List<PendingEntry> snapshot, PersistenceManagerFactory pmf) {
         if ((snapshot == null) || snapshot.isEmpty()) return;

--- a/src/main/java/org/ecocean/IndexingManager.java
+++ b/src/main/java/org/ecocean/IndexingManager.java
@@ -226,12 +226,19 @@ public class IndexingManager {
     /*
      * The production IndexingWork: a fresh Shepherd on its own connection.
      *
-     * The reader PersistenceManager bypasses the level-2 cache. DataNucleus publishes an object's
-     * new state into L2 during its preCommit -- BEFORE the datastore commit -- so with L2 reads on,
-     * this job could pick up another in-flight transaction's not-yet-committed (possibly about to
-     * be rolled back) copy instead of the committed row. Bypassing L2 for reads makes the job read
-     * the database, which is the only thing that is guaranteed committed by the time the job runs.
-     * L2 is still written to, so nothing else is affected.
+     * The reader PersistenceManager is set to bypass the level-2 cache for its object lookups.
+     * DataNucleus publishes an object's new state into L2 during its preCommit -- BEFORE the
+     * datastore commit -- so a reader that trusts L2 can pick up another in-flight transaction's
+     * not-yet-committed (possibly about to be rolled back) copy. That is a DataNucleus-wide
+     * property of the shared L2 cache and predates this class; it affects every reader in
+     * Wildbook, not just this one.
+     *
+     * The bypass here is PARTIAL and must not be mistaken for read isolation: in DataNucleus 5.2
+     * the per-PM retrieve mode governs single-object lookups (getObjectById), but lazy field loads
+     * and bulk loads still consult L2 under the PMF-wide settings, and the encounter serializer
+     * opens its own Shepherd (Encounter.opensearchDocumentSerializer(JsonGenerator)) that reads
+     * normally. Closing that gap needs a dedicated L2-less PMF for indexing reads or a fleet-wide
+     * cache policy decision, which is a separate change.
      */
     static final class ShepherdIndexingWork implements IndexingWork {
         static final String L2_RETRIEVE_MODE_PROPERTY = "datanucleus.cache.level2.retrieveMode";
@@ -306,12 +313,13 @@ public class IndexingManager {
                 finishIndexingJob(objectID);
             } catch (Exception e) {
                 // A genuine indexing failure (not the commit race), or a failure setting up the
-                // Shepherd. Make it visible rather than silently swallowing it, then drop it; the
-                // background reconciler (OpenSearch.opensearchSyncIndex) will recover it on its next
-                // pass if the row exists.
+                // Shepherd. Make it visible rather than silently swallowing it, then drop it. The
+                // background reconciler (OpenSearch.opensearchSyncIndex) re-indexes the row on a later
+                // pass only if its database version is strictly greater than the indexed one, so this
+                // is best-effort, not guaranteed recovery.
                 System.out.println("IndexingManager: WARNING - indexing failed for " + objectID +
                     " (attempt " + attempt + "/" + MAX_INDEXING_ATTEMPTS + "); dropping. " +
-                    "Background reconciler will recover it if it exists. " + e);
+                    "Background reconciler may recover it if its version advanced. " + e);
                 e.printStackTrace();
                 finishIndexingJob(objectID);
             } finally {
@@ -627,10 +635,17 @@ public class IndexingManager {
 
     /**
      * Step two of completion: hand each captured request to the queue. Each object is first evicted
-     * from the (PMF-wide, shared) level-2 cache by its DataNucleus identity, so no reader picks up
-     * a copy published before this commit; the indexing job itself additionally bypasses L2 (see
-     * ShepherdIndexingWork). Every step is isolated per entry: one failure never takes the rest of
-     * the snapshot down, and nothing here throws. Independent of the PM, which may be closed.
+     * from the (PMF-wide, shared) level-2 cache by its DataNucleus identity. That eviction is shared
+     * invalidation -- the next reader goes to the database -- not read isolation; see
+     * ShepherdIndexingWork for what the reader does and does not bypass. Every step is isolated per
+     * entry: one failure never takes the rest of the snapshot down, and nothing here throws.
+     * Independent of the PM, which may be closed.
+     *
+     * Delivery is best-effort. A handoff that fails here (no IndexingManager, or the queue throws)
+     * is logged and dropped; there is no durable retry. The background reconciler re-indexes a row
+     * only when its database version is strictly greater than the indexed one, so a dropped request
+     * for a change that did not advance the version leaves the document stale until something else
+     * touches it.
      */
     static void drainCaptured(List<PendingEntry> snapshot, PersistenceManagerFactory pmf) {
         if ((snapshot == null) || snapshot.isEmpty()) return;
@@ -652,8 +667,8 @@ public class IndexingManager {
         }
     }
 
-    /** capturePendingEntries() + drainCaptured(), for callers without a delegate to interleave. */
-    public static void completePendingEntries(PersistenceManager pm, Outcome how) {
+    /** capturePendingEntries() + drainCaptured() with nothing interleaved. Test convenience. */
+    static void completePendingEntries(PersistenceManager pm, Outcome how) {
         PersistenceManagerFactory pmf = pmfOf(pm);
 
         drainCaptured(capturePendingEntries(pm, how), pmf);

--- a/src/main/java/org/ecocean/IndexingManager.java
+++ b/src/main/java/org/ecocean/IndexingManager.java
@@ -3,7 +3,9 @@ package org.ecocean;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -32,11 +34,30 @@ public class IndexingManager {
     // on indexingQueue itself because resetIndexingQueuehWithInitialCapacity() reassigns the field.
     private final Object queueLock = new Object();
 
+    // Objects that were requested again while a job for them was already scheduled or running.
+    // The dedupe in addIndexingQueueEntry() must NOT simply drop that later request: the in-flight
+    // job may have loaded the object BEFORE the change behind the later request was committed, so
+    // the later request is the one that describes the object's final state. We remember the newest
+    // (class, unindex) per id and run exactly one more pass when the in-flight job reaches a
+    // terminal outcome (finishIndexingJob). Guarded by queueLock.
+    private Map<String, Requeued> requeue = new HashMap<String, Requeued>();
+
+    private static final class Requeued {
+        final Class myClass;
+        final boolean unindex;
+
+        Requeued(Class myClass, boolean unindex) {
+            this.myClass = myClass;
+            this.unindex = unindex;
+        }
+    }
+
     // Total number of attempts (the initial attempt plus retries) before giving up on an object that
     // cannot be found in the datastore. The common cause is the postStore-before-commit race: the
     // indexing job is enqueued on JDO flush, but the creating transaction has not committed yet, so the
     // row is not visible to this background thread's separate connection (JDOObjectNotFoundException).
-    private static final int MAX_INDEXING_ATTEMPTS = 6;
+    // Package-private so tests can drive the give-up path without hardcoding the number.
+    static final int MAX_INDEXING_ATTEMPTS = 6;
 
     // Delay (seconds) BEFORE the next attempt, indexed by the just-failed attempt number (1-based).
     // Length is MAX_INDEXING_ATTEMPTS - 1. Cumulative budget ~62s, comfortably longer than a typical
@@ -56,6 +77,14 @@ public class IndexingManager {
         executor = Executors.newScheduledThreadPool(numAllowedThreads);
     }
 
+    /*
+     * Test seam: drive the scheduler deterministically. The production constructor's pool runs
+     * jobs that open a Shepherd and hit the database, which a unit test must never do.
+     */
+    IndexingManager(ScheduledExecutorService executor) {
+        this.executor = executor;
+    }
+
     // Returns the indexing queue List of Strings
     public List<String> getIndexingQueue() { return indexingQueue; }
 
@@ -65,17 +94,53 @@ public class IndexingManager {
      * @boolean unindex Whether the object is to be indexed or unindexed.
      */
     public void addIndexingQueueEntry(Base base, boolean unindex) {
-        String objectID = base.getId();
-        Class myClass = base.getClass();
-        // Atomic check-then-add so two concurrent postStore events for the same object schedule
-        // only one job.
+        if (base == null) return;
+        addIndexingQueueEntry(base.getId(), base.getClass(), unindex);
+    }
+
+    /*
+     * Same, by identity rather than instance. Callers that run after a transaction has ended must
+     * use this form: the persistent instance may belong to a PersistenceManager that is closed.
+     */
+    public void addIndexingQueueEntry(String objectID, Class myClass, boolean unindex) {
+        if ((objectID == null) || (myClass == null)) return;
+        // Atomic check-then-act so two concurrent requests for the same object schedule only one job.
         synchronized (queueLock) {
-            if (indexingQueue.contains(objectID)) return;
+            if (indexingQueue.contains(objectID)) {
+                // A job for this id is already scheduled or running. Remember this request rather
+                // than dropping it: the in-flight job may have loaded the object before the change
+                // behind this call was committed. Newer requests overwrite older ones on purpose --
+                // the newest describes the object's final state. finishIndexingJob() runs it.
+                requeue.put(objectID, new Requeued(myClass, unindex));
+                return;
+            }
             indexingQueue.add(objectID);
         }
-        // IMPORTANT - no persistent objects, such as the passed in Base, can be referenced inside the
-        // job; we carry only the (id, class) and re-fetch by id on each attempt.
+        // IMPORTANT - no persistent objects can be referenced inside the job; we carry only the
+        // (id, class) and re-fetch by id on each attempt.
         scheduleIndexingJob(objectID, myClass, unindex, 1, 0L);
+    }
+
+    /*
+     * Terminal outcome of one object's indexing job: success, a genuine failure, or a retry give-up.
+     * If a newer request for the same id arrived while that job was scheduled, running, or retrying,
+     * consume it and run exactly one more pass -- leaving the id in indexingQueue so concurrent
+     * requests keep deduping against the follow-up. Otherwise release the id.
+     *
+     * Package-private so tests can mark "the job finished" without running a job (which would
+     * open a Shepherd and touch the database).
+     */
+    void finishIndexingJob(String objectID) {
+        Requeued again = null;
+
+        synchronized (queueLock) {
+            again = requeue.remove(objectID);
+            if (again == null) {
+                indexingQueue.remove(objectID);
+                return;
+            }
+        }
+        scheduleIndexingJob(objectID, again.myClass, again.unindex, 1, 0L);
     }
 
     // GH-1514: queue deep reindex for each MarkedIndividual identified by id,
@@ -118,59 +183,80 @@ public class IndexingManager {
     // (e.g. executor shutdown), so an id can never be orphaned in the queue.
     private void scheduleIndexingJob(final String objectID, final Class myClass, final boolean unindex,
         final int attempt, long delaySeconds) {
-        final Runnable rn = new Runnable() {
-            public void run() {
-                Shepherd bgShepherd = null;
-                try {
-                    bgShepherd = new Shepherd("context0");
-                    bgShepherd.setAction("IndexingManager_" + objectID);
-                    bgShepherd.beginDBTransaction();
-                    Base base = null;
-                    try {
-                        base = (Base)bgShepherd.getPM().getObjectById(myClass, objectID);
-                    } catch (javax.jdo.JDOObjectNotFoundException nf) {
-                        // Object not visible to this connection. Almost always the postStore-before-commit
-                        // race; handle (retry the index path) and stop here for this attempt.
-                        handleObjectNotFound(objectID, myClass, unindex, attempt);
-                        return;
-                    }
-                    if (unindex) {
-                        base.opensearchUnindexDeep();
-                    } else {
-                        base.opensearchIndexDeep();
-                    }
-                    // success - terminal
-                    removeIndexingQueueEntry(objectID);
-                } catch (Exception e) {
-                    // A genuine indexing failure (not the commit race), or a failure setting up the
-                    // Shepherd. Make it visible rather than silently swallowing it, then drop it; the
-                    // background reconciler (OpenSearch.opensearchSyncIndex) will recover it on its next
-                    // pass if the row exists.
-                    System.out.println("IndexingManager: WARNING - indexing failed for " + objectID +
-                        " (attempt " + attempt + "/" + MAX_INDEXING_ATTEMPTS + "); dropping. " +
-                        "Background reconciler will recover it if it exists. " + e);
-                    e.printStackTrace();
-                    removeIndexingQueueEntry(objectID);
-                } finally {
-                    if (bgShepherd != null) bgShepherd.rollbackAndClose();
-                }
-            }
-        };
+        final Runnable rn = new IndexingJob(objectID, myClass, unindex, attempt);
 
         try {
             executor.schedule(rn, delaySeconds, TimeUnit.SECONDS);
         } catch (RejectedExecutionException rex) {
-            // Executor is shutting down; do not leak the queue entry.
+            // Executor is shutting down; do not leak the queue entry. Deliberately a hard remove
+            // rather than finishIndexingJob(): the executor is gone, so scheduling a follow-up would
+            // only be rejected again. The background reconciler is the backstop.
             System.out.println("IndexingManager: could not schedule indexing job for " + objectID +
                 " (executor shutdown?); removing from queue. " + rex);
             removeIndexingQueueEntry(objectID);
         }
     }
 
+    /*
+     * One indexing attempt for one object. A named class (not an anonymous Runnable) so the request
+     * it carries is observable: tests capture what was handed to the scheduler and assert on it.
+     */
+    final class IndexingJob implements Runnable {
+        final String objectID;
+        final Class myClass;
+        final boolean unindex;
+        final int attempt;
+
+        IndexingJob(String objectID, Class myClass, boolean unindex, int attempt) {
+            this.objectID = objectID;
+            this.myClass = myClass;
+            this.unindex = unindex;
+            this.attempt = attempt;
+        }
+
+        public void run() {
+            Shepherd bgShepherd = null;
+            try {
+                bgShepherd = new Shepherd("context0");
+                bgShepherd.setAction("IndexingManager_" + objectID);
+                bgShepherd.beginDBTransaction();
+                Base base = null;
+                try {
+                    base = (Base)bgShepherd.getPM().getObjectById(myClass, objectID);
+                } catch (javax.jdo.JDOObjectNotFoundException nf) {
+                    // Object not visible to this connection. Almost always the postStore-before-commit
+                    // race; handle (retry the index path) and stop here for this attempt.
+                    handleObjectNotFound(objectID, myClass, unindex, attempt);
+                    return;
+                }
+                if (unindex) {
+                    base.opensearchUnindexDeep();
+                } else {
+                    base.opensearchIndexDeep();
+                }
+                // success - terminal (unless a newer request landed while we were running)
+                finishIndexingJob(objectID);
+            } catch (Exception e) {
+                // A genuine indexing failure (not the commit race), or a failure setting up the
+                // Shepherd. Make it visible rather than silently swallowing it, then drop it; the
+                // background reconciler (OpenSearch.opensearchSyncIndex) will recover it on its next
+                // pass if the row exists.
+                System.out.println("IndexingManager: WARNING - indexing failed for " + objectID +
+                    " (attempt " + attempt + "/" + MAX_INDEXING_ATTEMPTS + "); dropping. " +
+                    "Background reconciler will recover it if it exists. " + e);
+                e.printStackTrace();
+                finishIndexingJob(objectID);
+            } finally {
+                if (bgShepherd != null) bgShepherd.rollbackAndClose();
+            }
+        }
+    }
+
     // Handles the "row not visible" case. For the index path this is the commit-visibility race, so we
     // retry with backoff (leaving the id in the queue to dedup concurrent events). For the unindex path a
     // missing row means the object is already gone and there is nothing to deep-unindex, so we give up.
-    private void handleObjectNotFound(final String objectID, final Class myClass, final boolean unindex,
+    // Package-private so tests can drive the retry and give-up paths without a datastore.
+    void handleObjectNotFound(final String objectID, final Class myClass, final boolean unindex,
         final int attempt) {
         if (!unindex && attempt < MAX_INDEXING_ATTEMPTS) {
             long delay = RETRY_DELAY_SECONDS[attempt - 1];
@@ -183,21 +269,26 @@ public class IndexingManager {
             System.out.println("IndexingManager: object " + objectID + " still not found after " + attempt +
                 " attempt(s); giving up (object may have been rolled back / never committed, or is an " +
                 "unindex of an already-deleted row). Background reconciler will index it if it exists.");
-            removeIndexingQueueEntry(objectID);
+            // Still a terminal outcome, so a remembered follow-up must not be swallowed: a request
+            // that arrived while we were burning retries is precisely the one that CAN succeed now.
+            finishIndexingJob(objectID);
         }
     }
 
-    // Removes an object's UUID from the queue
+    // Removes an object's UUID from the queue, dropping any remembered follow-up with it. This is the
+    // hard release; job outcomes go through finishIndexingJob() so a follow-up survives.
     public void removeIndexingQueueEntry(String objectID) {
         synchronized (queueLock) {
             indexingQueue.remove(objectID);
+            requeue.remove(objectID);
         }
     }
 
-    // Resets the indexing queue
+    // Resets the indexing queue (and any remembered follow-ups)
     public void resetIndexingQueuehWithInitialCapacity(int initialCapacity) {
         synchronized (queueLock) {
             indexingQueue = Collections.synchronizedList(new ArrayList<String>());
+            requeue = new HashMap<String, Requeued>();
         }
     }
 

--- a/src/main/java/org/ecocean/IndexingManager.java
+++ b/src/main/java/org/ecocean/IndexingManager.java
@@ -388,7 +388,7 @@ public class IndexingManager {
     // plain HashMap -- concurrent use of one PM from two threads is unsupported here as everywhere.
     // =====================================================================================
 
-    static final String PENDING_USER_OBJECT_KEY = "org.ecocean.IndexingManager.pending";
+    public static final String PENDING_USER_OBJECT_KEY = "org.ecocean.IndexingManager.pending";
 
     /** How the writing transaction ended, as reported by the JDO/JTA completion callback. */
     enum Outcome { COMMITTED, ROLLED_BACK, UNKNOWN }
@@ -525,6 +525,26 @@ public class IndexingManager {
             return pm.getPersistenceManagerFactory();
         } catch (Exception ex) {
             return null;
+        }
+    }
+
+    /**
+     * Make this PersistenceManager's transaction report its completion to the park. Called once
+     * per PM from Shepherd.beginDBTransaction(), before the first begin(); DataNucleus keeps the
+     * registration across the PM's successive transactions. Idempotent; wraps (and keeps calling)
+     * any Synchronization somebody else registered first, because JDO allows exactly one; never
+     * throws.
+     */
+    public static void registerSynchronization(PersistenceManager pm) {
+        if (pm == null) return;
+        try {
+            if (pm.isClosed()) return;
+            javax.jdo.Transaction tx = pm.currentTransaction();
+            javax.transaction.Synchronization existing = tx.getSynchronization();
+            if (existing instanceof IndexingTransactionSynchronization) return;
+            tx.setSynchronization(new IndexingTransactionSynchronization(pm, pmfOf(pm), existing));
+        } catch (Exception ex) {
+            System.out.println("IndexingManager.registerSynchronization() failed: " + ex);
         }
     }
 

--- a/src/main/java/org/ecocean/IndexingManager.java
+++ b/src/main/java/org/ecocean/IndexingManager.java
@@ -4,13 +4,19 @@ package org.ecocean;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import javax.jdo.PersistenceManager;
+import javax.jdo.PersistenceManagerFactory;
+import javax.transaction.Status;
+import org.datanucleus.enhancement.Persistable;
 import org.ecocean.shepherd.core.Shepherd;
 import org.ecocean.shepherd.core.ShepherdProperties;
 
@@ -198,6 +204,74 @@ public class IndexingManager {
     }
 
     /*
+     * How one indexing attempt reaches the datastore and the index. Production opens a Shepherd
+     * (ShepherdIndexingWork); tests substitute a scripted implementation so a real IndexingJob can
+     * run on the test thread and prove it reports every outcome correctly.
+     */
+    interface IndexingWork {
+        /** Load the object by id; throws javax.jdo.JDOObjectNotFoundException if not visible. */
+        Base load(Class myClass, String objectID) throws Exception;
+
+        void index(Base base, boolean unindex) throws Exception;
+
+        /** Always called, exactly once, after load/index -- whatever happened. */
+        void close();
+    }
+
+    // Overridable seam (package-private) -- see IndexingJobWiringTest.
+    IndexingWork newIndexingWork(String objectID) {
+        return new ShepherdIndexingWork(objectID);
+    }
+
+    /*
+     * The production IndexingWork: a fresh Shepherd on its own connection.
+     *
+     * The reader PersistenceManager bypasses the level-2 cache. DataNucleus publishes an object's
+     * new state into L2 during its preCommit -- BEFORE the datastore commit -- so with L2 reads on,
+     * this job could pick up another in-flight transaction's not-yet-committed (possibly about to
+     * be rolled back) copy instead of the committed row. Bypassing L2 for reads makes the job read
+     * the database, which is the only thing that is guaranteed committed by the time the job runs.
+     * L2 is still written to, so nothing else is affected.
+     */
+    static final class ShepherdIndexingWork implements IndexingWork {
+        static final String L2_RETRIEVE_MODE_PROPERTY = "datanucleus.cache.level2.retrieveMode";
+        private final Shepherd shepherd;
+
+        ShepherdIndexingWork(String objectID) {
+            shepherd = new Shepherd("context0");
+            shepherd.setAction("IndexingManager_" + objectID);
+            shepherd.beginDBTransaction();
+            try {
+                PersistenceManager pm = shepherd.getPM();
+                if (pm != null) pm.setProperty(L2_RETRIEVE_MODE_PROPERTY, "bypass");
+            } catch (Exception ex) {
+                System.out.println("IndexingManager: could not set " + L2_RETRIEVE_MODE_PROPERTY +
+                    "=bypass on the reader PersistenceManager for " + objectID + ": " + ex);
+            }
+        }
+
+        Shepherd shepherd() {
+            return shepherd;
+        }
+
+        public Base load(Class myClass, String objectID) {
+            return (Base)shepherd.getPM().getObjectById(myClass, objectID);
+        }
+
+        public void index(Base base, boolean unindex) throws Exception {
+            if (unindex) {
+                base.opensearchUnindexDeep();
+            } else {
+                base.opensearchIndexDeep();
+            }
+        }
+
+        public void close() {
+            shepherd.rollbackAndClose();
+        }
+    }
+
+    /*
      * One indexing attempt for one object. A named class (not an anonymous Runnable) so the request
      * it carries is observable: tests capture what was handed to the scheduler and assert on it.
      */
@@ -215,25 +289,19 @@ public class IndexingManager {
         }
 
         public void run() {
-            Shepherd bgShepherd = null;
+            IndexingWork work = null;
             try {
-                bgShepherd = new Shepherd("context0");
-                bgShepherd.setAction("IndexingManager_" + objectID);
-                bgShepherd.beginDBTransaction();
+                work = newIndexingWork(objectID);
                 Base base = null;
                 try {
-                    base = (Base)bgShepherd.getPM().getObjectById(myClass, objectID);
+                    base = work.load(myClass, objectID);
                 } catch (javax.jdo.JDOObjectNotFoundException nf) {
                     // Object not visible to this connection. Almost always the postStore-before-commit
                     // race; handle (retry the index path) and stop here for this attempt.
                     handleObjectNotFound(objectID, myClass, unindex, attempt);
                     return;
                 }
-                if (unindex) {
-                    base.opensearchUnindexDeep();
-                } else {
-                    base.opensearchIndexDeep();
-                }
+                work.index(base, unindex);
                 // success - terminal (unless a newer request landed while we were running)
                 finishIndexingJob(objectID);
             } catch (Exception e) {
@@ -247,7 +315,7 @@ public class IndexingManager {
                 e.printStackTrace();
                 finishIndexingJob(objectID);
             } finally {
-                if (bgShepherd != null) bgShepherd.rollbackAndClose();
+                if (work != null) work.close();
             }
         }
     }
@@ -294,6 +362,292 @@ public class IndexingManager {
 
     public void shutdown() {
         if (executor != null) executor.shutdown();
+    }
+
+    // =====================================================================================
+    // Deferred (post-commit) indexing
+    //
+    // WildbookLifecycleListener.postStore() fires on JDO flush/store, NOT on commit. Enqueuing
+    // there means the background job -- which opens its own Shepherd and therefore its own JDBC
+    // connection -- can load the row BEFORE the writing transaction commits, and index pre-change
+    // state. Nothing detects that: for a row that already exists the reload SUCCEEDS (only a
+    // brand-new row raises JDOObjectNotFoundException, which is what the retry path handles), so
+    // the job reports success and the stale document sticks.
+    //
+    // So postStore no longer enqueues. It PARKS (id, class, unindex, DataNucleus identity) against
+    // the PersistenceManager doing the write -- in the PM's own JDO user-object map, which is
+    // identity-scoped by construction and is collected together with the PM. The park is released
+    // by the transaction's own completion callback (IndexingTransactionSynchronization, a
+    // javax.transaction.Synchronization registered once per PM): drained if the transaction
+    // committed, dropped if it rolled back. Nothing else may terminalize a park: not "commit threw"
+    // (DataNucleus leaves the transaction ACTIVE after a NucleusUserException, and the park must
+    // stay live with it), not close.
+    //
+    // Locking: bucket state is guarded by the bucket's own monitor and nothing else. We never hold
+    // a lock of ours while calling into a PersistenceManager, and the PM's user-object map is a
+    // plain HashMap -- concurrent use of one PM from two threads is unsupported here as everywhere.
+    // =====================================================================================
+
+    static final String PENDING_USER_OBJECT_KEY = "org.ecocean.IndexingManager.pending";
+
+    /** How the writing transaction ended, as reported by the JDO/JTA completion callback. */
+    enum Outcome { COMMITTED, ROLLED_BACK, UNKNOWN }
+
+    /*
+     * Explicit mapping of the javax.transaction.Status the Synchronization receives. DataNucleus
+     * 5.2 only ever reports COMMITTED or ROLLEDBACK from its resource-local transaction (heuristic
+     * outcomes are turned into a rollback attempt first). Anything else is evidence we do not
+     * understand, and must be treated as neither a proven commit nor a proven rollback.
+     */
+    static Outcome outcomeOf(int jtaStatus) {
+        switch (jtaStatus) {
+        case Status.STATUS_COMMITTED:
+            return Outcome.COMMITTED;
+        case Status.STATUS_ROLLEDBACK:
+            return Outcome.ROLLED_BACK;
+        default:
+            System.out.println("IndexingManager: WARNING - transaction completed with unexpected " +
+                "javax.transaction.Status " + jtaStatus + "; treating as UNKNOWN (index requests " +
+                "will run, unindex requests will not)");
+            return Outcome.UNKNOWN;
+        }
+    }
+
+    /** What PendingBucket.park() decided for one request. */
+    enum ParkResult { PARKED, ENQUEUE_NOW, DROP }
+
+    // One deferred index request. Only identity is kept -- never the Persistable, whose
+    // PersistenceManager may be closed by the time the entry is drained.
+    static final class PendingEntry {
+        final String objectID;
+        final Class myClass;
+        final boolean unindex;
+        // DataNucleus INTERNAL identity (Persistable.dnGetObjectId()), captured while the PM is
+        // open, for level-2 eviction at drain time. The level-2 cache is keyed by this, not by
+        // the javax.jdo.identity.* object JDOHelper.getObjectId() returns -- evicting with the
+        // latter silently misses. May be null (transient object, or capture failed).
+        final Object dnObjectId;
+
+        PendingEntry(String objectID, Class myClass, boolean unindex, Object dnObjectId) {
+            this.objectID = objectID;
+            this.myClass = myClass;
+            this.unindex = unindex;
+            this.dnObjectId = dnObjectId;
+        }
+
+        // identity of the REQUEST, so repeated parks of the same request collapse. dnObjectId is
+        // derived from objectID and is deliberately excluded.
+        @Override public boolean equals(Object other) {
+            if (this == other) return true;
+            if (!(other instanceof PendingEntry)) return false;
+            PendingEntry pe = (PendingEntry)other;
+            return this.unindex == pe.unindex && this.objectID.equals(pe.objectID) &&
+                   this.myClass.equals(pe.myClass);
+        }
+
+        @Override public int hashCode() {
+            return (objectID.hashCode() * 31 + myClass.hashCode()) * 31 + (unindex ? 1 : 0);
+        }
+    }
+
+    /*
+     * The per-PersistenceManager park: a set of requests plus, once the transaction has completed,
+     * its outcome. The first completion outcome sticks; later completion signals are ignored.
+     *
+     * A request that arrives AFTER completion (a parker that read this bucket just before the
+     * transaction ended) is never retained: if the transaction committed the change is durable and
+     * the request must run now; if it rolled back the request is dropped; if the outcome is unknown,
+     * an index request runs now (harmless -- the job re-reads the database) and an unindex is
+     * dropped (never run an ambiguous delete).
+     */
+    static final class PendingBucket {
+        final PersistenceManagerFactory pmf; // for level-2 eviction after the PM may be closed
+        private final Set<PendingEntry> entries = new LinkedHashSet<PendingEntry>(); // guarded by this
+        private Outcome outcome = null; // guarded by this; non-null once completed
+
+        PendingBucket(PersistenceManagerFactory pmf) {
+            this.pmf = pmf;
+        }
+
+        synchronized ParkResult park(PendingEntry pe) {
+            if (outcome == null) {
+                entries.add(pe);
+                return ParkResult.PARKED;
+            }
+            switch (outcome) {
+            case COMMITTED:
+                return ParkResult.ENQUEUE_NOW;
+            case ROLLED_BACK:
+                return ParkResult.DROP;
+            default:
+                return pe.unindex ? ParkResult.DROP : ParkResult.ENQUEUE_NOW;
+            }
+        }
+
+        /** Terminalize with this outcome; returns the requests that should now run (maybe none). */
+        synchronized List<PendingEntry> complete(Outcome how) {
+            if (outcome != null) return Collections.<PendingEntry>emptyList();
+            outcome = how;
+            List<PendingEntry> toRun = new ArrayList<PendingEntry>();
+            for (PendingEntry pe : entries) {
+                if ((how == Outcome.COMMITTED) || ((how == Outcome.UNKNOWN) && !pe.unindex))
+                    toRun.add(pe);
+            }
+            entries.clear();
+            return toRun;
+        }
+
+        synchronized boolean isCompleted() {
+            return outcome != null;
+        }
+
+        synchronized int size() {
+            return entries.size();
+        }
+    }
+
+    // Non-throwing read of the park on an OPEN pm (the transaction need not be active: completion
+    // callbacks run after it has ended). Returns null when there is nothing there.
+    private static PendingBucket bucketOf(PersistenceManager pm) {
+        if (pm == null) return null;
+        try {
+            if (pm.isClosed()) return null;
+            Object o = pm.getUserObject(PENDING_USER_OBJECT_KEY);
+            return (o instanceof PendingBucket) ? (PendingBucket)o : null;
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    private static PersistenceManagerFactory pmfOf(PersistenceManager pm) {
+        if (pm == null) return null;
+        try {
+            return pm.getPersistenceManagerFactory();
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    /**
+     * Give this PersistenceManager a live park. Called from Shepherd.beginDBTransaction() for a
+     * freshly obtained PM; idempotent, never throws, and never replaces a LIVE park (a redundant
+     * begin on an already-active transaction must not drop what that transaction has parked).
+     * A completed park is replaced -- normally completion installs its own successor, so this is
+     * only a safety net.
+     */
+    public static void installPendingBucket(PersistenceManager pm) {
+        if (pm == null) return;
+        try {
+            if (pm.isClosed()) return;
+            PendingBucket existing = bucketOf(pm);
+            if ((existing != null) && !existing.isCompleted()) return;
+            pm.putUserObject(PENDING_USER_OBJECT_KEY, new PendingBucket(pmfOf(pm)));
+        } catch (Exception ex) {
+            System.out.println("IndexingManager.installPendingBucket() failed: " + ex);
+        }
+    }
+
+    /**
+     * Park an index/unindex request until the PersistenceManager's transaction completes.
+     *
+     * Deferral only applies while a transaction is ACTIVE on an open PM that has a park. Anything
+     * else -- no PM (transient object), closed PM, no transaction (caller already committed, e.g.
+     * IndividualRemoveEncounter), a PM Shepherd never prepared -- gets the old immediate enqueue:
+     * there is no completion coming that could release a parked request, so parking would lose it.
+     */
+    public static void addPendingEntry(PersistenceManager pm, Base base, boolean unindex) {
+        if (base == null) return;
+        String objectID = base.getId();
+        if (objectID == null) return;
+        Class myClass = base.getClass();
+        PendingBucket bucket = null;
+        try {
+            if ((pm != null) && !pm.isClosed() && pm.currentTransaction().isActive())
+                bucket = bucketOf(pm);
+        } catch (Exception ex) {
+            bucket = null;
+        }
+        if (bucket == null) {
+            enqueueNow(objectID, myClass, unindex);
+            return;
+        }
+        PendingEntry pe = new PendingEntry(objectID, myClass, unindex, dataNucleusIdentity(base));
+        if (bucket.park(pe) == ParkResult.ENQUEUE_NOW) enqueueNow(objectID, myClass, unindex);
+    }
+
+    // The DataNucleus internal identity -- the key the level-2 cache actually uses.
+    private static Object dataNucleusIdentity(Base base) {
+        if (!(base instanceof Persistable)) return null;
+        try {
+            return ((Persistable)base).dnGetObjectId();
+        } catch (Exception ex) {
+            return null; // non-fatal: we simply skip the level-2 eviction for this object
+        }
+    }
+
+    /**
+     * Step one of completion: terminalize the PM's park with this outcome, take the requests that
+     * should now run, and install a fresh live park so the PM's NEXT transaction has somewhere to
+     * park -- however it is begun (Shepherd, or a raw pm.currentTransaction().begin()). Does no
+     * external work and never throws, so it can run before any delegate Synchronization gets a
+     * chance to close the PM. Follow with drainCaptured().
+     */
+    static List<PendingEntry> capturePendingEntries(PersistenceManager pm, Outcome how) {
+        PendingBucket bucket = bucketOf(pm);
+
+        if (bucket == null) return Collections.<PendingEntry>emptyList();
+        List<PendingEntry> snapshot = bucket.complete(how);
+        try {
+            if (!pm.isClosed()) pm.putUserObject(PENDING_USER_OBJECT_KEY, new PendingBucket(bucket.pmf));
+        } catch (Exception ex) {
+            System.out.println("IndexingManager: could not install the successor park: " + ex);
+        }
+        return snapshot;
+    }
+
+    /**
+     * Step two of completion: hand each captured request to the queue. Each object is first evicted
+     * from the (PMF-wide, shared) level-2 cache by its DataNucleus identity, so no reader picks up
+     * a copy published before this commit; the indexing job itself additionally bypasses L2 (see
+     * ShepherdIndexingWork). Every step is isolated per entry: one failure never takes the rest of
+     * the snapshot down, and nothing here throws. Independent of the PM, which may be closed.
+     */
+    static void drainCaptured(List<PendingEntry> snapshot, PersistenceManagerFactory pmf) {
+        if ((snapshot == null) || snapshot.isEmpty()) return;
+        for (PendingEntry pe : snapshot) {
+            if ((pmf != null) && (pe.dnObjectId != null)) {
+                try {
+                    pmf.getDataStoreCache().evict(pe.dnObjectId);
+                } catch (Exception ex) {
+                    System.out.println("IndexingManager: level-2 evict failed for " + pe.objectID +
+                        ": " + ex);
+                }
+            }
+            try {
+                enqueueNow(pe.objectID, pe.myClass, pe.unindex);
+            } catch (Exception ex) {
+                System.out.println("IndexingManager: post-commit enqueue failed for " + pe.objectID +
+                    "; background reconciler is the backstop. " + ex);
+            }
+        }
+    }
+
+    /** capturePendingEntries() + drainCaptured(), for callers without a delegate to interleave. */
+    public static void completePendingEntries(PersistenceManager pm, Outcome how) {
+        PersistenceManagerFactory pmf = pmfOf(pm);
+
+        drainCaptured(capturePendingEntries(pm, how), pmf);
+    }
+
+    private static void enqueueNow(String objectID, Class myClass, boolean unindex) {
+        IndexingManager im = IndexingManagerFactory.getIndexingManager();
+
+        if (im == null) {
+            System.out.println("IndexingManager: no IndexingManager available; dropping request for " +
+                objectID + " (background reconciler is the backstop)");
+            return;
+        }
+        im.addIndexingQueueEntry(objectID, myClass, unindex);
     }
 
 }

--- a/src/main/java/org/ecocean/IndexingTransactionSynchronization.java
+++ b/src/main/java/org/ecocean/IndexingTransactionSynchronization.java
@@ -1,0 +1,66 @@
+package org.ecocean;
+
+import java.util.List;
+import javax.jdo.PersistenceManager;
+import javax.jdo.PersistenceManagerFactory;
+import javax.transaction.Synchronization;
+
+/**
+ * Bridges a JDO transaction's completion to the deferred-indexing park in IndexingManager.
+ *
+ * DataNucleus invokes Synchronization.afterCompletion(status) from inside Transaction.commit() and
+ * Transaction.rollback(), after its own post-commit processing, on the committing thread. That is
+ * the one moment we know how the writing transaction ended, so it is the ONLY place a park is
+ * terminalized: drained if the transaction committed, dropped if it rolled back (see
+ * IndexingManager.Outcome for the unexpected-status rule). Because the callback comes from the
+ * transaction itself, a raw pm.currentTransaction().commit() is covered exactly like
+ * Shepherd.commitDBTransaction(); nothing in Shepherd's commit/rollback/close paths is involved.
+ *
+ * JDO allows one Synchronization per Transaction, so this wraps whatever was registered before it
+ * (nothing, in Wildbook today) and keeps calling it. The order inside afterCompletion is fixed and
+ * load-bearing:
+ *   1. capture: terminalize the park, take the requests that should run, install the successor
+ *      park -- no external work, cannot throw;
+ *   2. delegate.afterCompletion(status) -- may close the PM, may throw; neither can lose the
+ *      snapshot, and a throw is logged, never propagated;
+ *   3. drain the snapshot -- level-2 eviction and queue handoff, independent of the PM.
+ * beforeCompletion() is the delegate's chance to veto the commit, so its exceptions propagate.
+ *
+ * Registered once per PersistenceManager by Shepherd.beginDBTransaction() via
+ * IndexingManager.registerSynchronization(); DataNucleus keeps the registration across the PM's
+ * successive transactions.
+ */
+public final class IndexingTransactionSynchronization implements Synchronization {
+    private final PersistenceManager pm;
+    // captured at registration: needed for level-2 eviction after a delegate may have closed pm
+    private final PersistenceManagerFactory pmf;
+    private final Synchronization delegate; // may be null
+
+    public IndexingTransactionSynchronization(PersistenceManager pm, PersistenceManagerFactory pmf,
+        Synchronization delegate) {
+        this.pm = pm;
+        this.pmf = pmf;
+        this.delegate = delegate;
+    }
+
+    @Override public void beforeCompletion() {
+        if (delegate != null) delegate.beforeCompletion(); // a veto here must reach DataNucleus
+    }
+
+    @Override public void afterCompletion(int status) {
+        IndexingManager.Outcome how = IndexingManager.outcomeOf(status);
+        List<IndexingManager.PendingEntry> snapshot = IndexingManager.capturePendingEntries(pm, how);
+
+        if (delegate != null) {
+            try {
+                delegate.afterCompletion(status);
+            } catch (RuntimeException ex) {
+                System.out.println("IndexingTransactionSynchronization: wrapped Synchronization " +
+                    delegate.getClass().getName() + " threw from afterCompletion(" + status +
+                    "); continuing with the indexing handoff. " + ex);
+                ex.printStackTrace();
+            }
+        }
+        IndexingManager.drainCaptured(snapshot, pmf);
+    }
+}

--- a/src/main/java/org/ecocean/MarkedIndividual.java
+++ b/src/main/java/org/ecocean/MarkedIndividual.java
@@ -470,7 +470,9 @@ public class MarkedIndividual extends Base implements java.io.Serializable {
     public void enqueueAclReindex() {
         if (this.getSkipAutoIndexing() || OpenSearch.skipAutoIndexing()) return;
         try {
-            IndexingManagerFactory.getIndexingManager().addIndexingQueueEntry(this, false);
+            // Deferred while this object's transaction is open -- see Encounter.enqueueAclReindex().
+            IndexingManager.addPendingEntry(javax.jdo.JDOHelper.getPersistenceManager(this), this,
+                false);
         } catch (Exception ex) {
             System.out.println("MarkedIndividual.enqueueAclReindex failed for " + this.getId() + ": " + ex);
         }

--- a/src/main/java/org/ecocean/WildbookLifecycleListener.java
+++ b/src/main/java/org/ecocean/WildbookLifecycleListener.java
@@ -1,6 +1,7 @@
 package org.ecocean;
 
 import java.io.IOException;
+import javax.jdo.JDOHelper;
 import javax.jdo.listener.*;
 import org.datanucleus.enhancement.Persistable;
 import org.ecocean.Base;
@@ -68,8 +69,14 @@ public class WildbookLifecycleListener implements StoreLifecycleListener, Delete
             try {
                 // base.opensearchIndexDeep();
                 // new way - put indexing in managed queue
-                IndexingManager im = IndexingManagerFactory.getIndexingManager();
-                im.addIndexingQueueEntry(base, false);
+                //
+                // ...but not yet. postStore fires on JDO flush/store, not on commit, and the
+                // indexing job runs on its own connection: enqueuing here let it load the row
+                // before this transaction committed and index pre-change state (silently -- an
+                // existing row reloads fine, so nothing looked wrong). Park it against this
+                // PersistenceManager instead; the transaction's completion callback
+                // (IndexingTransactionSynchronization) queues it once the commit is done.
+                IndexingManager.addPendingEntry(JDOHelper.getPersistenceManager(obj), base, false);
             } catch (Exception ex) {
                 ex.printStackTrace();
             }

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -3388,6 +3388,11 @@ public class Shepherd {
         try {
             if (pm == null || pm.isClosed())
                 pm = ShepherdPMF.getPMF(localContext).getPersistenceManager();
+            if (pm == null) {
+                System.out.println(
+                    "Shepherd.beginDBTransaction(): could not obtain a PersistenceManager");
+                return; // nothing began; do not record a "begin" state for it
+            }
             listenerRegisteredOn = prepareAndBeginTransaction(pm, listenerRegisteredOn);
             ShepherdState.setShepherdState(action + "_" + shepherdID, "begin");
         } catch (JDOUserException jdoe) {

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -68,6 +68,13 @@ public class Shepherd {
     private String action = "undefined";
     private String shepherdID = "";
 
+    // The PersistenceManager this Shepherd has already registered its WildbookLifecycleListener and
+    // indexing Synchronization on. Compared by identity: beginDBTransaction() runs again on every
+    // updateDBTransaction() (= commit + begin) and used to add ANOTHER listener each time, so one
+    // store event fanned out to N duplicate callbacks. A brand-new pm (pm was null/closed) does not
+    // match and gets registered once.
+    private PersistenceManager listenerRegisteredOn = null;
+
     // Constructor to create a new shepherd thread object
     public Shepherd(String context) { this(context, null); }
 
@@ -3379,21 +3386,42 @@ public class Shepherd {
     public void beginDBTransaction() {
         // PersistenceManagerFactory pmf = ShepherdPMF.getPMF(localContext);
         try {
-            if (pm == null || pm.isClosed()) {
+            if (pm == null || pm.isClosed())
                 pm = ShepherdPMF.getPMF(localContext).getPersistenceManager();
-                pm.currentTransaction().begin();
-            } else if (!pm.currentTransaction().isActive()) {
-                pm.currentTransaction().begin();
-            }
+            listenerRegisteredOn = prepareAndBeginTransaction(pm, listenerRegisteredOn);
             ShepherdState.setShepherdState(action + "_" + shepherdID, "begin");
-
-            pm.addInstanceLifecycleListener(new WildbookLifecycleListener(), null);
         } catch (JDOUserException jdoe) {
             jdoe.printStackTrace();
         } catch (NullPointerException npe) {
             npe.printStackTrace();
         }
         // pmf=null;
+    }
+
+    /*
+     * Register the store listener and the indexing Synchronization (once per PersistenceManager),
+     * make sure the deferred-indexing park is in place, and only THEN activate the transaction.
+     * The order is the contract: a store callback can only fire once the transaction is active,
+     * and by then it needs both the listener and a live park already there.
+     *
+     * The Synchronization is what releases parked reindex requests when the transaction completes
+     * -- it is registered on the transaction itself, so commit/rollback/close here need not know
+     * about it (and a raw pm.currentTransaction().commit() is covered too).
+     *
+     * Package-private and static so the ordering can be asserted against a mock PersistenceManager
+     * without standing up a datastore. Returns the pm the registrations now belong to.
+     */
+    static PersistenceManager prepareAndBeginTransaction(PersistenceManager pm,
+        PersistenceManager listenerRegisteredOn) {
+        if (pm == null) return listenerRegisteredOn;
+        if (listenerRegisteredOn != pm) {
+            pm.addInstanceLifecycleListener(new WildbookLifecycleListener(), null);
+            IndexingManager.registerSynchronization(pm);
+            listenerRegisteredOn = pm;
+        }
+        IndexingManager.installPendingBucket(pm);
+        if (!pm.currentTransaction().isActive()) pm.currentTransaction().begin();
+        return listenerRegisteredOn;
     }
 
     public boolean isDBTransactionActive() {

--- a/src/test/java/org/ecocean/ChildReindexTriggerTest.java
+++ b/src/test/java/org/ecocean/ChildReindexTriggerTest.java
@@ -1,7 +1,9 @@
 package org.ecocean;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -11,15 +13,29 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jdo.JDOHelper;
+import javax.jdo.PersistenceManager;
+import javax.jdo.PersistenceManagerFactory;
+import javax.jdo.Transaction;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.mockito.invocation.InvocationOnMock;
 
 /**
  * Model-level unit tests for the child-reindex membership hooks (Spec-A Task 7).
  * Verifies that encounter<->individual membership changes enqueue a deep reindex of the
  * affected encounter + old/new individuals via IndexingManager, and that skipAutoIndexing
  * suppresses the enqueue (so bulk import / deserialization do not storm the queue).
+ *
+ * enqueueAclReindex() routes through IndexingManager.addPendingEntry(), which PARKS the request
+ * while the object's PersistenceManager has an active transaction and releases it when that
+ * transaction completes. The objects here are transient (no PersistenceManager), so they take the
+ * immediate fallback and land on the (id, class, unindex) overload -- same request, different
+ * signature. The two tests at the bottom pin the parked path with a stubbed PersistenceManager.
  *
  * The ACL-propagation path inside Encounter.opensearchIndexPermissions() requires a live
  * Shepherd + OpenSearch and is covered by the Task 9 integration test, not here.
@@ -50,8 +66,10 @@ class ChildReindexTriggerTest {
     @Test void setIndividual_enqueuesEncounterAndOldIndividual() throws Exception {
         Encounter enc = spy(new Encounter());
         enc.setSkipAutoIndexing(false);
+        enc.setCatalogNumber("enc-0"); // a request needs an id; nothing is enqueued for id-less objects
         MarkedIndividual oldInd = spy(new MarkedIndividual());
         oldInd.setSkipAutoIndexing(false);
+        oldInd.setIndividualID("ind-old");
         setIndividualField(enc, oldInd);
         MarkedIndividual newInd = mock(MarkedIndividual.class);
 
@@ -62,17 +80,19 @@ class ChildReindexTriggerTest {
             enc.setIndividual(newInd);
         }
         // enc (its new individual + annotations refresh via deep index)
-        verify(im).addIndexingQueueEntry(eq(enc), eq(false));
+        verify(im).addIndexingQueueEntry(eq("enc-0"), eq(Encounter.class), eq(false));
         // old individual the encounter left
-        verify(im).addIndexingQueueEntry(eq(oldInd), eq(false));
+        verify(im).addIndexingQueueEntry(eq("ind-old"), eq(MarkedIndividual.class), eq(false));
     }
 
     // skipAutoIndexing on the encounter (and old individual) suppresses all enqueues.
     @Test void setIndividual_skipAutoIndexing_noEnqueue() throws Exception {
         Encounter enc = spy(new Encounter());
         enc.setSkipAutoIndexing(true);
+        enc.setCatalogNumber("enc-skip");
         MarkedIndividual oldInd = spy(new MarkedIndividual());
         oldInd.setSkipAutoIndexing(true); // both skip => assert NO enqueue at all
+        oldInd.setIndividualID("ind-skip");
         setIndividualField(enc, oldInd);
         MarkedIndividual newInd = mock(MarkedIndividual.class);
 
@@ -82,13 +102,15 @@ class ChildReindexTriggerTest {
             factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
             enc.setIndividual(newInd);
         }
-        verify(im, never()).addIndexingQueueEntry(any(), anyBoolean());
+        verify(im, never()).addIndexingQueueEntry(any(Base.class), anyBoolean());
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
     }
 
     // MarkedIndividual.removeEncounter enqueues the individual AND the departed encounter.
     @Test void removeEncounter_enqueuesIndividualAndEncounter() throws Exception {
         MarkedIndividual ind = spy(new MarkedIndividual());
         ind.setSkipAutoIndexing(false);
+        ind.setIndividualID("ind-1");
         Encounter enc = spy(new Encounter());
         enc.setSkipAutoIndexing(false);
         enc.setCatalogNumber("enc-1");
@@ -101,14 +123,15 @@ class ChildReindexTriggerTest {
             factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
             ind.removeEncounter(enc);
         }
-        verify(im).addIndexingQueueEntry(eq(ind), eq(false));
-        verify(im).addIndexingQueueEntry(eq(enc), eq(false));
+        verify(im).addIndexingQueueEntry(eq("ind-1"), eq(MarkedIndividual.class), eq(false));
+        verify(im).addIndexingQueueEntry(eq("enc-1"), eq(Encounter.class), eq(false));
     }
 
     // MarkedIndividual.addEncounter enqueues the joining encounter.
     @Test void addEncounter_enqueuesEncounter() throws Exception {
         MarkedIndividual ind = spy(new MarkedIndividual());
         ind.setSkipAutoIndexing(false);
+        ind.setIndividualID("ind-2");
         Encounter enc = spy(new Encounter());
         enc.setSkipAutoIndexing(false);
         enc.setCatalogNumber("enc-2");
@@ -119,6 +142,71 @@ class ChildReindexTriggerTest {
             factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
             ind.addEncounter(enc);
         }
-        verify(im).addIndexingQueueEntry(eq(enc), eq(false));
+        verify(im).addIndexingQueueEntry(eq("enc-2"), eq(Encounter.class), eq(false));
+    }
+
+    // ---- the parked path ----------------------------------------------------------------------
+
+    private static PersistenceManager preparedPm() {
+        PersistenceManager pm = mock(PersistenceManager.class);
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        Transaction tx = mock(Transaction.class);
+        final Map<Object, Object> userObjects = new HashMap<Object, Object>();
+
+        when(tx.isActive()).thenReturn(true);
+        when(pm.currentTransaction()).thenReturn(tx);
+        when(pm.isClosed()).thenReturn(false);
+        when(pm.getPersistenceManagerFactory()).thenReturn(pmf);
+        when(pm.getUserObject(any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.get(inv.getArgument(0)));
+        when(pm.putUserObject(any(), any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.put(inv.getArgument(0), inv.getArgument(1)));
+        IndexingManager.installPendingBucket(pm);
+        return pm;
+    }
+
+    private static int parked(PersistenceManager pm) {
+        return ((IndexingManager.PendingBucket)pm.getUserObject(
+            IndexingManager.PENDING_USER_OBJECT_KEY)).size();
+    }
+
+    // Inside a transaction the request must wait for the commit: parked, not enqueued.
+    @Test void enqueueAclReindex_parksWhileTheObjectsTransactionIsActive() {
+        PersistenceManager pm = preparedPm();
+        Encounter enc = new Encounter();
+        enc.setSkipAutoIndexing(false);
+        enc.setCatalogNumber("enc-parked");
+
+        IndexingManager im = mock(IndexingManager.class);
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockNoGlobalSkip();
+            MockedStatic<JDOHelper> jdo = mockStatic(JDOHelper.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            jdo.when(() -> JDOHelper.getPersistenceManager(enc)).thenReturn(pm);
+            enc.enqueueAclReindex();
+        }
+        verify(im, never()).addIndexingQueueEntry(any(Base.class), anyBoolean());
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+        assertEquals(1, parked(pm));
+    }
+
+    // The permissions pass runs in a read transaction that is ROLLED BACK at the end; parking
+    // there would drop the request. It uses the Now flavor, which enqueues immediately.
+    @Test void enqueueAclReindexNow_enqueuesImmediatelyEvenInsideATransaction() {
+        PersistenceManager pm = preparedPm();
+        Encounter enc = new Encounter();
+        enc.setSkipAutoIndexing(false);
+        enc.setCatalogNumber("enc-now");
+
+        IndexingManager im = mock(IndexingManager.class);
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockNoGlobalSkip();
+            MockedStatic<JDOHelper> jdo = mockStatic(JDOHelper.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            jdo.when(() -> JDOHelper.getPersistenceManager(enc)).thenReturn(pm);
+            enc.enqueueAclReindexNow();
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-now"), eq(Encounter.class), eq(false));
+        assertEquals(0, parked(pm));
     }
 }

--- a/src/test/java/org/ecocean/IndexingJobWiringTest.java
+++ b/src/test/java/org/ecocean/IndexingJobWiringTest.java
@@ -1,0 +1,189 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.jdo.JDOObjectNotFoundException;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * IndexingManagerRequeueTest marks "the job finished" by hand. This test proves the job itself
+ * does so on every outcome: it runs a real IndexingJob on the test thread with its datastore and
+ * index access replaced by a fake IndexingWork, then asserts on what the scheduler and the public
+ * queue saw. No Shepherd, no datastore, no OpenSearch.
+ */
+class IndexingJobWiringTest {
+    /** Scripted stand-in for "open a Shepherd, load by id, index, close". */
+    private static final class FakeWork implements IndexingManager.IndexingWork {
+        Base toLoad;                         // null => throw JDOObjectNotFoundException from load()
+        final RuntimeException indexFailure; // non-null => index() throws it
+        final List<String> events = new ArrayList<String>();
+
+        FakeWork(Base toLoad, RuntimeException indexFailure) {
+            this.toLoad = toLoad;
+            this.indexFailure = indexFailure;
+        }
+
+        public Base load(Class myClass, String objectID) {
+            events.add("load");
+            if (toLoad == null) throw new JDOObjectNotFoundException("not visible: " + objectID);
+            return toLoad;
+        }
+
+        public void index(Base base, boolean unindex) {
+            events.add(unindex ? "unindex" : "index");
+            if (indexFailure != null) throw indexFailure;
+        }
+
+        public void close() {
+            events.add("close");
+        }
+    }
+
+    private static IndexingManager managerUsing(ScheduledExecutorService exec, FakeWork work) {
+        return new IndexingManager(exec) {
+            @Override IndexingManager.IndexingWork newIndexingWork(String objectID) {
+                return work;
+            }
+        };
+    }
+
+    private static List<Runnable> scheduled(ScheduledExecutorService exec, int expected) {
+        ArgumentCaptor<Runnable> cap = ArgumentCaptor.forClass(Runnable.class);
+
+        verify(exec, times(expected)).schedule(cap.capture(), anyLong(), any(TimeUnit.class));
+        return cap.getAllValues();
+    }
+
+    private static Encounter encounter(String id) {
+        Encounter enc = new Encounter();
+
+        enc.setCatalogNumber(id);
+        return enc;
+    }
+
+    @Test void successfulJob_indexesThenReleasesTheId_andCloses() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        FakeWork work = new FakeWork(encounter("enc-ok"), null);
+        IndexingManager im = managerUsing(exec, work);
+
+        im.addIndexingQueueEntry("enc-ok", Encounter.class, false);
+        scheduled(exec, 1).get(0).run();
+
+        assertEquals(List.of("load", "index", "close"), work.events);
+        assertFalse(im.getIndexingQueue().contains("enc-ok"), "terminal success releases the id");
+        scheduled(exec, 1); // nothing further
+    }
+
+    @Test void unindexJob_callsUnindex() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        FakeWork work = new FakeWork(encounter("enc-un"), null);
+        IndexingManager im = managerUsing(exec, work);
+
+        im.addIndexingQueueEntry("enc-un", Encounter.class, true);
+        scheduled(exec, 1).get(0).run();
+        assertEquals(List.of("load", "unindex", "close"), work.events);
+    }
+
+    // The whole point of the follow-up: a request that arrives while the job is running must run
+    // once more after it, because the running job may have loaded pre-commit state.
+    @Test void successfulJob_withARequestRecordedWhileRunning_schedulesExactlyOneFollowUp() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        FakeWork work = new FakeWork(encounter("enc-again"), null);
+        IndexingManager im = managerUsing(exec, work);
+
+        im.addIndexingQueueEntry("enc-again", Encounter.class, false);
+        Runnable job = scheduled(exec, 1).get(0);
+
+        im.addIndexingQueueEntry("enc-again", Encounter.class, false); // arrives "while running"
+        job.run();
+
+        List<Runnable> all = scheduled(exec, 2);
+        IndexingManager.IndexingJob followUp = (IndexingManager.IndexingJob)all.get(1);
+        assertEquals("enc-again", followUp.objectID);
+        assertEquals(1, followUp.attempt, "a follow-up is a fresh pass");
+        assertTrue(im.getIndexingQueue().contains("enc-again"), "still queued until the follow-up ends");
+
+        followUp.run();
+        scheduled(exec, 2);
+        assertFalse(im.getIndexingQueue().contains("enc-again"));
+    }
+
+    // A genuine indexing failure is terminal: the id is released (the reconciler is the backstop)
+    // and a remembered follow-up still runs -- it may well succeed.
+    @Test void indexingFailure_isTerminal_releasesOrRunsFollowUp_andCloses() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        FakeWork work = new FakeWork(encounter("enc-fail"), new RuntimeException("opensearch down"));
+        IndexingManager im = managerUsing(exec, work);
+
+        im.addIndexingQueueEntry("enc-fail", Encounter.class, false);
+        scheduled(exec, 1).get(0).run();
+        assertEquals(List.of("load", "index", "close"), work.events);
+        assertFalse(im.getIndexingQueue().contains("enc-fail"), "failure is terminal");
+
+        // and with a follow-up recorded:
+        im.addIndexingQueueEntry("enc-fail", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-fail", Encounter.class, false);
+        scheduled(exec, 2).get(1).run();
+        scheduled(exec, 3); // the follow-up
+        assertTrue(im.getIndexingQueue().contains("enc-fail"));
+    }
+
+    // "Row not visible" is NOT terminal below the retry limit: schedule attempt+1, keep the id
+    // queued, and do NOT consume a remembered follow-up yet.
+    @Test void rowNotVisible_schedulesARetry_keepsTheIdAndTheFollowUp_andCloses() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        FakeWork work = new FakeWork(null, null); // load() throws JDOObjectNotFoundException
+        IndexingManager im = managerUsing(exec, work);
+
+        im.addIndexingQueueEntry("enc-late", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-late", Encounter.class, false); // follow-up recorded
+        Runnable first = scheduled(exec, 1).get(0);
+
+        first.run();
+        assertEquals(List.of("load", "close"), work.events, "close runs even on the not-found path");
+
+        List<Runnable> all = scheduled(exec, 2);
+        IndexingManager.IndexingJob retry = (IndexingManager.IndexingJob)all.get(1);
+        assertEquals(2, retry.attempt, "a retry, not a follow-up");
+        assertTrue(im.getIndexingQueue().contains("enc-late"));
+
+        // the retry finds the row (the writer committed meanwhile): success, and only NOW does
+        // the remembered follow-up run
+        work.toLoad = encounter("enc-late");
+        retry.run();
+        assertEquals(List.of("load", "close", "load", "index", "close"), work.events);
+        IndexingManager.IndexingJob followUp = (IndexingManager.IndexingJob)scheduled(exec, 3).get(2);
+        assertEquals(1, followUp.attempt, "a follow-up is a fresh pass, not attempt 3");
+        assertTrue(im.getIndexingQueue().contains("enc-late"));
+
+        followUp.run();
+        scheduled(exec, 3);
+        assertFalse(im.getIndexingQueue().contains("enc-late"));
+    }
+
+    // A missing row on the UNINDEX path is terminal immediately (nothing to unindex).
+    @Test void rowNotVisibleForUnindex_isTerminal() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        FakeWork work = new FakeWork(null, null);
+        IndexingManager im = managerUsing(exec, work);
+
+        im.addIndexingQueueEntry("enc-gone", Encounter.class, true);
+        scheduled(exec, 1).get(0).run();
+        assertFalse(im.getIndexingQueue().contains("enc-gone"));
+        scheduled(exec, 1);
+    }
+}

--- a/src/test/java/org/ecocean/IndexingManagerRequeueTest.java
+++ b/src/test/java/org/ecocean/IndexingManagerRequeueTest.java
@@ -1,0 +1,176 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * The indexing queue dedupes by object id. On main a second request for an id whose job is
+ * already scheduled or running is simply DROPPED. That is wrong whenever the in-flight job may
+ * have loaded the object before the change behind the second request was committed: the second
+ * request is precisely the one that would index the right state.
+ *
+ * These tests pin the replacement behavior: a second request is remembered and runs as exactly
+ * one follow-up pass once the in-flight job reaches a terminal outcome (success, failure, or
+ * retry give-up). Only observable behavior is asserted: what gets handed to the scheduler and
+ * what is in the public queue. No job ever runs -- the scheduler is a mock, so nothing touches a
+ * datastore.
+ */
+class IndexingManagerRequeueTest {
+    private static IndexingManager managerWith(ScheduledExecutorService exec) {
+        return new IndexingManager(exec);
+    }
+
+    private static void assertScheduledCount(ScheduledExecutorService exec, int expected) {
+        verify(exec, times(expected)).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+    }
+
+    @Test void secondRequestWhileInFlight_runsExactlyOneFollowUpWhenTheJobFinishes() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        IndexingManager im = managerWith(exec);
+
+        im.addIndexingQueueEntry("enc-race-1", Encounter.class, false);
+        assertTrue(im.getIndexingQueue().contains("enc-race-1"), "first request takes the slot");
+        assertScheduledCount(exec, 1);
+
+        // the change behind this second request may have committed AFTER the first job loaded
+        im.addIndexingQueueEntry("enc-race-1", Encounter.class, false);
+        assertScheduledCount(exec, 1); // deduped: still only the first job is scheduled
+
+        im.finishIndexingJob("enc-race-1"); // first job reaches a terminal outcome
+        assertScheduledCount(exec, 2); // ...so the remembered request runs as a follow-up pass
+        assertTrue(im.getIndexingQueue().contains("enc-race-1"),
+            "id stays queued across the follow-up so concurrent requests keep deduping");
+
+        im.finishIndexingJob("enc-race-1"); // follow-up finishes; nothing newer arrived
+        assertScheduledCount(exec, 2);
+        assertFalse(im.getIndexingQueue().contains("enc-race-1"), "id released once clean");
+    }
+
+    @Test void threeRequestsWhileInFlight_collapseToOneFollowUp() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        IndexingManager im = managerWith(exec);
+
+        im.addIndexingQueueEntry("enc-race-2", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-race-2", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-race-2", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-race-2", Encounter.class, false);
+        assertScheduledCount(exec, 1);
+
+        im.finishIndexingJob("enc-race-2");
+        assertScheduledCount(exec, 2); // one follow-up describes the final state; not three
+
+        im.finishIndexingJob("enc-race-2");
+        assertScheduledCount(exec, 2);
+        assertFalse(im.getIndexingQueue().contains("enc-race-2"));
+    }
+
+    // The retry give-up path is a terminal outcome too. A request that arrived while the job was
+    // burning "row not visible" retries is exactly the one that CAN succeed now.
+    @Test void giveUpAfterMaxAttempts_stillRunsTheFollowUp() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        IndexingManager im = managerWith(exec);
+
+        im.addIndexingQueueEntry("enc-giveup-1", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-giveup-1", Encounter.class, false);
+        assertScheduledCount(exec, 1);
+
+        im.handleObjectNotFound("enc-giveup-1", Encounter.class, false,
+            IndexingManager.MAX_INDEXING_ATTEMPTS);
+        assertScheduledCount(exec, 2); // the follow-up, not another retry
+        assertTrue(im.getIndexingQueue().contains("enc-giveup-1"));
+
+        im.finishIndexingJob("enc-giveup-1");
+        assertFalse(im.getIndexingQueue().contains("enc-giveup-1"));
+    }
+
+    // A retry that is NOT yet at the limit must keep retrying and must NOT consume the follow-up.
+    @Test void retryBelowMaxAttempts_reschedulesAndKeepsTheFollowUp() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        IndexingManager im = managerWith(exec);
+
+        im.addIndexingQueueEntry("enc-retry-1", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-retry-1", Encounter.class, false);
+        assertScheduledCount(exec, 1);
+
+        im.handleObjectNotFound("enc-retry-1", Encounter.class, false, 1);
+        assertScheduledCount(exec, 2); // the retry
+
+        im.finishIndexingJob("enc-retry-1"); // the retry eventually succeeds
+        assertScheduledCount(exec, 3); // and only now does the follow-up run
+        im.finishIndexingJob("enc-retry-1");
+        assertScheduledCount(exec, 3);
+        assertFalse(im.getIndexingQueue().contains("enc-retry-1"));
+    }
+
+    // Hard release (used when the executor rejects work, and by the queue reset) drops the
+    // follow-up along with the id. Otherwise a later request for the same id would find a stale
+    // follow-up and run one pass too many -- or worse, an unindex that no longer applies.
+    @Test void hardRemove_dropsTheFollowUpWithTheId() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        IndexingManager im = managerWith(exec);
+
+        im.addIndexingQueueEntry("enc-hard-1", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-hard-1", Encounter.class, false);
+        assertScheduledCount(exec, 1);
+
+        im.removeIndexingQueueEntry("enc-hard-1");
+        assertFalse(im.getIndexingQueue().contains("enc-hard-1"));
+
+        // a brand-new request must behave like a first request: one job, no phantom follow-up
+        im.addIndexingQueueEntry("enc-hard-1", Encounter.class, false);
+        assertScheduledCount(exec, 2);
+        im.finishIndexingJob("enc-hard-1");
+        assertScheduledCount(exec, 2);
+        assertFalse(im.getIndexingQueue().contains("enc-hard-1"));
+    }
+
+    @Test void resetQueue_dropsAllFollowUps() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        IndexingManager im = managerWith(exec);
+
+        im.addIndexingQueueEntry("enc-reset-1", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-reset-1", Encounter.class, false);
+        im.resetIndexingQueuehWithInitialCapacity(10);
+        assertFalse(im.getIndexingQueue().contains("enc-reset-1"));
+
+        im.addIndexingQueueEntry("enc-reset-1", Encounter.class, false);
+        assertScheduledCount(exec, 2);
+        im.finishIndexingJob("enc-reset-1");
+        assertScheduledCount(exec, 2); // no phantom follow-up survived the reset
+    }
+
+    // The newest request wins: an index followed by an unindex for the same id must run the
+    // UNINDEX as the follow-up, because it describes the object's final state.
+    @Test void followUpCarriesTheNewestRequest() {
+        ScheduledExecutorService exec = mock(ScheduledExecutorService.class);
+        IndexingManager im = managerWith(exec);
+
+        im.addIndexingQueueEntry("enc-newest-1", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-newest-1", Encounter.class, false);
+        im.addIndexingQueueEntry("enc-newest-1", Encounter.class, true);
+        im.finishIndexingJob("enc-newest-1");
+
+        ArgumentCaptor<Runnable> jobs = ArgumentCaptor.forClass(Runnable.class);
+        verify(exec, times(2)).schedule(jobs.capture(), anyLong(), any(TimeUnit.class));
+        IndexingManager.IndexingJob first = (IndexingManager.IndexingJob)jobs.getAllValues().get(0);
+        IndexingManager.IndexingJob followUp =
+            (IndexingManager.IndexingJob)jobs.getAllValues().get(1);
+        assertFalse(first.unindex, "the first job is the original index request");
+        assertTrue(followUp.unindex,
+            "follow-up must carry the newest request (unindex), not the first remembered one");
+        assertEquals("enc-newest-1", followUp.objectID);
+        assertEquals(1, followUp.attempt, "a follow-up is a fresh pass, not a retry");
+    }
+}

--- a/src/test/java/org/ecocean/IndexingPendingParkTest.java
+++ b/src/test/java/org/ecocean/IndexingPendingParkTest.java
@@ -1,0 +1,574 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.jdo.PersistenceManager;
+import javax.jdo.PersistenceManagerFactory;
+import javax.jdo.Transaction;
+import javax.jdo.datastore.DataStoreCache;
+import javax.transaction.Status;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.MockedStatic;
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ * The per-PersistenceManager park for reindex requests raised inside a transaction.
+ *
+ * WildbookLifecycleListener.postStore() fires on JDO flush, not on commit. Enqueuing there let the
+ * background indexer -- which opens its own connection -- read and index pre-commit state. So a
+ * request is now PARKED against the writing PM and released only by the transaction's completion
+ * callback (IndexingTransactionSynchronization): drained if the transaction committed, dropped if
+ * it rolled back.
+ *
+ * Two layers are tested. PendingBucket is the state machine; it is tested directly because a late
+ * parker that read the bucket reference just before completion is exactly "a thread holding the
+ * bucket object", and that race is not reachable through the PM-level statics in a unit test. The
+ * PM-level statics are then tested for their wiring: user-object map, transaction state, successor
+ * installation, level-2 eviction by DataNucleus identity, per-entry failure isolation, and the
+ * immediate fallback. No datastore anywhere.
+ */
+class IndexingPendingParkTest {
+    /** A PersistenceManager stub whose user-object map actually behaves like one. */
+    private static PersistenceManager pmWithUserObjects(PersistenceManagerFactory pmf,
+        Transaction tx) {
+        PersistenceManager pm = mock(PersistenceManager.class);
+        final Map<Object, Object> userObjects = new HashMap<Object, Object>();
+
+        when(pm.currentTransaction()).thenReturn(tx);
+        when(pm.isClosed()).thenReturn(false);
+        when(pm.getPersistenceManagerFactory()).thenReturn(pmf);
+        when(pm.getUserObject(any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.get(inv.getArgument(0)));
+        when(pm.putUserObject(any(), any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.put(inv.getArgument(0), inv.getArgument(1)));
+        when(pm.removeUserObject(any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.remove(inv.getArgument(0)));
+        return pm;
+    }
+
+    private static Transaction activeTx() {
+        Transaction tx = mock(Transaction.class);
+
+        when(tx.isActive()).thenReturn(true);
+        return tx;
+    }
+
+    // a PM that Shepherd has already prepared: park installed, transaction open
+    private static PersistenceManager preparedPm(PersistenceManagerFactory pmf) {
+        PersistenceManager pm = pmWithUserObjects(pmf, activeTx());
+
+        IndexingManager.installPendingBucket(pm);
+        assertNotNull(pm.getUserObject(IndexingManager.PENDING_USER_OBJECT_KEY),
+            "precondition: park installed on the PM");
+        return pm;
+    }
+
+    private static IndexingManager.PendingBucket bucketOf(PersistenceManager pm) {
+        return (IndexingManager.PendingBucket)pm.getUserObject(
+            IndexingManager.PENDING_USER_OBJECT_KEY);
+    }
+
+    private static Encounter encounterWithId(String id) {
+        Encounter enc = new Encounter();
+
+        enc.setCatalogNumber(id);
+        enc.setSkipAutoIndexing(false);
+        return enc;
+    }
+
+    private static IndexingManager.PendingEntry entry(String id, boolean unindex) {
+        return new IndexingManager.PendingEntry(id, Encounter.class, unindex, null);
+    }
+
+    // ---- Outcome mapping -----------------------------------------------------------------------
+
+    @Test void outcomeOf_mapsJtaStatusExplicitly() {
+        assertEquals(IndexingManager.Outcome.COMMITTED,
+            IndexingManager.outcomeOf(Status.STATUS_COMMITTED));
+        assertEquals(IndexingManager.Outcome.ROLLED_BACK,
+            IndexingManager.outcomeOf(Status.STATUS_ROLLEDBACK));
+        // DataNucleus only ever reports the two above; anything else is evidence we must not
+        // silently treat as a proven commit OR a proven rollback
+        assertEquals(IndexingManager.Outcome.UNKNOWN, IndexingManager.outcomeOf(Status.STATUS_UNKNOWN));
+        assertEquals(IndexingManager.Outcome.UNKNOWN, IndexingManager.outcomeOf(Status.STATUS_ACTIVE));
+        assertEquals(IndexingManager.Outcome.UNKNOWN,
+            IndexingManager.outcomeOf(Status.STATUS_NO_TRANSACTION));
+    }
+
+    // ---- PendingBucket: the state machine ------------------------------------------------------
+
+    @Test void bucket_parksUntilCompleted_thenCommittedCompletionHandsBackEverything() {
+        IndexingManager.PendingBucket b = new IndexingManager.PendingBucket(null);
+
+        assertEquals(IndexingManager.ParkResult.PARKED, b.park(entry("a", false)));
+        assertEquals(IndexingManager.ParkResult.PARKED, b.park(entry("b", false)));
+        assertFalse(b.isCompleted());
+        assertEquals(2, b.size());
+
+        List<IndexingManager.PendingEntry> drained = b.complete(IndexingManager.Outcome.COMMITTED);
+        assertTrue(b.isCompleted());
+        assertEquals(2, drained.size());
+        assertEquals("a", drained.get(0).objectID);
+        assertEquals("b", drained.get(1).objectID);
+        assertEquals(0, b.size(), "completion takes the contents");
+    }
+
+    @Test void bucket_rolledBackCompletion_handsBackNothing() {
+        IndexingManager.PendingBucket b = new IndexingManager.PendingBucket(null);
+
+        b.park(entry("a", false));
+        List<IndexingManager.PendingEntry> drained = b.complete(IndexingManager.Outcome.ROLLED_BACK);
+        assertTrue(b.isCompleted());
+        assertTrue(drained.isEmpty(), "nothing committed, so nothing to index");
+    }
+
+    // An outcome we cannot interpret must not silently drop evidence, and must never run an
+    // ambiguous unindex: index requests are harmless (the job re-reads the database), so they run.
+    @Test void bucket_unknownCompletion_handsBackOnlyIndexRequests() {
+        IndexingManager.PendingBucket b = new IndexingManager.PendingBucket(null);
+
+        b.park(entry("idx", false));
+        b.park(entry("gone", true));
+        List<IndexingManager.PendingEntry> drained = b.complete(IndexingManager.Outcome.UNKNOWN);
+        assertEquals(1, drained.size());
+        assertEquals("idx", drained.get(0).objectID);
+        assertFalse(drained.get(0).unindex);
+    }
+
+    // postStore fires many times per transaction; repeated parks of one request must collapse.
+    @Test void bucket_collapsesDuplicateParks_butKeepsDistinctRequests() {
+        IndexingManager.PendingBucket b = new IndexingManager.PendingBucket(null);
+
+        b.park(entry("a", false));
+        b.park(entry("a", false));
+        b.park(entry("a", false));
+        b.park(entry("a", true)); // an unindex for the same id is a different request
+        assertEquals(2, b.complete(IndexingManager.Outcome.COMMITTED).size());
+    }
+
+    // A parker that grabbed the bucket just before the transaction completed must not add to a
+    // bucket nobody will look at again. Committed: the change is durable, run now. Rolled back:
+    // drop. Unknown: index runs now, unindex is dropped.
+    @Test void bucket_lateParkAfterCommittedCompletion_saysEnqueueNow() {
+        IndexingManager.PendingBucket b = new IndexingManager.PendingBucket(null);
+
+        b.complete(IndexingManager.Outcome.COMMITTED);
+        assertEquals(IndexingManager.ParkResult.ENQUEUE_NOW, b.park(entry("late", false)));
+        assertEquals(IndexingManager.ParkResult.ENQUEUE_NOW, b.park(entry("late", true)));
+        assertEquals(0, b.size(), "a late request is never retained");
+    }
+
+    @Test void bucket_lateParkAfterRolledBackCompletion_saysDrop() {
+        IndexingManager.PendingBucket b = new IndexingManager.PendingBucket(null);
+
+        b.complete(IndexingManager.Outcome.ROLLED_BACK);
+        assertEquals(IndexingManager.ParkResult.DROP, b.park(entry("late", false)));
+        assertEquals(IndexingManager.ParkResult.DROP, b.park(entry("late", true)));
+    }
+
+    @Test void bucket_lateParkAfterUnknownCompletion_runsIndexDropsUnindex() {
+        IndexingManager.PendingBucket b = new IndexingManager.PendingBucket(null);
+
+        b.complete(IndexingManager.Outcome.UNKNOWN);
+        assertEquals(IndexingManager.ParkResult.ENQUEUE_NOW, b.park(entry("late", false)));
+        assertEquals(IndexingManager.ParkResult.DROP, b.park(entry("late", true)));
+    }
+
+    @Test void bucket_firstCompletionOutcomeSticks() {
+        IndexingManager.PendingBucket b = new IndexingManager.PendingBucket(null);
+
+        b.park(entry("a", false));
+        assertEquals(1, b.complete(IndexingManager.Outcome.COMMITTED).size());
+        assertTrue(b.complete(IndexingManager.Outcome.COMMITTED).isEmpty(), "idempotent");
+        assertTrue(b.complete(IndexingManager.Outcome.ROLLED_BACK).isEmpty(),
+            "a later rollback signal cannot un-commit");
+        assertEquals(IndexingManager.ParkResult.ENQUEUE_NOW, b.park(entry("late", false)),
+            "the first completion outcome (committed) is the one that sticks");
+    }
+
+    // ---- PM-level wiring ----------------------------------------------------------------------
+
+    // Parking must NOT enqueue -- the transaction has not committed yet.
+    @Test void addPendingEntry_parksWithoutEnqueuing() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-park-1"), false);
+        }
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+        verify(im, never()).addIndexingQueueEntry(any(Base.class), anyBoolean());
+        assertEquals(1, bucketOf(pm).size(), "the request is parked, not lost");
+    }
+
+    // The level-2 cache is keyed by DataNucleus's INTERNAL identity, not the javax.jdo.identity.*
+    // object JDOHelper.getObjectId() returns -- evicting with the latter silently misses. The park
+    // must capture Persistable.dnGetObjectId() and evict with that, BEFORE enqueuing.
+    @Test void completeCommitted_evictsDataNucleusIdentityThenEnqueuesByIdentity() {
+        DataStoreCache l2 = mock(DataStoreCache.class);
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+
+        when(pmf.getDataStoreCache()).thenReturn(l2);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager im = mock(IndexingManager.class);
+        Object dnId = new Object();
+        Encounter enc = spy(encounterWithId("enc-drain-1")); // transient: no real identity, stub it
+        doReturn(dnId).when(enc).dnGetObjectId();
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, enc, false);
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.COMMITTED);
+        }
+        InOrder inOrder = inOrder(l2, im);
+
+        inOrder.verify(l2).evict(dnId);
+        inOrder.verify(im).addIndexingQueueEntry(eq("enc-drain-1"), eq(Encounter.class), eq(false));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test void completeRolledBack_enqueuesNothing() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-rb-1"), false);
+            assertEquals(1, bucketOf(pm).size(), "precondition: something was actually parked");
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.ROLLED_BACK);
+        }
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+    }
+
+    @Test void completeUnknown_enqueuesIndexRequestsOnly() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-unk-idx"), false);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-unk-gone"), true);
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.UNKNOWN);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-unk-idx"), eq(Encounter.class), eq(false));
+        verify(im, never()).addIndexingQueueEntry(eq("enc-unk-gone"), any(), anyBoolean());
+    }
+
+    // A level-2 cache that throws must not stop the object from being indexed.
+    @Test void completeCommitted_evictFailure_stillEnqueues() {
+        DataStoreCache l2 = mock(DataStoreCache.class);
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+
+        when(pmf.getDataStoreCache()).thenReturn(l2);
+        doThrow(new RuntimeException("boom")).when(l2).evict(any());
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager im = mock(IndexingManager.class);
+        Encounter enc = spy(encounterWithId("enc-evictfail-1"));
+        doReturn(new Object()).when(enc).dnGetObjectId();
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, enc, false);
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.COMMITTED);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-evictfail-1"), eq(Encounter.class), eq(false));
+    }
+
+    // One failing handoff must not take the rest of the snapshot down with it, and must not stop
+    // the successor park from being installed.
+    @Test void completeCommitted_oneEnqueueThrows_othersStillEnqueue_andSuccessorIsInstalled() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager.PendingBucket first = bucketOf(pm);
+        IndexingManager im = mock(IndexingManager.class);
+
+        doThrow(new RuntimeException("queue exploded")).when(im).addIndexingQueueEntry(
+            eq("enc-boom"), any(), anyBoolean());
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-boom"), false);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-fine"), false);
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.COMMITTED);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-fine"), eq(Encounter.class), eq(false));
+        assertNotSame(first, bucketOf(pm), "successor installed despite the failure");
+        assertFalse(bucketOf(pm).isCompleted());
+    }
+
+    // No IndexingManager at all (factory initialization failed) must not throw out of completion.
+    @Test void completeCommitted_nullIndexingManager_doesNotThrow() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(null);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-nomgr"), false);
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.COMMITTED);
+        }
+        assertFalse(bucketOf(pm).isCompleted(), "a fresh park is in place regardless");
+    }
+
+    // The successor park must be installed BEFORE any external handoff work, so a failure there
+    // (or a delegate that runs in between) can never leave the PM without a live park.
+    @Test void capture_installsSuccessorBeforeReturning_andDrainIsIndependentOfThePm() {
+        DataStoreCache l2 = mock(DataStoreCache.class);
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+
+        when(pmf.getDataStoreCache()).thenReturn(l2);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager.PendingBucket first = bucketOf(pm);
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-cap-1"), false);
+
+            List<IndexingManager.PendingEntry> snapshot =
+                IndexingManager.capturePendingEntries(pm, IndexingManager.Outcome.COMMITTED);
+            assertEquals(1, snapshot.size());
+            assertTrue(first.isCompleted());
+            assertNotSame(first, bucketOf(pm), "successor already installed");
+            verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+
+            // simulate a delegate closing the PM in between: the snapshot must still drain
+            when(pm.isClosed()).thenReturn(true);
+            IndexingManager.drainCaptured(snapshot, pmf);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-cap-1"), eq(Encounter.class), eq(false));
+    }
+
+    @Test void drainCaptured_evictsEachDataNucleusIdentityBeforeItsEnqueue() {
+        DataStoreCache l2 = mock(DataStoreCache.class);
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+
+        when(pmf.getDataStoreCache()).thenReturn(l2);
+        IndexingManager im = mock(IndexingManager.class);
+        Object idA = new Object();
+        Object idB = new Object();
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.drainCaptured(Arrays.asList(
+                new IndexingManager.PendingEntry("a", Encounter.class, false, idA),
+                new IndexingManager.PendingEntry("b", MarkedIndividual.class, true, idB),
+                new IndexingManager.PendingEntry("c", Encounter.class, false, null)), pmf);
+        }
+        InOrder inOrder = inOrder(l2, im);
+
+        inOrder.verify(l2).evict(idA);
+        inOrder.verify(im).addIndexingQueueEntry("a", Encounter.class, false);
+        inOrder.verify(l2).evict(idB);
+        inOrder.verify(im).addIndexingQueueEntry("b", MarkedIndividual.class, true);
+        inOrder.verify(im).addIndexingQueueEntry("c", Encounter.class, false); // no id: no evict
+        verify(l2, times(2)).evict(any());
+    }
+
+    // Completion is the ONLY way a park becomes terminal, and it must leave a fresh, live park
+    // behind so the PM's next transaction has somewhere to park -- however that transaction is
+    // begun (Shepherd or a raw pm.currentTransaction().begin()).
+    @Test void completion_installsAFreshLivePark_forTheNextTransaction() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager.PendingBucket first = bucketOf(pm);
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-t1"), false);
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.COMMITTED);
+            verify(im).addIndexingQueueEntry(eq("enc-t1"), eq(Encounter.class), eq(false));
+
+            IndexingManager.PendingBucket second = bucketOf(pm);
+            assertNotSame(first, second, "a fresh park replaces the completed one");
+            assertTrue(first.isCompleted());
+            assertFalse(second.isCompleted());
+
+            // transaction 2 on the same PM: parked, not enqueued
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-t2"), false);
+            verify(im, never()).addIndexingQueueEntry(eq("enc-t2"), any(), anyBoolean());
+            assertEquals(1, second.size());
+
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.COMMITTED);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-t2"), eq(Encounter.class), eq(false));
+    }
+
+    @Test void completion_afterRollback_alsoInstallsAFreshLivePark() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-rb-t1"), false);
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.ROLLED_BACK);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-rb-t2"), false);
+            assertEquals(1, bucketOf(pm).size(),
+                "a rolled-back predecessor must not swallow the next transaction's request");
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.COMMITTED);
+        }
+        verify(im, never()).addIndexingQueueEntry(eq("enc-rb-t1"), any(), anyBoolean());
+        verify(im).addIndexingQueueEntry(eq("enc-rb-t2"), eq(Encounter.class), eq(false));
+    }
+
+    // Completion on a PM that has since been closed must not try to install a successor (the
+    // user-object map is gone with the PM) and must not throw.
+    @Test void completion_onClosedPm_doesNotInstallOrThrow() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-closed-t1"), false);
+            when(pm.isClosed()).thenReturn(true);
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.COMMITTED);
+        }
+        verify(pm, times(1)).putUserObject(any(), any()); // only the original install
+    }
+
+    // beginDBTransaction() runs again for an already-active transaction; installing a fresh park
+    // there would drop everything the open transaction had already parked.
+    @Test void installPendingBucket_doesNotClobberALivePark() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager.PendingBucket live = bucketOf(pm);
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-live-1"), false);
+            IndexingManager.installPendingBucket(pm); // a redundant begin
+            assertSame(live, bucketOf(pm), "live park must survive a redundant begin");
+            assertEquals(1, live.size());
+        }
+    }
+
+    @Test void installPendingBucket_replacesACompletedPark() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager.PendingBucket stale = bucketOf(pm);
+
+        stale.complete(IndexingManager.Outcome.COMMITTED); // completed with no successor installed
+        IndexingManager.installPendingBucket(pm);
+        assertNotSame(stale, bucketOf(pm));
+        assertFalse(bucketOf(pm).isCompleted());
+    }
+
+    // With no usable PersistenceManager there is nothing to defer to: fall back to the immediate
+    // behavior rather than silently losing the request.
+    @Test void addPendingEntry_nullPm_enqueuesImmediately() {
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(null, encounterWithId("enc-nopm-1"), false);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-nopm-1"), eq(Encounter.class), eq(false));
+    }
+
+    @Test void addPendingEntry_closedPm_enqueuesImmediately() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager im = mock(IndexingManager.class);
+
+        when(pm.isClosed()).thenReturn(true);
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-closed-1"), false);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-closed-1"), eq(Encounter.class), eq(false));
+    }
+
+    // A caller that has already committed (transaction no longer active) must NOT be deferred:
+    // there is no completion coming to release it. This is the IndividualRemoveEncounter shape.
+    @Test void addPendingEntry_inactiveTransaction_enqueuesImmediately() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        Transaction tx = mock(Transaction.class);
+
+        when(tx.isActive()).thenReturn(false);
+        PersistenceManager pm = pmWithUserObjects(pmf, tx);
+        IndexingManager.installPendingBucket(pm);
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-postcommit-1"), false);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-postcommit-1"), eq(Encounter.class), eq(false));
+        assertEquals(0, bucketOf(pm).size(), "nothing should have been parked");
+    }
+
+    // A PM nobody prepared (no park installed) cannot defer either.
+    @Test void addPendingEntry_pmWithoutPark_enqueuesImmediately() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = pmWithUserObjects(pmf, activeTx());
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-nopark-1"), false);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-nopark-1"), eq(Encounter.class), eq(false));
+    }
+
+    @Test void addPendingEntry_nullOrIdlessBase_isANoOp() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf);
+        IndexingManager im = mock(IndexingManager.class);
+
+        Base idless = mock(Base.class); // getId() returns null
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, null, false);
+            IndexingManager.addPendingEntry(pm, idless, false);
+        }
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+        assertEquals(0, bucketOf(pm).size());
+    }
+
+    @Test void completePendingEntries_onPmWithoutPark_isANoOp() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = pmWithUserObjects(pmf, activeTx());
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.COMMITTED);
+            IndexingManager.completePendingEntries(null, IndexingManager.Outcome.COMMITTED);
+        }
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+        verify(pm, times(0)).putUserObject(any(), any());
+    }
+}

--- a/src/test/java/org/ecocean/IndexingPostCommitHandoffDbTest.java
+++ b/src/test/java/org/ecocean/IndexingPostCommitHandoffDbTest.java
@@ -16,6 +16,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -126,15 +131,21 @@ class IndexingPostCommitHandoffDbTest {
         }
     }
 
+    // The row as the DATABASE has it -- plain JDBC, deliberately not a Shepherd, so the assertion
+    // cannot be satisfied by anything DataNucleus holds in its level-1 or level-2 cache.
     private static String committedComments() {
-        Shepherd reader = new Shepherd("context0");
+        String sql = "SELECT \"OCCURRENCEREMARKS\" FROM \"ENCOUNTER\" WHERE \"CATALOGNUMBER\" = ?";
 
-        reader.setAction("IndexingPostCommitHandoffDbTest.reader");
-        reader.beginDBTransaction();
-        try {
-            return reader.getEncounter(encId).getComments();
-        } finally {
-            reader.rollbackAndClose();
+        try (Connection c = DriverManager.getConnection(postgres.getJdbcUrl(),
+            postgres.getUsername(), postgres.getPassword());
+            PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setString(1, encId);
+            try (ResultSet rs = ps.executeQuery()) {
+                assertTrue(rs.next(), "the seeded encounter row exists");
+                return rs.getString(1);
+            }
+        } catch (SQLException e) {
+            throw new AssertionError("could not read the encounter row over JDBC", e);
         }
     }
 
@@ -303,13 +314,17 @@ class IndexingPostCommitHandoffDbTest {
         assertEquals("v2-retry", committedComments());
     }
 
-    // Closing the PM while that vetoed transaction is still active: whatever DataNucleus does
-    // with the transaction (its CloseActiveTxAction is rollback or exception, by configuration),
-    // nothing was committed, so nothing may reach the queue and the row must be unchanged.
-    @Test void failedCommitThenClose_enqueuesNothing() {
+    // Closing the PM while that vetoed transaction is still active. DataNucleus core defaults
+    // closeActiveTxAction to "exception", but the JDO API adapter overrides it to "rollback", so
+    // under JDO the close ROLLS BACK: the transaction completes with STATUS_ROLLEDBACK while the
+    // PM's user-object map is still there, the park is terminalized and dropped through the normal
+    // callback, and only then is the PM torn down. Nothing was committed, so nothing may reach the
+    // queue and the row must be unchanged.
+    @Test void failedCommitThenClose_rollsBack_andEnqueuesNothing() {
         Shepherd sh = new Shepherd("context0");
         Recorder rec = new Recorder(sh);
         String before = committedComments();
+        IndexingManager.PendingBucket park;
 
         sh.setAction("IndexingPostCommitHandoffDbTest.failedCommitClose");
         try (MockedStatic<IndexingManagerFactory> f = mockStatic(IndexingManagerFactory.class);
@@ -323,20 +338,20 @@ class IndexingPostCommitHandoffDbTest {
 
             PersistenceManager pm = sh.getPM();
             Transaction tx = pm.currentTransaction();
+            park = (IndexingManager.PendingBucket)pm.getUserObject(
+                IndexingManager.PENDING_USER_OBJECT_KEY);
+            assertEquals(1, park.size(), "precondition: the request is parked");
             tx.setSynchronization(new VetoOnce(tx.getSynchronization()));
             assertThrows(Exception.class, tx::commit);
             assertTrue(tx.isActive());
 
-            try {
-                pm.close();
-            } catch (Exception closeRefused) {
-                // exception-flavored CloseActiveTxAction: the PM stays open with its transaction;
-                // Shepherd's close below then rolls back through the normal path
-                assertFalse(pm.isClosed());
-            }
+            pm.close(); // JDO default closeActiveTxAction=rollback: completes, does not throw
+            assertTrue(pm.isClosed());
+            assertFalse(tx.isActive());
         } finally {
-            sh.rollbackAndClose();
+            sh.rollbackAndClose(); // no-op on a closed PM
         }
+        assertTrue(park.isCompleted(), "the rollback callback terminalized the park");
         verifyNoInteractions(rec.im);
         assertEquals(before, committedComments());
     }
@@ -382,8 +397,12 @@ class IndexingPostCommitHandoffDbTest {
         try {
             Encounter e = warm.getEncounter(encId);
             dnId = ((Persistable)e).dnGetObjectId();
-            l2 = ((JDODataStoreCache)warm.getPM().getPersistenceManagerFactory().getDataStoreCache())
-                .getLevel2Cache();
+            JDODataStoreCache dsc =
+                (JDODataStoreCache)warm.getPM().getPersistenceManagerFactory().getDataStoreCache();
+            // the fixture's L2 is "soft" like production; pin this id so a GC between here and the
+            // assertion cannot turn a fixture problem into a false eviction result
+            dsc.pin(dnId);
+            l2 = dsc.getLevel2Cache();
             warm.commitDBTransaction();
         } finally {
             warm.closeDBTransaction();

--- a/src/test/java/org/ecocean/IndexingPostCommitHandoffDbTest.java
+++ b/src/test/java/org/ecocean/IndexingPostCommitHandoffDbTest.java
@@ -54,9 +54,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * was asked to do and WHEN. On main the mock sees a call at flush time -- before commit -- which
  * is the bug; here it must see exactly one call, after commit, for a row that is committed.
  *
- * Reads of committed content happen after commit returns, through a fresh Shepherd, rather than
- * inside the enqueue callback (which runs inside DataNucleus's commit), to keep the test free of
- * any dependency on connection-pool or lock behavior.
+ * Reads of committed content happen after commit returns, over plain JDBC, rather than inside the
+ * enqueue callback (which runs inside DataNucleus's commit): that keeps the test free of any
+ * dependency on connection-pool or lock behavior, and means no DataNucleus cache can satisfy the
+ * assertion.
  */
 @Testcontainers
 class IndexingPostCommitHandoffDbTest {
@@ -400,7 +401,10 @@ class IndexingPostCommitHandoffDbTest {
             JDODataStoreCache dsc =
                 (JDODataStoreCache)warm.getPM().getPersistenceManagerFactory().getDataStoreCache();
             // the fixture's L2 is "soft" like production; pin this id so a GC between here and the
-            // assertion cannot turn a fixture problem into a false eviction result
+            // assertion cannot turn a fixture problem into a false eviction result. Twice: in
+            // DataNucleus 5.2.7 AbstractReferencedLevel2Cache.pin() creates its pinnedIds set on the
+            // first call and skips adding the id, so only the second call actually records it.
+            dsc.pin(dnId);
             dsc.pin(dnId);
             l2 = dsc.getLevel2Cache();
             warm.commitDBTransaction();

--- a/src/test/java/org/ecocean/IndexingPostCommitHandoffDbTest.java
+++ b/src/test/java/org/ecocean/IndexingPostCommitHandoffDbTest.java
@@ -1,0 +1,431 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.jdo.PersistenceManager;
+import javax.jdo.Transaction;
+import javax.transaction.Synchronization;
+
+import org.datanucleus.api.jdo.JDODataStoreCache;
+import org.datanucleus.cache.Level2Cache;
+import org.datanucleus.enhancement.Persistable;
+import org.datanucleus.exceptions.NucleusUserException;
+import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.shepherd.core.TestPMFUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.invocation.InvocationOnMock;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * The post-commit handoff against REAL DataNucleus and REAL Postgres.
+ *
+ * The unit tests around IndexingManager drive drain/complete by hand. This test does not: it
+ * modifies an existing Encounter through a real Shepherd, flushes, commits (or rolls back, or
+ * fails to commit) through the real transaction, and asserts on what a mocked IndexingManager
+ * was asked to do and WHEN. On main the mock sees a call at flush time -- before commit -- which
+ * is the bug; here it must see exactly one call, after commit, for a row that is committed.
+ *
+ * Reads of committed content happen after commit returns, through a fresh Shepherd, rather than
+ * inside the enqueue callback (which runs inside DataNucleus's commit), to keep the test free of
+ * any dependency on connection-pool or lock behavior.
+ */
+@Testcontainers
+class IndexingPostCommitHandoffDbTest {
+    @Container
+    static PostgreSQLContainer<?> postgres =
+        new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("wildbook_test")
+            .withUsername("wildbook")
+            .withPassword("wildbook");
+
+    static String encId;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        CommonConfiguration.initialize("context0", new Properties());
+
+        Properties props = new Properties();
+        props.setProperty("datanucleus.ConnectionUserName", postgres.getUsername());
+        props.setProperty("datanucleus.ConnectionPassword", postgres.getPassword());
+        props.setProperty("datanucleus.ConnectionDriverName", postgres.getDriverClassName());
+        props.setProperty("datanucleus.ConnectionURL", postgres.getJdbcUrl());
+        props.setProperty("datanucleus.schema.autoCreateTables", "true");
+        // explicit, because the level-2 eviction test depends on it (it is also the default)
+        props.setProperty("datanucleus.cache.level2.type", "soft");
+        TestPMFUtil.closePMF("context0");
+
+        Shepherd sh = new Shepherd("context0", props);
+        try {
+            sh.beginDBTransaction();
+            Encounter enc = new Encounter();
+            // keep seeding out of the indexing path entirely
+            enc.setSkipAutoIndexing(true);
+            enc.setComments("v1");
+            sh.storeNewEncounter(enc);
+            encId = enc.getId();
+            sh.commitDBTransaction();
+        } catch (Exception e) {
+            sh.rollbackDBTransaction();
+            throw e;
+        } finally {
+            sh.closeDBTransaction();
+        }
+    }
+
+    @AfterAll
+    static void tearDown() {
+        TestPMFUtil.closePMF("context0");
+    }
+
+    // ---- helpers ------------------------------------------------------------------------------
+
+    /** Records each identity-overload enqueue together with whether the writer's tx was still active. */
+    private static final class Recorder {
+        final IndexingManager im = mock(IndexingManager.class);
+        final List<String> ids = new ArrayList<String>();
+        final List<Boolean> writerActiveAtEnqueue = new ArrayList<Boolean>();
+
+        Recorder(final Shepherd writer) {
+            doAnswer((InvocationOnMock inv) -> {
+                ids.add(inv.getArgument(0));
+                writerActiveAtEnqueue.add(writer.getPM().currentTransaction().isActive());
+                return null;
+            }).when(im).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+        }
+
+        void assertExactlyOneEnqueueAfterCommit(String id) {
+            verify(im, times(1)).addIndexingQueueEntry(eq(id), eq(Encounter.class), eq(false));
+            verify(im, never()).addIndexingQueueEntry(any(Base.class), anyBoolean());
+            assertEquals(List.of(id), ids);
+            assertEquals(List.of(false), writerActiveAtEnqueue,
+                "the enqueue must happen after the writer's transaction has ended");
+        }
+    }
+
+    private static String committedComments() {
+        Shepherd reader = new Shepherd("context0");
+
+        reader.setAction("IndexingPostCommitHandoffDbTest.reader");
+        reader.beginDBTransaction();
+        try {
+            return reader.getEncounter(encId).getComments();
+        } finally {
+            reader.rollbackAndClose();
+        }
+    }
+
+    private static Encounter loadForWrite(Shepherd sh) {
+        Encounter enc = sh.getEncounter(encId);
+
+        enc.setSkipAutoIndexing(false);
+        return enc;
+    }
+
+    /** Throws NucleusUserException from beforeCompletion exactly once, then behaves normally. */
+    private static final class VetoOnce implements Synchronization {
+        private final Synchronization inner;
+        private boolean armed = true;
+
+        VetoOnce(Synchronization inner) {
+            this.inner = inner;
+        }
+
+        public void beforeCompletion() {
+            if (armed) {
+                armed = false;
+                throw new NucleusUserException("veto this commit once");
+            }
+            if (inner != null) inner.beforeCompletion();
+        }
+
+        public void afterCompletion(int status) {
+            if (inner != null) inner.afterCompletion(status);
+        }
+    }
+
+    // ---- the contract ---------------------------------------------------------------------------
+
+    @Test void flushDoesNotEnqueue_commitEnqueuesOnce_andTheRowIsCommittedByThen() {
+        Shepherd sh = new Shepherd("context0");
+        Recorder rec = new Recorder(sh);
+
+        sh.setAction("IndexingPostCommitHandoffDbTest.commit");
+        try (MockedStatic<IndexingManagerFactory> f = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class)) {
+            f.when(IndexingManagerFactory::getIndexingManager).thenReturn(rec.im);
+            os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+
+            sh.beginDBTransaction();
+            loadForWrite(sh).setComments("v2-commit");
+            sh.getPM().flush(); // postStore fires here, on main this is where the enqueue happened
+            verifyNoInteractions(rec.im);
+
+            sh.commitDBTransaction();
+        } finally {
+            sh.closeDBTransaction();
+        }
+        rec.assertExactlyOneEnqueueAfterCommit(encId);
+        assertEquals("v2-commit", committedComments());
+    }
+
+    // The callback hangs off the transaction, not off Shepherd, so a raw commit is covered too.
+    @Test void rawPersistenceManagerCommit_alsoEnqueuesAfterCommit() {
+        Shepherd sh = new Shepherd("context0");
+        Recorder rec = new Recorder(sh);
+
+        sh.setAction("IndexingPostCommitHandoffDbTest.rawCommit");
+        try (MockedStatic<IndexingManagerFactory> f = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class)) {
+            f.when(IndexingManagerFactory::getIndexingManager).thenReturn(rec.im);
+            os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+
+            sh.beginDBTransaction();
+            loadForWrite(sh).setComments("v2-raw");
+            sh.getPM().flush();
+            verifyNoInteractions(rec.im);
+
+            sh.getPM().currentTransaction().commit(); // NOT Shepherd.commitDBTransaction()
+        } finally {
+            sh.closeDBTransaction();
+        }
+        rec.assertExactlyOneEnqueueAfterCommit(encId);
+        assertEquals("v2-raw", committedComments());
+    }
+
+    @Test void rollback_enqueuesNothing() {
+        Shepherd sh = new Shepherd("context0");
+        Recorder rec = new Recorder(sh);
+        String before = committedComments();
+
+        sh.setAction("IndexingPostCommitHandoffDbTest.rollback");
+        try (MockedStatic<IndexingManagerFactory> f = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class)) {
+            f.when(IndexingManagerFactory::getIndexingManager).thenReturn(rec.im);
+            os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+
+            sh.beginDBTransaction();
+            loadForWrite(sh).setComments("never-committed");
+            sh.getPM().flush();
+            sh.rollbackDBTransaction();
+        } finally {
+            sh.closeDBTransaction();
+        }
+        verifyNoInteractions(rec.im);
+        assertEquals(before, committedComments());
+    }
+
+    // A second transaction on the same PM, begun RAW (no Shepherd.beginDBTransaction, so nothing
+    // re-installs the park): completion of the first must have left a live park behind.
+    @Test void secondTransactionBegunRaw_parksAgain() {
+        Shepherd sh = new Shepherd("context0");
+        Recorder rec = new Recorder(sh);
+
+        sh.setAction("IndexingPostCommitHandoffDbTest.rawSecond");
+        try (MockedStatic<IndexingManagerFactory> f = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class)) {
+            f.when(IndexingManagerFactory::getIndexingManager).thenReturn(rec.im);
+            os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+
+            sh.beginDBTransaction();
+            loadForWrite(sh).setComments("v2-first");
+            sh.commitDBTransaction();
+            verify(rec.im, times(1)).addIndexingQueueEntry(eq(encId), eq(Encounter.class), eq(false));
+
+            sh.getPM().currentTransaction().begin(); // raw
+            loadForWrite(sh).setComments("v2-second");
+            sh.getPM().flush();
+            verify(rec.im, times(1)).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+            sh.getPM().currentTransaction().commit(); // raw
+            verify(rec.im, times(2)).addIndexingQueueEntry(eq(encId), eq(Encounter.class), eq(false));
+        } finally {
+            sh.closeDBTransaction();
+        }
+        assertEquals(List.of(false, false), rec.writerActiveAtEnqueue);
+        assertEquals("v2-second", committedComments());
+    }
+
+    // DataNucleus leaves the transaction ACTIVE when commit() fails with a NucleusUserException,
+    // so the caller can fix the problem and commit again. The park must survive the failed commit
+    // and drain on the retry. (#1743 drained on "commit threw", which terminalized a park whose
+    // transaction was still open -- and then enqueued every later store in that transaction
+    // pre-commit.)
+    @Test void failedCommitLeavesTheTransactionActive_parkSurvives_retryEnqueuesOnce() {
+        Shepherd sh = new Shepherd("context0");
+        Recorder rec = new Recorder(sh);
+
+        sh.setAction("IndexingPostCommitHandoffDbTest.failedCommit");
+        try (MockedStatic<IndexingManagerFactory> f = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class)) {
+            f.when(IndexingManagerFactory::getIndexingManager).thenReturn(rec.im);
+            os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+
+            sh.beginDBTransaction();
+            loadForWrite(sh).setComments("v2-retry");
+            sh.getPM().flush(); // the park now holds the request
+            verifyNoInteractions(rec.im);
+
+            Transaction tx = sh.getPM().currentTransaction();
+            tx.setSynchronization(new VetoOnce(tx.getSynchronization()));
+
+            assertThrows(Exception.class, tx::commit, "first commit is vetoed");
+            assertTrue(tx.isActive(), "DataNucleus keeps the transaction open after a user error");
+            verifyNoInteractions(rec.im);
+
+            tx.commit(); // the retry
+        } finally {
+            sh.closeDBTransaction();
+        }
+        rec.assertExactlyOneEnqueueAfterCommit(encId);
+        assertEquals("v2-retry", committedComments());
+    }
+
+    // Closing the PM while that vetoed transaction is still active: whatever DataNucleus does
+    // with the transaction (its CloseActiveTxAction is rollback or exception, by configuration),
+    // nothing was committed, so nothing may reach the queue and the row must be unchanged.
+    @Test void failedCommitThenClose_enqueuesNothing() {
+        Shepherd sh = new Shepherd("context0");
+        Recorder rec = new Recorder(sh);
+        String before = committedComments();
+
+        sh.setAction("IndexingPostCommitHandoffDbTest.failedCommitClose");
+        try (MockedStatic<IndexingManagerFactory> f = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class)) {
+            f.when(IndexingManagerFactory::getIndexingManager).thenReturn(rec.im);
+            os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+
+            sh.beginDBTransaction();
+            loadForWrite(sh).setComments("never-committed-3");
+            sh.getPM().flush();
+
+            PersistenceManager pm = sh.getPM();
+            Transaction tx = pm.currentTransaction();
+            tx.setSynchronization(new VetoOnce(tx.getSynchronization()));
+            assertThrows(Exception.class, tx::commit);
+            assertTrue(tx.isActive());
+
+            try {
+                pm.close();
+            } catch (Exception closeRefused) {
+                // exception-flavored CloseActiveTxAction: the PM stays open with its transaction;
+                // Shepherd's close below then rolls back through the normal path
+                assertFalse(pm.isClosed());
+            }
+        } finally {
+            sh.rollbackAndClose();
+        }
+        verifyNoInteractions(rec.im);
+        assertEquals(before, committedComments());
+    }
+
+    @Test void failedCommitThenRollback_enqueuesNothing() {
+        Shepherd sh = new Shepherd("context0");
+        Recorder rec = new Recorder(sh);
+        String before = committedComments();
+
+        sh.setAction("IndexingPostCommitHandoffDbTest.failedCommitRollback");
+        try (MockedStatic<IndexingManagerFactory> f = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class)) {
+            f.when(IndexingManagerFactory::getIndexingManager).thenReturn(rec.im);
+            os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+
+            sh.beginDBTransaction();
+            loadForWrite(sh).setComments("never-committed-2");
+            sh.getPM().flush();
+
+            Transaction tx = sh.getPM().currentTransaction();
+            tx.setSynchronization(new VetoOnce(tx.getSynchronization()));
+            assertThrows(Exception.class, tx::commit);
+            assertTrue(tx.isActive());
+
+            sh.rollbackDBTransaction();
+        } finally {
+            sh.closeDBTransaction();
+        }
+        verifyNoInteractions(rec.im);
+        assertEquals(before, committedComments());
+    }
+
+    // The level-2 cache is keyed by DataNucleus's internal identity. Completion must evict THAT
+    // key -- evicting with JDOHelper.getObjectId()'s javax.jdo.identity object silently misses.
+    @Test void committedCompletion_evictsTheRowFromLevel2ByDataNucleusIdentity() {
+        // warm the level-2 cache: read + commit puts the object in
+        Shepherd warm = new Shepherd("context0");
+        Object dnId;
+        Level2Cache l2;
+
+        warm.setAction("IndexingPostCommitHandoffDbTest.warm");
+        warm.beginDBTransaction();
+        try {
+            Encounter e = warm.getEncounter(encId);
+            dnId = ((Persistable)e).dnGetObjectId();
+            l2 = ((JDODataStoreCache)warm.getPM().getPersistenceManagerFactory().getDataStoreCache())
+                .getLevel2Cache();
+            warm.commitDBTransaction();
+        } finally {
+            warm.closeDBTransaction();
+        }
+        assertTrue(l2.containsOid(dnId), "precondition: the row is in the level-2 cache");
+
+        Shepherd sh = new Shepherd("context0");
+        Recorder rec = new Recorder(sh);
+
+        sh.setAction("IndexingPostCommitHandoffDbTest.evict");
+        try (MockedStatic<IndexingManagerFactory> f = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class)) {
+            f.when(IndexingManagerFactory::getIndexingManager).thenReturn(rec.im);
+            os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+
+            sh.beginDBTransaction();
+            loadForWrite(sh).setComments("v2-evict");
+            sh.commitDBTransaction();
+        } finally {
+            sh.closeDBTransaction();
+        }
+        rec.assertExactlyOneEnqueueAfterCommit(encId);
+        assertFalse(l2.containsOid(dnId), "completion evicted the committed row from level-2");
+    }
+
+    // The indexing job's reader must not trust level-2: DataNucleus publishes an object's new
+    // state there during preCommit, BEFORE the datastore commit, so another in-flight transaction's
+    // copy can be sitting in the cache when the job runs.
+    @Test void readerWork_bypassesLevel2ForReads() {
+        IndexingManager.ShepherdIndexingWork work = new IndexingManager.ShepherdIndexingWork("probe");
+
+        try {
+            Map<String, Object> props = work.shepherd().getPM().getProperties();
+            String value = null;
+            for (Map.Entry<String, Object> e : props.entrySet()) {
+                if (IndexingManager.ShepherdIndexingWork.L2_RETRIEVE_MODE_PROPERTY.equalsIgnoreCase(
+                    e.getKey())) value = String.valueOf(e.getValue());
+            }
+            assertEquals("bypass", value == null ? null : value.toLowerCase(),
+                "reader PersistenceManager must read past the level-2 cache");
+        } finally {
+            work.close();
+        }
+    }
+}

--- a/src/test/java/org/ecocean/IndexingTransactionSynchronizationTest.java
+++ b/src/test/java/org/ecocean/IndexingTransactionSynchronizationTest.java
@@ -1,0 +1,330 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jdo.PersistenceManager;
+import javax.jdo.PersistenceManagerFactory;
+import javax.jdo.Transaction;
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.MockedStatic;
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ * The bridge from the JDO transaction's completion callback to the park in IndexingManager.
+ *
+ * DataNucleus calls Synchronization.afterCompletion(status) from inside commit() and rollback(),
+ * after its own post-commit work. That callback -- and only that callback -- terminalizes the
+ * park. Order inside it is fixed and load-bearing: (1) capture + terminalize the park and install
+ * its successor, (2) call the delegate Synchronization we wrapped (if any), (3) drain the captured
+ * snapshot. A delegate can legitimately close the PM; doing (1) first means that cannot lose the
+ * snapshot, and doing (3) last preserves delegate-before-enqueue for anyone who relies on it.
+ */
+class IndexingTransactionSynchronizationTest {
+    private static PersistenceManager pmWithUserObjects(PersistenceManagerFactory pmf,
+        Transaction tx) {
+        PersistenceManager pm = mock(PersistenceManager.class);
+        final Map<Object, Object> userObjects = new HashMap<Object, Object>();
+
+        when(pm.currentTransaction()).thenReturn(tx);
+        when(pm.isClosed()).thenReturn(false);
+        when(pm.getPersistenceManagerFactory()).thenReturn(pmf);
+        when(pm.getUserObject(any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.get(inv.getArgument(0)));
+        when(pm.putUserObject(any(), any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.put(inv.getArgument(0), inv.getArgument(1)));
+        return pm;
+    }
+
+    /** A Transaction mock that actually remembers the Synchronization set on it. */
+    private static Transaction transactionHoldingSynchronization(boolean active) {
+        Transaction tx = mock(Transaction.class);
+        final Synchronization[] held = new Synchronization[1];
+
+        when(tx.isActive()).thenReturn(active);
+        doAnswer((InvocationOnMock inv) -> {
+            held[0] = inv.getArgument(0);
+            return null;
+        }).when(tx).setSynchronization(any());
+        when(tx.getSynchronization()).thenAnswer((InvocationOnMock inv) -> held[0]);
+        return tx;
+    }
+
+    private static PersistenceManager preparedPm(PersistenceManagerFactory pmf, Transaction tx) {
+        PersistenceManager pm = pmWithUserObjects(pmf, tx);
+
+        IndexingManager.installPendingBucket(pm);
+        return pm;
+    }
+
+    private static IndexingManager.PendingBucket bucketOf(PersistenceManager pm) {
+        return (IndexingManager.PendingBucket)pm.getUserObject(
+            IndexingManager.PENDING_USER_OBJECT_KEY);
+    }
+
+    private static Encounter encounterWithId(String id) {
+        Encounter enc = new Encounter();
+
+        enc.setCatalogNumber(id);
+        enc.setSkipAutoIndexing(false);
+        return enc;
+    }
+
+    // ---- outcome routing ----------------------------------------------------------------------
+
+    @Test void afterCompletion_committed_drainsTheParkToTheQueue() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf, transactionHoldingSynchronization(true));
+        IndexingManager im = mock(IndexingManager.class);
+        IndexingTransactionSynchronization sync =
+            new IndexingTransactionSynchronization(pm, pmf, null);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-c"), false);
+            verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+            sync.afterCompletion(Status.STATUS_COMMITTED);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-c"), eq(Encounter.class), eq(false));
+    }
+
+    @Test void afterCompletion_rolledBack_dropsThePark() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf, transactionHoldingSynchronization(true));
+        IndexingManager im = mock(IndexingManager.class);
+        IndexingTransactionSynchronization sync =
+            new IndexingTransactionSynchronization(pm, pmf, null);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-r"), false);
+            sync.afterCompletion(Status.STATUS_ROLLEDBACK);
+        }
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+    }
+
+    @Test void afterCompletion_unexpectedStatus_runsIndexRequestsButNeverAnUnindex() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf, transactionHoldingSynchronization(true));
+        IndexingManager im = mock(IndexingManager.class);
+        IndexingTransactionSynchronization sync =
+            new IndexingTransactionSynchronization(pm, pmf, null);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-u-idx"), false);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-u-gone"), true);
+            sync.afterCompletion(Status.STATUS_UNKNOWN);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-u-idx"), eq(Encounter.class), eq(false));
+        verify(im, never()).addIndexingQueueEntry(eq("enc-u-gone"), any(), anyBoolean());
+    }
+
+    @Test void afterCompletion_leavesAFreshLiveParkForTheNextTransaction() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf, transactionHoldingSynchronization(true));
+        IndexingManager.PendingBucket first = bucketOf(pm);
+        IndexingTransactionSynchronization sync =
+            new IndexingTransactionSynchronization(pm, pmf, null);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(
+                mock(IndexingManager.class));
+            sync.afterCompletion(Status.STATUS_COMMITTED);
+        }
+        assertTrue(first.isCompleted());
+        assertNotSame(first, bucketOf(pm));
+        assertFalse(bucketOf(pm).isCompleted());
+    }
+
+    // ---- delegate handling --------------------------------------------------------------------
+
+    // beforeCompletion is the delegate's chance to veto the commit; we must not swallow that.
+    @Test void beforeCompletion_callsTheDelegate_andLetsItsExceptionPropagate() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf, transactionHoldingSynchronization(true));
+        Synchronization delegate = mock(Synchronization.class);
+        IndexingTransactionSynchronization sync =
+            new IndexingTransactionSynchronization(pm, pmf, delegate);
+
+        sync.beforeCompletion();
+        verify(delegate).beforeCompletion();
+
+        doThrow(new IllegalStateException("veto")).when(delegate).beforeCompletion();
+        assertThrows(IllegalStateException.class, sync::beforeCompletion);
+    }
+
+    @Test void beforeCompletion_withoutDelegate_isANoOp() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf, transactionHoldingSynchronization(true));
+
+        new IndexingTransactionSynchronization(pm, pmf, null).beforeCompletion();
+    }
+
+    // The delegate runs AFTER the park is terminalized and its successor installed, and BEFORE
+    // anything is handed to the queue.
+    @Test void afterCompletion_callsDelegate_afterCaptureAndBeforeDrain_withTheSameStatus() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf, transactionHoldingSynchronization(true));
+        IndexingManager.PendingBucket first = bucketOf(pm);
+        IndexingManager im = mock(IndexingManager.class);
+        Synchronization delegate = mock(Synchronization.class);
+        final boolean[] observedInsideDelegate = new boolean[2]; // [firstCompleted, successorLive]
+
+        doAnswer((InvocationOnMock inv) -> {
+            observedInsideDelegate[0] = first.isCompleted();
+            IndexingManager.PendingBucket now = bucketOf(pm);
+            observedInsideDelegate[1] = (now != first) && !now.isCompleted();
+            return null;
+        }).when(delegate).afterCompletion(anyInt());
+        IndexingTransactionSynchronization sync =
+            new IndexingTransactionSynchronization(pm, pmf, delegate);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-d"), false);
+            sync.afterCompletion(Status.STATUS_COMMITTED);
+        }
+        assertTrue(observedInsideDelegate[0], "park already terminalized when the delegate ran");
+        assertTrue(observedInsideDelegate[1], "successor already installed when the delegate ran");
+        InOrder inOrder = inOrder(delegate, im);
+
+        inOrder.verify(delegate).afterCompletion(Status.STATUS_COMMITTED);
+        inOrder.verify(im).addIndexingQueueEntry(eq("enc-d"), eq(Encounter.class), eq(false));
+    }
+
+    // A delegate may close the PM (its transaction is over). The snapshot was captured first, and
+    // the drain must not depend on the PM, so nothing is lost.
+    @Test void afterCompletion_delegateClosesThePm_snapshotStillDrains() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf, transactionHoldingSynchronization(true));
+        IndexingManager im = mock(IndexingManager.class);
+        Synchronization delegate = mock(Synchronization.class);
+
+        doAnswer((InvocationOnMock inv) -> {
+            when(pm.isClosed()).thenReturn(true);
+            when(pm.getUserObject(any())).thenThrow(new javax.jdo.JDOFatalUserException("closed"));
+            return null;
+        }).when(delegate).afterCompletion(anyInt());
+        IndexingTransactionSynchronization sync =
+            new IndexingTransactionSynchronization(pm, pmf, delegate);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-closed"), false);
+            sync.afterCompletion(Status.STATUS_COMMITTED);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-closed"), eq(Encounter.class), eq(false));
+    }
+
+    // A delegate that throws from afterCompletion must not prevent the handoff, and must not
+    // propagate out of a completion callback.
+    @Test void afterCompletion_delegateThrows_snapshotStillDrains_andNothingPropagates() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = preparedPm(pmf, transactionHoldingSynchronization(true));
+        IndexingManager im = mock(IndexingManager.class);
+        Synchronization delegate = mock(Synchronization.class);
+
+        doThrow(new RuntimeException("delegate broke")).when(delegate).afterCompletion(anyInt());
+        IndexingTransactionSynchronization sync =
+            new IndexingTransactionSynchronization(pm, pmf, delegate);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            IndexingManager.addPendingEntry(pm, encounterWithId("enc-throw"), false);
+            sync.afterCompletion(Status.STATUS_COMMITTED);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-throw"), eq(Encounter.class), eq(false));
+    }
+
+    // ---- registration -------------------------------------------------------------------------
+
+    @Test void registerSynchronization_installsOurs_andIsIdempotent() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        Transaction tx = transactionHoldingSynchronization(false);
+        PersistenceManager pm = pmWithUserObjects(pmf, tx);
+
+        IndexingManager.registerSynchronization(pm);
+        IndexingManager.registerSynchronization(pm);
+        IndexingManager.registerSynchronization(pm);
+
+        verify(tx, times(1)).setSynchronization(any(IndexingTransactionSynchronization.class));
+        assertTrue(tx.getSynchronization() instanceof IndexingTransactionSynchronization);
+    }
+
+    // JDO allows exactly one Synchronization per Transaction. Anyone who registered before us
+    // must keep receiving both callbacks, with the same status.
+    @Test void registerSynchronization_wrapsAPreExistingSynchronization() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        Transaction tx = transactionHoldingSynchronization(false);
+        PersistenceManager pm = pmWithUserObjects(pmf, tx);
+        Synchronization foreign = mock(Synchronization.class);
+
+        tx.setSynchronization(foreign);
+        IndexingManager.registerSynchronization(pm);
+
+        Synchronization installed = tx.getSynchronization();
+        assertTrue(installed instanceof IndexingTransactionSynchronization);
+        assertNotSame(foreign, installed);
+
+        installed.beforeCompletion();
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(
+                mock(IndexingManager.class));
+            installed.afterCompletion(Status.STATUS_ROLLEDBACK);
+        }
+        verify(foreign).beforeCompletion();
+        verify(foreign).afterCompletion(Status.STATUS_ROLLEDBACK);
+    }
+
+    @Test void registerSynchronization_neverThrows_onNullOrClosedPm() {
+        IndexingManager.registerSynchronization(null);
+
+        PersistenceManager closed = mock(PersistenceManager.class);
+        when(closed.isClosed()).thenReturn(true);
+        IndexingManager.registerSynchronization(closed);
+
+        PersistenceManager broken = mock(PersistenceManager.class);
+        when(broken.currentTransaction()).thenThrow(new javax.jdo.JDOFatalUserException("boom"));
+        IndexingManager.registerSynchronization(broken);
+    }
+
+    @Test void afterCompletion_onAPmThatWasNeverPrepared_isANoOp() {
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        PersistenceManager pm = pmWithUserObjects(pmf, transactionHoldingSynchronization(true));
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            new IndexingTransactionSynchronization(pm, pmf, null).afterCompletion(
+                Status.STATUS_COMMITTED);
+        }
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+        assertNull(pm.getUserObject(IndexingManager.PENDING_USER_OBJECT_KEY),
+            "nothing was installed on a PM that never had a park");
+    }
+}

--- a/src/test/java/org/ecocean/WildbookLifecycleListenerParkTest.java
+++ b/src/test/java/org/ecocean/WildbookLifecycleListenerParkTest.java
@@ -1,0 +1,128 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jdo.JDOHelper;
+import javax.jdo.PersistenceManager;
+import javax.jdo.PersistenceManagerFactory;
+import javax.jdo.Transaction;
+import javax.jdo.listener.InstanceLifecycleEvent;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ * postStore() fires on JDO flush, not on commit. It must PARK the reindex request against the
+ * object's PersistenceManager (released by the transaction's completion callback), not enqueue
+ * it -- enqueuing there is what let the background indexer read pre-commit state.
+ */
+class WildbookLifecycleListenerParkTest {
+    private static PersistenceManager preparedPm() {
+        PersistenceManager pm = mock(PersistenceManager.class);
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        Transaction tx = mock(Transaction.class);
+        final Map<Object, Object> userObjects = new HashMap<Object, Object>();
+
+        when(tx.isActive()).thenReturn(true);
+        when(pm.currentTransaction()).thenReturn(tx);
+        when(pm.isClosed()).thenReturn(false);
+        when(pm.getPersistenceManagerFactory()).thenReturn(pmf);
+        when(pm.getUserObject(any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.get(inv.getArgument(0)));
+        when(pm.putUserObject(any(), any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.put(inv.getArgument(0), inv.getArgument(1)));
+        IndexingManager.installPendingBucket(pm);
+        return pm;
+    }
+
+    private static int parked(PersistenceManager pm) {
+        return ((IndexingManager.PendingBucket)pm.getUserObject(
+            IndexingManager.PENDING_USER_OBJECT_KEY)).size();
+    }
+
+    private static InstanceLifecycleEvent storeEventFor(Object source) {
+        InstanceLifecycleEvent event = mock(InstanceLifecycleEvent.class);
+
+        when(event.getSource()).thenReturn(source);
+        return event;
+    }
+
+    @Test void postStore_parksAgainstTheObjectsPersistenceManager_insteadOfEnqueuing() {
+        PersistenceManager pm = preparedPm();
+        Encounter enc = new Encounter();
+
+        enc.setCatalogNumber("enc-store-1");
+        enc.setSkipAutoIndexing(false);
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class);
+            MockedStatic<JDOHelper> jdo = mockStatic(JDOHelper.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+            jdo.when(() -> JDOHelper.getPersistenceManager(enc)).thenReturn(pm);
+
+            new WildbookLifecycleListener().postStore(storeEventFor(enc));
+        }
+        verify(im, never()).addIndexingQueueEntry(any(Base.class), anyBoolean());
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+        assertEquals(1, parked(pm), "the request waits for the transaction to complete");
+    }
+
+    // The park then hands the request over by identity when the transaction commits.
+    @Test void postStore_parkedRequest_isEnqueuedByIdentityOnCommit() {
+        PersistenceManager pm = preparedPm();
+        Encounter enc = new Encounter();
+
+        enc.setCatalogNumber("enc-store-2");
+        enc.setSkipAutoIndexing(false);
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class);
+            MockedStatic<JDOHelper> jdo = mockStatic(JDOHelper.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+            jdo.when(() -> JDOHelper.getPersistenceManager(enc)).thenReturn(pm);
+
+            new WildbookLifecycleListener().postStore(storeEventFor(enc));
+            IndexingManager.completePendingEntries(pm, IndexingManager.Outcome.COMMITTED);
+        }
+        verify(im).addIndexingQueueEntry(eq("enc-store-2"), eq(Encounter.class), eq(false));
+    }
+
+    // Both skip guards still apply before anything is parked.
+    @Test void postStore_honorsSkipAutoIndexing() {
+        PersistenceManager pm = preparedPm();
+        Encounter enc = new Encounter();
+
+        enc.setCatalogNumber("enc-skip-1");
+        enc.setSkipAutoIndexing(true);
+        IndexingManager im = mock(IndexingManager.class);
+
+        try (MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class);
+            MockedStatic<OpenSearch> os = mockStatic(OpenSearch.class);
+            MockedStatic<JDOHelper> jdo = mockStatic(JDOHelper.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(im);
+            os.when(OpenSearch::skipAutoIndexing).thenReturn(false);
+            jdo.when(() -> JDOHelper.getPersistenceManager(enc)).thenReturn(pm);
+
+            new WildbookLifecycleListener().postStore(storeEventFor(enc));
+        }
+        assertEquals(0, parked(pm));
+        verify(im, never()).addIndexingQueueEntry(anyString(), any(), anyBoolean());
+    }
+}

--- a/src/test/java/org/ecocean/shepherd/core/ShepherdBeginRegistrationTest.java
+++ b/src/test/java/org/ecocean/shepherd/core/ShepherdBeginRegistrationTest.java
@@ -1,0 +1,110 @@
+package org.ecocean.shepherd.core;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jdo.PersistenceManager;
+import javax.jdo.PersistenceManagerFactory;
+import javax.jdo.Transaction;
+
+import org.ecocean.IndexingManager;
+import org.ecocean.IndexingTransactionSynchronization;
+import org.ecocean.WildbookLifecycleListener;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ * beginDBTransaction() is the ONE Shepherd lifecycle method this change touches. For a freshly
+ * obtained PersistenceManager it must register the store listener, register the indexing
+ * Synchronization, and install the deferred-indexing park -- and only THEN activate the
+ * transaction. A store callback can only fire once the transaction is active, and by then it
+ * needs both the listener and a live park in place.
+ *
+ * It must also do the registrations once per PM, not once per begin(): beginDBTransaction() runs
+ * again on every updateDBTransaction(), and on main each run added ANOTHER WildbookLifecycleListener,
+ * so one store event fanned out to N duplicate callbacks.
+ */
+class ShepherdBeginRegistrationTest {
+    private static final String PENDING_KEY = IndexingManager.PENDING_USER_OBJECT_KEY;
+
+    private static PersistenceManager mockPm(Transaction tx, boolean txActive) {
+        PersistenceManager pm = mock(PersistenceManager.class);
+        PersistenceManagerFactory pmf = mock(PersistenceManagerFactory.class);
+        final Map<Object, Object> userObjects = new HashMap<Object, Object>();
+
+        when(tx.isActive()).thenReturn(txActive);
+        when(pm.currentTransaction()).thenReturn(tx);
+        when(pm.isClosed()).thenReturn(false);
+        when(pm.getPersistenceManagerFactory()).thenReturn(pmf);
+        when(pm.getUserObject(any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.get(inv.getArgument(0)));
+        when(pm.putUserObject(any(), any())).thenAnswer((InvocationOnMock inv) ->
+            userObjects.put(inv.getArgument(0), inv.getArgument(1)));
+        return pm;
+    }
+
+    @Test void freshPm_registersListenerAndSynchronization_installsPark_thenBegins() {
+        Transaction tx = mock(Transaction.class);
+        PersistenceManager pm = mockPm(tx, false);
+
+        PersistenceManager registeredOn = Shepherd.prepareAndBeginTransaction(pm, null);
+
+        assertSame(pm, registeredOn, "the caller records which pm is now registered");
+        InOrder inOrder = inOrder(pm, tx);
+
+        inOrder.verify(pm).addInstanceLifecycleListener(any(WildbookLifecycleListener.class), any());
+        inOrder.verify(tx).setSynchronization(any(IndexingTransactionSynchronization.class));
+        inOrder.verify(pm).putUserObject(eq(PENDING_KEY), any());
+        inOrder.verify(tx).begin();
+        assertNotNull(pm.getUserObject(PENDING_KEY), "park must exist once the transaction is on");
+    }
+
+    // Same PM, next transaction (updateDBTransaction shape): no duplicate listener, no second
+    // Synchronization; the park is refreshed only if needed, and still before begin().
+    @Test void recycledPm_doesNotReRegister_butStillInstallsParkBeforeBegin() {
+        Transaction tx = mock(Transaction.class);
+        PersistenceManager pm = mockPm(tx, false);
+
+        PersistenceManager registeredOn = Shepherd.prepareAndBeginTransaction(pm, pm);
+
+        assertSame(pm, registeredOn);
+        verify(pm, never()).addInstanceLifecycleListener(any(), any());
+        verify(tx, never()).setSynchronization(any());
+        InOrder inOrder = inOrder(pm, tx);
+
+        inOrder.verify(pm).putUserObject(eq(PENDING_KEY), any());
+        inOrder.verify(tx).begin();
+    }
+
+    // A redundant beginDBTransaction() on an already-active transaction must not re-begin, and
+    // must not disturb the live park.
+    @Test void alreadyActiveTransaction_doesNotBeginAgain_andKeepsTheLivePark() {
+        Transaction tx = mock(Transaction.class);
+        PersistenceManager pm = mockPm(tx, true);
+
+        IndexingManager.installPendingBucket(pm);
+        Object live = pm.getUserObject(PENDING_KEY);
+
+        Shepherd.prepareAndBeginTransaction(pm, pm);
+        verify(tx, never()).begin();
+        assertSame(live, pm.getUserObject(PENDING_KEY), "live park survives a redundant begin");
+    }
+
+    @Test void nullPm_isANoOp() {
+        assertNull(Shepherd.prepareAndBeginTransaction(null, null));
+        PersistenceManager previous = mock(PersistenceManager.class);
+        assertSame(previous, Shepherd.prepareAndBeginTransaction(null, previous));
+    }
+}


### PR DESCRIPTION
Re-derivation of #1743 on the JDO transaction's own completion callback, as recommended by the Codex review of that PR. #1743 stays open as the problem record until this lands.

Closes #1696. That report (GiraffeSpotter, React encounter search) is this bug seen from the search page: the Identity filter "Include only encounters with no assigned Individual ID" listed encounters that already had an ID, because the encounter document's `individualId` was indexed from the pre-commit row on the match-results Confirm path (`iaResultsSetID.jsp`). That path never bumps `Encounter.modified`, so the background reconciler could not repair it and the stale rows persisted. Related problem record: #1548.

## The bug

`WildbookLifecycleListener.postStore()` fires on JDO **flush**, not commit. It enqueued the OpenSearch reindex there, and the indexing job opens its own Shepherd (its own connection) and reloads the object by id. For a row that already exists that reload **succeeds** and returns pre-commit state, so the job indexed the old values and reported success. Only a brand-new row raised `JDOObjectNotFoundException`, which is the one case the retry path handled. The queue's dedupe (`if (indexingQueue.contains(id)) return;`) then silently dropped the correct post-commit request whenever the pre-commit job was still in flight.

Search index stale, no data loss: Postgres is always right. Affected surfaces are the OpenSearch-backed ones, including the annotation index that feeds the match candidate pool.

## What changed

**The park.** `postStore`, `Encounter.enqueueAclReindex()` and `MarkedIndividual.enqueueAclReindex()` no longer enqueue. They park `(id, class, unindex, DataNucleus identity)` in the writing PersistenceManager's user-object map. A transient object, or a caller that has already committed, falls through to an immediate enqueue exactly as before.

**The release.** A `javax.transaction.Synchronization` (`IndexingTransactionSynchronization`) is registered once per PM via `Transaction.setSynchronization`. DataNucleus calls its `afterCompletion(status)` from inside `commit()`/`rollback()` after its own post-commit work. That callback is the **only** thing that terminalizes a park: `STATUS_COMMITTED` drains it (evict from L2 by DataNucleus identity, then enqueue by identity), `STATUS_ROLLEDBACK` drops it, anything else runs index requests (the job re-reads the DB, so that is harmless) and never an ambiguous unindex. Because it hangs off the transaction, a raw `pm.currentTransaction().commit()` is covered identically.

**What that removes.** No edits to `Shepherd.commitDBTransaction()`, `commitDBTransactionWithStatus()`, `updateDBTransaction()`, `rollbackDBTransaction()`, `closeDBTransaction()` or `rollbackAndClose()`. No lock around Shepherd's lifecycle. The only Shepherd change is `beginDBTransaction()`: for a fresh PM it registers the listener and the Synchronization once (main re-added a `WildbookLifecycleListener` on every begin, so one store event fanned out to N callbacks) and installs the park **before** `Transaction.begin()`.

**The dedupe.** A second request for an in-flight id is remembered and runs as exactly one follow-up pass when the job reaches any terminal outcome (success, failure, retry give-up), instead of being dropped.

**The reader.** The indexing job's PM sets `datanucleus.cache.level2.retrieveMode=bypass` for its primary lookup. See the boundary below for what that does and does not cover.

## Why this is safe where #1743 was not

- **"Commit threw" no longer terminalizes anything.** DataNucleus deliberately leaves the transaction active after a `NucleusUserException` so the caller can fix and retry. #1743 drained on that path, marking the park terminal while the transaction was still open, after which every later store in that transaction enqueued pre-commit again. Here the park stays live until the transaction actually completes. Tested against real DataNucleus with a one-shot vetoing Synchronization.
- **L2 eviction actually evicts.** The L2 cache is keyed by DataNucleus's internal identity; `JDOHelper.getObjectId()` returns a `javax.jdo.identity.*` object, and evicting with it silently misses. This uses `Persistable.dnGetObjectId()`, asserted against the real `Level2Cache`.
- **Completion survives failures.** The successor park is installed before any external work; each evict+enqueue is isolated; a null `IndexingManager` is logged, not thrown.
- **A wrapped Synchronization cannot lose the park.** Capture and successor installation happen before the delegate runs; the delegate may close the PM or throw.

## Boundaries (stated on purpose)

- **L2 read isolation is partial, and that is a separate problem.** DataNucleus publishes an object's new state into the shared L2 cache during **preCommit**, before the datastore commit, so any reader in Wildbook can briefly see another in-flight transaction's uncommitted copy. That predates this PR and affects web requests as much as the indexer. The per-PM bypass here covers the job's primary `getObjectById`; in DataNucleus 5.2 it does **not** cover lazy field loads, bulk loads, or the second Shepherd the encounter serializer opens. Closing that needs either a dedicated L2-less PMF for indexing reads (a second connection pool per install) or a fleet-wide L2 policy decision. Follow-up, not this PR.
- **Delivery is best-effort.** A handoff that fails at enqueue time (no `IndexingManager`, executor rejected) is logged and dropped; there is no durable retry. The reconciler re-indexes only when the DB version is strictly greater than the indexed one.
- The `Encounter.modified` bump from #1743 is **not** here. Codex showed the second-resolution setter can **decrease** the version relative to EncounterForm's millisecond ISO value. A persisted monotonic revision is the right fix; separate PR.
- `postDelete()` still unindexes pre-commit. Separate fix.
- Deep-index **child** writes (individual, occurrence, annotations) run on their own executor after the job returns and can still be overtaken by an older cascade. This PR guarantees the top-level document only.
- Transient objects (no PM yet) and PMs Shepherd never prepared still enqueue immediately, as on main.
- Heuristic transaction outcomes are reported by DataNucleus as a rollback attempt; a heuristic-mixed outcome cannot be resolved here.
- `logNestedExceptions` null-safety refactor from #1743: unrelated once the drain is out of `commitDBTransaction()`.

## Tests

68 unit tests (no datastore) + 9 Testcontainers tests against real Postgres and DataNucleus 5.2.7, with the row oracle being a raw JDBC `SELECT` (no Shepherd, no DataNucleus cache):

- flush enqueues nothing; Shepherd commit enqueues exactly once, after the transaction ended; the row is committed by then
- raw `pm.currentTransaction().commit()` behaves identically
- rollback enqueues nothing
- a second transaction begun **raw** on the same PM parks and drains again
- vetoed commit leaves the transaction active and the park intact; retry enqueues once
- vetoed commit + rollback enqueues nothing
- vetoed commit + `pm.close()`: under the JDO adapter's default `closeActiveTxAction=rollback` the close rolls back, the park completes through the normal callback, nothing is enqueued, row unchanged
- committed completion evicts the row from the real L2 by DataNucleus identity
- the indexing job's reader PM has L2 retrieve mode `bypass`

**RED evidence** (Testcontainers test run against the pre-change listener): 8 of 9 fail, the first with

```
NoInteractionsWanted ... But found these interactions on mock 'indexingManager':
-> at org.ecocean.WildbookLifecycleListener.postStore(WildbookLifecycleListener.java:72)
```

that is, the enqueue at flush time.

Full backend suite: 970 tests, 0 failures, 0 errors, 7 skipped (114 classes).

## Credits

Written by **Claude Fable 5.1** (Claude Code). **Codex** (`codex-cli 0.153.4`, `gpt-6-astra`, reasoning effort high) reviewed #1743 and proposed this design, then reviewed the plan and the diff for this PR. Its #1743 review found the failed-commit terminalization bug this design removes. Its plan review caught four load-bearing problems before any code was written: the L2 eviction key mismatch, the pre-commit L2 publication, the delegate-first callback order that could lose the park, and the need for per-entry failure isolation with the successor installed first. Its diff review established that the per-PM L2 bypass is partial in DataNucleus 5.2, explained the close-on-active-transaction behavior via the JDO adapter default, and pushed the test oracle to raw JDBC.

**Review status, stated plainly:** Codex's first diff round returned *not converged* with two Majors, both about the partial L2 bypass. Those are answered with the scope boundary above rather than with code, because the fix they call for (an L2-less PMF or a fleet-wide cache policy) is a separate change with its own blast radius. The convergence round then evaluated the branch against that stated boundary and returned **"CONVERGED: no Major findings within scope"**, accepting the boundary as legitimate ("not a dodge: shared-L2 isolation is a separate, pre-existing problem"). Its two remaining Minors (a DataNucleus `pin()` quirk in the L2 test fixture, and four comment phrasings that overclaimed recovery or isolation) are fixed in the last commit. Three Codex rounds in total on this PR: plan, diff, convergence.

Earlier rounds of #1743 were reviewed by Codex `gpt-5.6-terra`.

