### PR TITLE
Restore individual ID suggestions on the match page

### DIFF
--- a/frontend/src/__tests__/pages/MatchResults/CreateNewIndividualModal.test.jsx
+++ b/frontend/src/__tests__/pages/MatchResults/CreateNewIndividualModal.test.jsx
@@ -1,7 +1,20 @@
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
 import { IntlProvider } from "react-intl";
+import { toast } from "react-toastify";
 import CreateNewIndividualModal from "../../../pages/MatchResultsPage/components/CreateNewIndividualModal";
+
+// Use a stable, real intl context; the global mock returns a new object per render.
+jest.unmock("react-intl");
+jest.mock("react-toastify", () => ({
+  toast: { error: jest.fn(), success: jest.fn() },
+}));
 
 const themeColor = {
   primaryColors: { primary500: "#00ACCE" },
@@ -34,15 +47,15 @@ const renderModal = (props = {}) =>
   );
 
 beforeEach(() => {
-  globalThis.fetch = jest.fn(() =>
-    Promise.resolve({ json: () => Promise.resolve({ success: false }) }),
-  );
+  jest.clearAllMocks();
+  globalThis.fetch = jest.fn(() => new Promise(() => {}));
 });
 
 describe("CreateNewIndividualModal", () => {
   test("does not render when show is false", () => {
     renderModal({ show: false });
     expect(screen.queryByText("CREATE_NEW_INDIVIDUAL")).not.toBeInTheDocument();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   test("renders modal title when show is true", () => {
@@ -123,13 +136,14 @@ describe("CreateNewIndividualModal", () => {
       json: () =>
         Promise.resolve({
           success: true,
-          results: [{ success: true, nextName: "ID-007" }],
+          results: [{ type: "locationId", success: true, nextName: "ID-007" }],
         }),
     });
     renderModal({ locationId: "loc-1" });
     await waitFor(() => {
       expect(globalThis.fetch).toHaveBeenCalledWith(
         expect.stringContaining("next_name?locationId=loc-1"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
       );
     });
   });
@@ -140,7 +154,7 @@ describe("CreateNewIndividualModal", () => {
       json: () =>
         Promise.resolve({
           success: true,
-          results: [{ success: true, nextName: "ID-042" }],
+          results: [{ type: "locationId", success: true, nextName: "ID-042" }],
         }),
     });
     renderModal({ locationId: "loc-2" });
@@ -154,7 +168,7 @@ describe("CreateNewIndividualModal", () => {
       json: () =>
         Promise.resolve({
           success: true,
-          results: [{ success: true, nextName: "ID-099" }],
+          results: [{ type: "locationId", success: true, nextName: "ID-099" }],
         }),
     });
     const onNameChange = jest.fn();
@@ -162,5 +176,153 @@ describe("CreateNewIndividualModal", () => {
     await screen.findByText("USE_THIS");
     fireEvent.click(screen.getByText("USE_THIS"));
     expect(onNameChange).toHaveBeenCalledWith("ID-099", true);
+  });
+
+  test.each(["", null, undefined])(
+    "shows user suggestion without a location (%s)",
+    async (locationId) => {
+      globalThis.fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          success: true,
+          results: [
+            { type: "user", success: true, nextName: "42", nextNameKey: "IoT" },
+          ],
+        }),
+      });
+      const onNameChange = jest.fn();
+      renderModal({ locationId, onNameChange, newIndividualName: "My name" });
+      await screen.findByText(/Suggested ID: 42/);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "/api/v3/individuals/info/next_name",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+      expect(screen.getByRole("textbox")).toHaveValue("My name");
+      fireEvent.click(screen.getByText("USE_THIS"));
+      expect(onNameChange).toHaveBeenCalledWith("42", false);
+    },
+  );
+
+  test("skips an empty location suggestion and displays the user suggestion", async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        results: [
+          { type: "locationId", success: true, nextName: null },
+          { type: "user", success: true, nextName: "43" },
+        ],
+      }),
+    });
+    renderModal({ locationId: "location without prefix" });
+    expect(await screen.findByText(/Suggested ID: 43/)).toBeInTheDocument();
+    expect(globalThis.fetch.mock.calls[0][0]).toContain(
+      "locationId=location%20without%20prefix",
+    );
+  });
+
+  test("prefers the location suggestion when both names are available", async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        results: [
+          { type: "locationId", success: true, nextName: "LOC-44" },
+          { type: "user", success: true, nextName: "44" },
+        ],
+      }),
+    });
+    const onNameChange = jest.fn();
+    renderModal({ locationId: "loc-1", onNameChange });
+    fireEvent.click(await screen.findByText("USE_THIS"));
+    expect(onNameChange).toHaveBeenCalledWith("LOC-44", true);
+  });
+
+  test.each([
+    { success: true, results: [] },
+    {
+      success: true,
+      results: [{ type: "locationId", success: true, nextName: null }],
+    },
+    { success: false },
+  ])(
+    "allows manual naming when no suggestion is available: %j",
+    async (data) => {
+      globalThis.fetch.mockResolvedValue({ ok: true, json: async () => data });
+      const onNameChange = jest.fn();
+      renderModal({ onNameChange });
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("create-new-individual-suggested-id-loading"),
+        ).not.toBeInTheDocument(),
+      );
+      expect(screen.queryByText("USE_THIS")).not.toBeInTheDocument();
+      fireEvent.change(screen.getByRole("textbox"), {
+        target: { value: "Custom" },
+      });
+      expect(onNameChange).toHaveBeenCalledWith("Custom", false);
+    },
+  );
+
+  test("keeps manual naming available when the suggestion request fails", async () => {
+    globalThis.fetch.mockResolvedValue({ ok: false, status: 500 });
+    const onNameChange = jest.fn();
+    renderModal({ onNameChange });
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Failed to load suggested ID"),
+    );
+    expect(screen.queryByText("USE_THIS")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Custom" },
+    });
+    expect(onNameChange).toHaveBeenCalledWith("Custom", false);
+  });
+
+  test("ignores a stale response after location changes and refreshes when reopened", async () => {
+    let resolveOld;
+    globalThis.fetch
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOld = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          results: [{ type: "locationId", success: true, nextName: "NEW-1" }],
+        }),
+      });
+    const modal = (props) => (
+      <IntlProvider locale="en" messages={messages}>
+        <CreateNewIndividualModal {...defaultProps} {...props} />
+      </IntlProvider>
+    );
+    const { rerender } = render(modal({ locationId: "old" }));
+    const oldSignal = globalThis.fetch.mock.calls[0][1].signal;
+    rerender(modal({ locationId: "new" }));
+    expect(await screen.findByText(/NEW-1/)).toBeInTheDocument();
+    expect(oldSignal.aborted).toBe(true);
+    await act(async () =>
+      resolveOld({
+        ok: true,
+        json: async () => ({
+          success: true,
+          results: [{ type: "locationId", success: true, nextName: "OLD-1" }],
+        }),
+      }),
+    );
+    expect(screen.queryByText(/OLD-1/)).not.toBeInTheDocument();
+    rerender(modal({ show: false, locationId: "new" }));
+    globalThis.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        results: [{ type: "locationId", success: true, nextName: "NEW-2" }],
+      }),
+    });
+    rerender(modal({ locationId: "new" }));
+    expect(await screen.findByText(/NEW-2/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/MatchResultsPage/components/CreateNewIndividualModal.jsx
+++ b/frontend/src/pages/MatchResultsPage/components/CreateNewIndividualModal.jsx
@@ -17,17 +17,22 @@ const CreateNewIndividualModal = ({
 }) => {
   const intl = useIntl();
   const [selectedRemark, setSelectedRemark] = React.useState("");
-  const [suggestedId, setSuggestedId] = React.useState(null);
+  const [suggestion, setSuggestion] = React.useState(null);
   const [loadingSuggestedId, setLoadingSuggestedId] = React.useState(false);
 
+  const suggestedId = suggestion?.nextName;
+
   React.useEffect(() => {
-    if (!show || !locationId) return undefined;
+    setSuggestion(null);
+    setLoadingSuggestedId(false);
+    if (!show) return undefined;
 
     const controller = new AbortController();
     setLoadingSuggestedId(true);
 
+    const url = "/api/v3/individuals/info/next_name";
     fetch(
-      `/api/v3/individuals/info/next_name?locationId=${encodeURIComponent(locationId)}`,
+      locationId ? `${url}?locationId=${encodeURIComponent(locationId)}` : url,
       { signal: controller.signal },
     )
       .then(async (res) => {
@@ -35,21 +40,23 @@ const CreateNewIndividualModal = ({
         return res.json();
       })
       .then((data) => {
-        if (data.success === true && data.results && data.results.length > 0) {
-          const successfulResult = data.results.find((r) => r.success === true);
-          if (successfulResult && successfulResult.nextName) {
-            setSuggestedId(successfulResult.nextName);
-          } else {
-            setSuggestedId(null);
-          }
-        } else {
-          setSuggestedId(null);
-        }
+        if (controller.signal.aborted) return;
+        const result =
+          data.success === true && Array.isArray(data.results)
+            ? data.results.find(
+                (r) =>
+                  r.success === true &&
+                  typeof r.nextName === "string" &&
+                  r.nextName.trim() &&
+                  ["locationId", "user"].includes(r.type),
+              )
+            : null;
+        setSuggestion(result || null);
       })
       .catch((err) => {
-        if (err.name === "AbortError") return;
+        if (controller.signal.aborted || err.name === "AbortError") return;
 
-        setSuggestedId(null);
+        setSuggestion(null);
         toast.error(
           intl.formatMessage({
             id: "LOAD_SUGGESTED_ID_FAILED",
@@ -71,7 +78,7 @@ const CreateNewIndividualModal = ({
   React.useEffect(() => {
     if (!show) {
       setSelectedRemark("");
-      setSuggestedId(null);
+      setSuggestion(null);
     }
   }, [show]);
 
@@ -80,7 +87,7 @@ const CreateNewIndividualModal = ({
   };
 
   const handleUseSuggestedId = () => {
-    onNameChange(suggestedId.toString(), true);
+    onNameChange(suggestedId, suggestion.type === "locationId");
     toast.success(
       intl.formatMessage({
         id: "SUGGESTED_ID_APPLIED",
@@ -202,7 +209,7 @@ const CreateNewIndividualModal = ({
             />
           </Form.Group>
 
-          {locationId && (
+          {(loadingSuggestedId || suggestedId) && (
             <div
               className="mb-3"
               id="create-new-individual-suggested-id"


### PR DESCRIPTION
The React match page now requests individual ID suggestions even when the encounter has no location, and skips successful API results with an empty name. This restores suggestions when a location has no configured prefix and a user suggestion is available. Requests are refreshed when the modal opens, and aborted responses cannot overwrite current suggestions.

Location suggestions retain the existing location-based allocation behavior. User suggestions populate the existing entered-name save path; user-sequence allocation and name-label persistence are outside this change. No backend or store changes are included.

Fixes #1724

Validation:
- Match modal, match store, and bottom bar suites: 138 tests passed. After adding an API-failure regression, the modal suite passed all 24 tests.
- Jest exits nonzero because of four pre-existing obsolete snapshots, also present in the baseline run.
- ESLint and `git diff --check` passed.
- Claude CLI design and code reviews found no blockers.
- Existing localized UI strings are reused; no dependencies or header changes.
<img width="1200" height="1108" alt="image" src="https://github.com/user-attachments/assets/31472c99-dc88-41e8-9bd5-f5bfb21475f5" />

