### PR TITLE
Keep the encounter link on identified match pages

### DIFF
--- a/frontend/src/__tests__/pages/MatchResults/MatchResultsBottomBar.test.jsx
+++ b/frontend/src/__tests__/pages/MatchResults/MatchResultsBottomBar.test.jsx
@@ -305,6 +305,91 @@ describe("MatchResultsBottomBar — no_further_action_needed state", () => {
   });
 });
 
+describe.each([
+  ["no_individuals", "match-bottombar"],
+  ["no_further_action_needed", "match-bottombar-no-action"],
+])("MatchResultsBottomBar — query links in %s", (matchingState, prefix) => {
+  test("keeps the encounter link alongside the identified animal link", () => {
+    renderBar({
+      matchingState,
+      encounterId: "enc /?&001",
+      individualId: "ind /?&001",
+      individualDisplayName: "Luna",
+    });
+    const encounterLink = screen.getByTestId(`${prefix}-encounter-link`);
+    const individualLink = screen.getByRole("link", { name: "Luna" });
+    expect(encounterLink).toHaveAttribute(
+      "href",
+      "/react/encounter?number=enc%20%2F%3F%26001",
+    );
+    expect(encounterLink).toHaveTextContent("ENCOUNTER enc /");
+    expect(individualLink).toHaveAttribute(
+      "href",
+      "/individuals.jsp?id=ind%20%2F%3F%26001",
+    );
+    for (const link of [encounterLink, individualLink]) {
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  });
+
+  test("shows only the encounter link when the query is unidentified", () => {
+    renderBar({ matchingState });
+    expect(screen.getByTestId(`${prefix}-encounter-link`)).toHaveAttribute(
+      "href",
+      "/react/encounter?number=enc-001",
+    );
+    expect(
+      screen.queryByTestId(`${prefix}-individual-link`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("uses the individual ID when its display name is missing", () => {
+    renderBar({ matchingState, individualId: "ind-001" });
+    expect(screen.getByRole("link", { name: "ind-001" })).toHaveAttribute(
+      "href",
+      "/individuals.jsp?id=ind-001",
+    );
+    expect(screen.getByTestId(`${prefix}-encounter-link`)).toBeInTheDocument();
+  });
+
+  test("does not create an individual link from a display name without an ID", () => {
+    renderBar({ matchingState, individualDisplayName: "Luna" });
+    expect(screen.getByTestId(`${prefix}-encounter-link`)).toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${prefix}-individual-link`),
+    ).not.toBeInTheDocument();
+  });
+});
+
+test("preserves the query encounter destination after it becomes identified", () => {
+  const { rerender } = renderBar();
+  expect(screen.getByTestId("match-bottombar-encounter-link")).toHaveAttribute(
+    "href",
+    "/react/encounter?number=enc-001",
+  );
+  rerender(
+    <IntlProvider locale="en" messages={{}}>
+      <MatchResultsBottomBar
+        store={makeStore({
+          matchingState: "no_further_action_needed",
+          individualId: "ind-001",
+          individualDisplayName: "Luna",
+        })}
+        themeColor={themeColor}
+        identificationRemarks={["AI", "Manual"]}
+      />
+    </IntlProvider>,
+  );
+  expect(
+    screen.getByTestId("match-bottombar-no-action-encounter-link"),
+  ).toHaveAttribute("href", "/react/encounter?number=enc-001");
+  expect(screen.getByRole("link", { name: "Luna" })).toHaveAttribute(
+    "href",
+    "/individuals.jsp?id=ind-001",
+  );
+});
+
 describe("MatchResultsBottomBar — Cancel button", () => {
   test("renders CANCEL button", () => {
     renderBar();

--- a/frontend/src/pages/MatchResultsPage/components/MatchResultsBottomBar.jsx
+++ b/frontend/src/pages/MatchResultsPage/components/MatchResultsBottomBar.jsx
@@ -83,12 +83,47 @@ const MatchResultsBottomBar = observer(
       await store.handleMerge();
     };
 
+    const renderQueryLinks = (idPrefix) => {
+      const encId = store.encounterId || "";
+      const linkStyle = { color: themeColor.primaryColors.primary500 };
+
+      return (
+        <>
+          <a
+            id={`${idPrefix}-encounter-link`}
+            data-testid={`${idPrefix}-encounter-link`}
+            href={`/react/encounter?number=${encodeURIComponent(encId)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-decoration-none"
+            style={linkStyle}
+          >
+            <FormattedMessage id="ENCOUNTER" /> {encId.slice(0, 5)}
+          </a>
+          {store.individualId && (
+            <>
+              {" ("}
+              <a
+                id={`${idPrefix}-individual-link`}
+                data-testid={`${idPrefix}-individual-link`}
+                href={`/individuals.jsp?id=${encodeURIComponent(store.individualId)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-decoration-none"
+                style={linkStyle}
+              >
+                {store.individualDisplayName || store.individualId}
+              </a>
+              {")"}
+            </>
+          )}
+        </>
+      );
+    };
+
     const getActionContent = () => {
       switch (matchingState) {
         case "no_individuals": {
-          const encId = store.encounterId || "";
-          const shortEncId = encId.slice(0, 5);
-
           const left = (
             <div
               className="text-truncate"
@@ -97,37 +132,7 @@ const MatchResultsBottomBar = observer(
               data-testid="match-bottombar-left-no-individuals"
             >
               <FormattedMessage id="SET_MATCH_FOR" />{" "}
-              {store.individualDisplayName ? (
-                <a
-                  id="match-bottombar-individual-link"
-                  data-testid="match-bottombar-individual-link"
-                  href={`/individuals.jsp?id=${encodeURIComponent(
-                    store.individualId,
-                  )}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-decoration-none"
-                  style={{
-                    color: themeColor.primaryColors.primary500,
-                  }}
-                >
-                  {store.individualDisplayName}
-                </a>
-              ) : (
-                <a
-                  id="match-bottombar-encounter-link"
-                  data-testid="match-bottombar-encounter-link"
-                  href={`/react/encounter?number=${encodeURIComponent(encId)}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-decoration-none"
-                  style={{
-                    color: themeColor.primaryColors.primary500,
-                  }}
-                >
-                  {"encounter"} {shortEncId}
-                </a>
-              )}{" "}
+              {renderQueryLinks("match-bottombar")}{" "}
               <FormattedMessage id="OR_CHOOSE_FROM_RESULTS_BELOW" />
             </div>
           );
@@ -390,9 +395,6 @@ const MatchResultsBottomBar = observer(
 
         case "no_further_action_needed":
           if (store.selectedMatch.length === 0) {
-            const encId = store.encounterId || "";
-            const shortEncId = encId.slice(0, 5);
-
             return {
               left: (
                 <div
@@ -402,37 +404,7 @@ const MatchResultsBottomBar = observer(
                   data-testid="match-bottombar-left-no-action-empty-selection"
                 >
                   <FormattedMessage id="SET_MATCH_FOR" />{" "}
-                  {store.individualDisplayName ? (
-                    <a
-                      id="match-bottombar-no-action-individual-link"
-                      data-testid="match-bottombar-no-action-individual-link"
-                      href={`/individuals.jsp?id=${encodeURIComponent(
-                        store.individualId,
-                      )}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-decoration-none"
-                      style={{
-                        color: themeColor.primaryColors.primary500,
-                      }}
-                    >
-                      {store.individualDisplayName}
-                    </a>
-                  ) : (
-                    <a
-                      id="match-bottombar-no-action-encounter-link"
-                      data-testid="match-bottombar-no-action-encounter-link"
-                      href={`/react/encounter?number=${encodeURIComponent(encId)}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-decoration-none"
-                      style={{
-                        color: themeColor.primaryColors.primary500,
-                      }}
-                    >
-                      {"encounter"} {shortEncId}
-                    </a>
-                  )}
+                  {renderQueryLinks("match-bottombar-no-action")}
                 </div>
               ),
               right: null,


### PR DESCRIPTION
The match page now keeps the query encounter link when the encounter is identified, alongside a separate link to its individual. Previously, the individual link replaced the encounter link. Both affected header states share the same link rendering, use the existing translated Encounter label, and fall back to the individual ID when its display name is unavailable.

Fixes #1707

Validation:
- Match page, action bar, and multi-query store suites: 66 tests passed. Jest exits nonzero due to four pre-existing obsolete snapshots, also present in the baseline.
- ESLint and `git diff --check` passed.
- Regression coverage includes identified/unidentified encounters, missing individual names or IDs, encoded destinations, and the transition after identification.
- Claude CLI design and code reviews completed. Verified the existing locale entries and the parent page's encounter-ID guard in response to review notes.
- Existing link destinations and new-tab behavior are retained. No backend, dependency, or matching-action changes.

<img width="1910" height="894" alt="image" src="https://github.com/user-attachments/assets/0fbfc77e-fd72-4a2a-aa58-255b9d36a69b" />
