### PR TITLE
Honor location-based roles in the API, React and search access checks (#1549, #1244)

### DIFF
--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -3408,15 +3408,28 @@ public class Encounter extends Base implements java.io.Serializable {
      *   yield [] (admin-only via opensearchAccess' isAdmin branch).
      * - Otherwise: the other party of every PERSISTED approved/edit
      *   collaboration with the submitter, plus orgAdmins of the submitter's
-     *   organization(s) (one-way).
+     *   organization(s) (one-way), plus holders of a location-based role
+     *   (a Role named after this encounter's locationID or an ancestor of it,
+     *   see LocationRoleAccess). The location grant does not depend on the
+     *   owner resolving; the collaboration/orgAdmin grants still fail closed.
+     * - The owner is never listed (granted via submitterUserId).
      */
     public List<String> computeViewUsers(Shepherd myShepherd) {
         List<String> ids = new ArrayList<String>();
         if (this.isPubliclyReadable()) return ids;
+        java.util.Set<String> seen = new java.util.HashSet<String>();
+        // 0. location-based roles, independent of who owns the encounter
+        for (String id : org.ecocean.security.LocationRoleAccess.userIdsWithLocationRole(
+            this.getLocationID(), myShepherd)) {
+            if (seen.add(id)) ids.add(id);
+        }
         String submitter = this.getSubmitterID();
         User submitterUser = (submitter == null) ? null : myShepherd.getUser(submitter);
-        if (submitterUser == null) return ids; // fail closed: admin-only
-        java.util.Set<String> seen = new java.util.HashSet<String>();
+        if (submitterUser == null) return ids; // owner-dependent grants fail closed
+        if (submitterUser.getId() != null) {
+            ids.remove(submitterUser.getId()); // the owner may hold the role; never list them
+            seen.add(submitterUser.getId());
+        }
         // 1. persisted approved/edit collaborators (mutual view), correct direction
         for (Collaboration col : Collaboration.persistedCollaborationsForUser(myShepherd, submitter)) {
             if (!col.isApproved() && !col.isEditApproved()) continue;
@@ -4290,6 +4303,9 @@ public class Encounter extends Base implements java.io.Serializable {
         OpenSearch os = new OpenSearch();
         Map<String, Set<String> > collab = new HashMap<String, Set<String> >();
         Map<String, String> usernameToId = new HashMap<String, String>();
+        // location-based roles: role name -> user ids holding it (see LocationRoleAccess)
+        Map<String, Set<String> > roleNameToUserIds = new HashMap<String, Set<String> >();
+        Map<String, Set<String> > lineageCache = new HashMap<String, Set<String> >();
         Shepherd myShepherd = new Shepherd("context0");
         myShepherd.setAction("Encounter.opensearchIndexPermissions");
         myShepherd.beginDBTransaction();
@@ -4307,22 +4323,36 @@ public class Encounter extends Base implements java.io.Serializable {
                     collab.get(user.getId()).add(col.getOtherUsername(user.getUsername()));
                 }
             }
+            // getRolesInContext propagates a datastore failure, so a bad read aborts the pass
+            // (permissionsNeeded stays set) instead of silently revoking every location grant
+            for (Role role : myShepherd.getRolesInContext("context0")) {
+                if ((role == null) || (role.getRolename() == null) || (role.getUsername() == null))
+                    continue;
+                if (org.ecocean.security.LocationRoleAccess.SYSTEM_ROLE_NAMES.contains(
+                    role.getRolename())) continue;
+                String roleUid = usernameToId.get(role.getUsername());
+                if (roleUid == null) continue;
+                if (!roleNameToUserIds.containsKey(role.getRolename()))
+                    roleNameToUserIds.put(role.getRolename(), new HashSet<String>());
+                roleNameToUserIds.get(role.getRolename()).add(roleUid);
+            }
         } catch (Exception ex) {
-            System.out.println("opensearchIndexPermissions(): ABORT — user/collab precompute failed; will retry next tick");
+            System.out.println("opensearchIndexPermissions(): ABORT — user/collab/role precompute failed; will retry next tick");
             ex.printStackTrace();
             myShepherd.rollbackAndClose();
             return false;
         }
         Util.mark("perm: user build done", startT);
         System.out.println("opensearchIndexPermissions(): " + usernameToId.size() +
-            " total users; " + collab.size() + " have active collab");
+            " total users; " + collab.size() + " have active collab; " + roleNameToUserIds.size() +
+            " location role names");
         // now iterated over (non-public) encounters
         int encCount = 0;
         int viewUsersWriteFailures = 0;
         org.json.JSONObject updateData = new org.json.JSONObject();
         // we do not need full Encounter objects here to update index docs, so lets do this via sql/fields - much faster
         String sql =
-            "SELECT \"CATALOGNUMBER\", \"SUBMITTERID\" FROM \"ENCOUNTER\" WHERE \"SUBMITTERID\" IS NOT NULL AND \"SUBMITTERID\" != '' AND \"SUBMITTERID\" != 'N/A' AND \"SUBMITTERID\" != 'public'";
+            "SELECT \"CATALOGNUMBER\", \"SUBMITTERID\", \"LOCATIONID\" FROM \"ENCOUNTER\" WHERE \"SUBMITTERID\" IS NOT NULL AND \"SUBMITTERID\" != '' AND \"SUBMITTERID\" != 'N/A' AND \"SUBMITTERID\" != 'public'";
         Query q = null;
         try {
             q = myShepherd.getPM().newQuery("javax.jdo.query.SQL", sql);
@@ -4333,7 +4363,9 @@ public class Encounter extends Base implements java.io.Serializable {
                 Object[] row = (Object[])it.next();
                 String id = (String)row[0];
                 String submitterId = (String)row[1];
+                String locationID = (row.length > 2) ? (String)row[2] : null;
                 org.json.JSONArray viewUsers = new org.json.JSONArray();
+                Set<String> viewUserIds = new java.util.LinkedHashSet<String>();
                 String uid = usernameToId.get(submitterId);
                 if (uid == null) {
                     System.out.println("opensearchIndexPermissions(): WARNING invalid username " +
@@ -4386,9 +4418,15 @@ public class Encounter extends Base implements java.io.Serializable {
                     if (localCollabs.contains(submitterId) && !localUid.equals(uid)) {
                         // if the submitterId is in the list, put the uid of the user in viewUsers for OpenSearch
                         // (skip self-collab: localUid == uid means the collaborator IS the owner)
-                        viewUsers.put(localUid);
+                        viewUserIds.add(localUid);
                     }
                 }
+                // location-based roles: everyone holding a Role named after this encounter's
+                // locationID or an ancestor of it (same rule as computeViewUsers)
+                viewUserIds.addAll(org.ecocean.security.LocationRoleAccess.viewUserIdsForLocation(
+                    locationID, roleNameToUserIds, lineageCache));
+                viewUserIds.remove(uid); // the owner is granted via submitterUserId, never listed
+                for (String viewUid : viewUserIds) viewUsers.put(viewUid);
                 updateData.put("viewUsers", viewUsers); // always write, incl [] so revocation propagates
                 // Child-reindex change-detection: compare freshly computed viewUsers (as a set) to
                 // what is CURRENTLY indexed. Enqueue the deep child reindex ONLY when the currently

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -3332,6 +3332,16 @@ public class Encounter extends Base implements java.io.Serializable {
         return Collaboration.canUserAccessEncounter(this, request);
     }
 
+    // same rule as canUserAccess(User, String) but the location-based role lookup reuses the
+    // caller's Shepherd instead of opening one (see Collaboration.canUserAccessEncounter)
+    public boolean canUserAccess(User user, Shepherd myShepherd) {
+        if ((user == null) || (myShepherd == null)) return false;
+        if (isUserOwner(user)) return true;
+        String username = user.getUsername();
+        if (username == null) return false;
+        return Collaboration.canUserAccessEncounter(this, username, myShepherd);
+    }
+
     public boolean canUserAccess(User user, String context) {
         if (user == null) return false;
         // see comment below on canUserEdit(); substituting isUserOwner() now
@@ -3347,8 +3357,7 @@ public class Encounter extends Base implements java.io.Serializable {
        cause unintended consequences. so, for now, canUserView() is pretty much exclusively for search
      */
     public boolean canUserView(User user, Shepherd myShepherd) {
-        return (user != null) && (user.isAdmin(myShepherd) || this.canUserAccess(user,
-                myShepherd.getContext()));
+        return (user != null) && (user.isAdmin(myShepherd) || this.canUserAccess(user, myShepherd));
     }
 
     // as part of 10.9, canUserEdit() was modified. it was not
@@ -3367,7 +3376,10 @@ public class Encounter extends Base implements java.io.Serializable {
         // legacy ServletUtilities.isUserAuthorizedForEncounter() behavior
         if (User.isUsernameAnonymous(this.getSubmitterID())) return true;
         if (Collaboration.canEditEncounter(this, user, myShepherd.getContext())) return true;
-        // TODO there seems to be some legacy stuff about roles based on location. is this real?
+        // location-based role: a Role named after this encounter's locationID, or an ancestor of
+        // it in the locationID tree, grants edit (parity with the classic-page check)
+        if (org.ecocean.security.LocationRoleAccess.userHasLocationRole(user.getUsername(),
+            this.getLocationID(), myShepherd)) return true;
         return false;
     }
 

--- a/src/main/java/org/ecocean/Encounter.java
+++ b/src/main/java/org/ecocean/Encounter.java
@@ -4328,8 +4328,7 @@ public class Encounter extends Base implements java.io.Serializable {
             for (Role role : myShepherd.getRolesInContext("context0")) {
                 if ((role == null) || (role.getRolename() == null) || (role.getUsername() == null))
                     continue;
-                if (org.ecocean.security.LocationRoleAccess.SYSTEM_ROLE_NAMES.contains(
-                    role.getRolename())) continue;
+                if (Role.SYSTEM_ROLE_NAMES.contains(role.getRolename())) continue;
                 String roleUid = usernameToId.get(role.getUsername());
                 if (roleUid == null) continue;
                 if (!roleNameToUserIds.containsKey(role.getRolename()))

--- a/src/main/java/org/ecocean/LocationID.java
+++ b/src/main/java/org/ecocean/LocationID.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Properties;
@@ -315,6 +316,51 @@ public class LocationID {
                 }
             }
         } catch (JSONException e) {}
+    }
+
+    /**
+     * Root-to-node lineage of ids for locationID in tree (the node itself is last). The root is
+     * part of the lineage when it carries an id. Returns just [locationID] when the tree is null,
+     * the id is absent, or the id appears more than once (ambiguous); empty for a blank id.
+     *
+     * Unlike getIDForChildAndParents() this yields a single path: an id that appears under more
+     * than one parent falls back to exact match, where that method can flatten several matching
+     * branches into one list.
+     */
+    public static List<String> lineageFor(String locationID, JSONObject tree) {
+        if ((locationID == null) || locationID.trim().isEmpty()) return Collections.emptyList();
+        List<String> exactOnly = Collections.singletonList(locationID);
+        if (tree == null) return exactOnly;
+        List<List<String> > paths = new ArrayList<List<String> >();
+        try {
+            collectPaths(tree, locationID, new ArrayList<String>(), paths);
+        } catch (Exception ex) {
+            return exactOnly;
+        }
+        if (paths.size() != 1) return exactOnly;
+        return paths.get(0);
+    }
+
+    // depth-first walk recording every root-to-node path ending at a node whose id equals target;
+    // a node with a blank or missing id is still traversed but contributes nothing to the path
+    private static void collectPaths(Object node, String target, List<String> path,
+        List<List<String> > out) {
+        if (!(node instanceof JSONObject)) return; // malformed entry: ignore
+        JSONObject json = (JSONObject)node;
+        String id = json.optString("id", null);
+        boolean pushed = false;
+        if ((id != null) && !id.trim().isEmpty()) {
+            path.add(id);
+            pushed = true;
+            if (id.equals(target)) out.add(new ArrayList<String>(path));
+        }
+        JSONArray kids = json.optJSONArray("locationID");
+        if (kids != null) {
+            for (int i = 0; i < kids.length(); i++) {
+                collectPaths(kids.opt(i), target, path, out);
+            }
+        }
+        if (pushed) path.remove(path.size() - 1);
     }
 
     private static String getIDIfContainsChildID(JSONObject jsonobj, String childID,

--- a/src/main/java/org/ecocean/Role.java
+++ b/src/main/java/org/ecocean/Role.java
@@ -1,11 +1,35 @@
 package org.ecocean;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 /**
  * <code>User</code> stores information about a contact/user. Examples: photographer, submitter
  * @author Ed Stastny
  */
 public class Role implements java.io.Serializable {
     private static final long serialVersionUID = -7034712240056255450L;
+
+    /**
+     * The role names Wildbook defines itself, highest privilege first. They are seeded at first
+     * startup (StartupWildbook), ranked when merging two users (UserConsolidate), and excluded
+     * from location-based role matching (LocationRoleAccess) so that a location id which happens
+     * to collide with one of them is never read as a location grant.
+     *
+     * This is not the list of roles an admin may assign: that is the indexed "roleN" property in
+     * commonConfiguration.properties, which installs extend with their own location role names
+     * (see appadmin/users.jsp). Site configuration must not change what counts as a system role,
+     * because the names below are also hard-coded in the Shiro rules in web.xml.
+     */
+    public static final List<String> SYSTEM_ROLES = Collections.unmodifiableList(
+        Arrays.asList("admin", "orgAdmin", "researcher", "rest", "machinelearning"));
+
+    /** SYSTEM_ROLES as a set, for membership tests where the hierarchy order does not matter. */
+    public static final Set<String> SYSTEM_ROLE_NAMES = Collections.unmodifiableSet(
+        new LinkedHashSet<String>(SYSTEM_ROLES));
 
     private String username;
     private String rolename;

--- a/src/main/java/org/ecocean/StartupWildbook.java
+++ b/src/main/java/org/ecocean/StartupWildbook.java
@@ -120,21 +120,12 @@ public class StartupWildbook implements ServletContextListener {
                 myShepherd.beginDBTransaction();
                 System.out.println("Creating tomcat roles...");
 
-                Role newRole1 = new Role("tomcat", "admin");
-                newRole1.setContext("context0");
-                myShepherd.getPM().makePersistent(newRole1);
-                Role newRole1a = new Role("tomcat", "orgAdmin");
-                newRole1a.setContext("context0");
-                myShepherd.getPM().makePersistent(newRole1a);
-                Role newRole2 = new Role("tomcat", "researcher");
-                newRole2.setContext("context0");
-                myShepherd.getPM().makePersistent(newRole2);
-                Role newRole3 = new Role("tomcat", "machinelearning");
-                newRole3.setContext("context0");
-                myShepherd.getPM().makePersistent(newRole3);
-                Role newRole5 = new Role("tomcat", "rest");
-                newRole5.setContext("context0");
-                myShepherd.getPM().makePersistent(newRole5);
+                // seeded in hierarchy order; the order these rows are written is not significant
+                for (String rolename : Role.SYSTEM_ROLES) {
+                    Role newRole = new Role("tomcat", rolename);
+                    newRole.setContext("context0");
+                    myShepherd.getPM().makePersistent(newRole);
+                }
                 myShepherd.commitDBTransaction();
                 System.out.println("Creating tomcat user account...");
             }

--- a/src/main/java/org/ecocean/security/Collaboration.java
+++ b/src/main/java/org/ecocean/security/Collaboration.java
@@ -476,6 +476,8 @@ public class Collaboration implements java.io.Serializable {
 
     public static boolean canUserAccessEncounter(Encounter enc, HttpServletRequest request) {
         if (enc != null && enc.getSubmitterID() == null) return true;
+        // location-based role (a Role named after the encounter's locationID or an ancestor)
+        if (LocationRoleAccess.requestHasLocationRole(request, enc.getLocationID())) return true;
         // System.out.println("canUserAccessEncounter(Encounter enc, HttpServletRequest request)");
         return canUserAccessOwnedObject(enc.getAssignedUsername(), request);
     }
@@ -484,8 +486,40 @@ public class Collaboration implements java.io.Serializable {
         String owner = enc.getAssignedUsername();
 
         if (User.isUsernameAnonymous(owner)) return true; // anon-owned is "fair game" to anyone
+        if (userHasLocationRole(enc, context, username)) return true;
         // System.out.println("canUserAccessEncounter(Encounter enc, String context, String username)");
         return canCollaborate(context, username, owner);
+    }
+
+    // same rule as above, reusing the caller's Shepherd for the location-role lookup
+    public static boolean canUserAccessEncounter(Encounter enc, String username,
+        Shepherd myShepherd) {
+        if ((enc == null) || (username == null) || (myShepherd == null)) return false;
+        String owner = enc.getAssignedUsername();
+        if (User.isUsernameAnonymous(owner)) return true; // anon-owned is "fair game" to anyone
+        if (LocationRoleAccess.userHasLocationRole(username, enc.getLocationID(), myShepherd))
+            return true;
+        return canCollaborate(myShepherd.getContext(), username, owner);
+    }
+
+    // location-based role lookup on a short-lived Shepherd, closed before any collaboration
+    // lookup opens its own (see collaborationBetweenUsers)
+    private static boolean userHasLocationRole(Encounter enc, String context, String username) {
+        if ((enc == null) || (username == null)) return false;
+        if (LocationRoleAccess.roleNamesFor(enc.getLocationID()).isEmpty()) return false;
+        Shepherd myShepherd = new Shepherd(context);
+        myShepherd.setAction("Collaboration.userHasLocationRole");
+        try {
+            myShepherd.beginDBTransaction();
+            return LocationRoleAccess.userHasLocationRole(username, enc.getLocationID(),
+                    myShepherd);
+        } catch (Exception ex) {
+            System.out.println("Collaboration.userHasLocationRole failed for " + username +
+                " on " + enc.getCatalogNumber() + ": " + ex);
+            return false;
+        } finally {
+            myShepherd.rollbackAndClose();
+        }
     }
 
     public static boolean canUserViewOccurrence(Occurrence occ, User user, Shepherd myShepherd) {

--- a/src/main/java/org/ecocean/security/LocationRoleAccess.java
+++ b/src/main/java/org/ecocean/security/LocationRoleAccess.java
@@ -1,19 +1,16 @@
 package org.ecocean.security;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import org.ecocean.LocationID;
+import org.ecocean.Role;
 import org.ecocean.User;
 import org.ecocean.shepherd.core.Shepherd;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 /**
@@ -35,12 +32,12 @@ import org.json.JSONObject;
  *   (ambiguous), gets exact-name matching only;
  * - blank ids in the tree are skipped; a null or blank locationID grants nothing;
  * - system role names never count as location roles, even when a location id collides with one.
+ *
+ * The lineage walk itself is tree geometry with no role concept in it, so it lives on
+ * LocationID.lineageFor(); the system role names live on Role.SYSTEM_ROLE_NAMES, shared with
+ * StartupWildbook and UserConsolidate.
  */
 public final class LocationRoleAccess {
-    public static final Set<String> SYSTEM_ROLE_NAMES = Collections.unmodifiableSet(
-        new HashSet<String>(Arrays.asList("admin", "orgAdmin", "researcher", "rest",
-        "machinelearning")));
-
     private LocationRoleAccess() {}
 
     /** Role names that grant access to an encounter at locationID: itself plus its ancestors
@@ -57,49 +54,9 @@ public final class LocationRoleAccess {
     }
 
     static Set<String> roleNamesFor(String locationID, JSONObject tree) {
-        Set<String> names = new LinkedHashSet<String>(lineageFor(locationID, tree));
-        names.removeAll(SYSTEM_ROLE_NAMES);
+        Set<String> names = new LinkedHashSet<String>(LocationID.lineageFor(locationID, tree));
+        names.removeAll(Role.SYSTEM_ROLE_NAMES);
         return names;
-    }
-
-    /**
-     * Root-to-node lineage of ids for locationID in tree (the node itself is last). The root is
-     * part of the lineage when it carries an id. Returns just [locationID] when the tree is null,
-     * the id is absent, or the id appears more than once (ambiguous); empty for a blank id.
-     */
-    public static List<String> lineageFor(String locationID, JSONObject tree) {
-        if (isBlank(locationID)) return Collections.emptyList();
-        List<String> exactOnly = Collections.singletonList(locationID);
-        if (tree == null) return exactOnly;
-        List<List<String> > paths = new ArrayList<List<String> >();
-        try {
-            collectPaths(tree, locationID, new ArrayList<String>(), paths);
-        } catch (Exception ex) {
-            return exactOnly;
-        }
-        if (paths.size() != 1) return exactOnly;
-        return paths.get(0);
-    }
-
-    // depth-first walk recording every path that ends at a node whose id equals target
-    private static void collectPaths(Object node, String target, List<String> path,
-        List<List<String> > out) {
-        if (!(node instanceof JSONObject)) return; // malformed entry: ignore
-        JSONObject json = (JSONObject)node;
-        String id = json.optString("id", null);
-        boolean pushed = false;
-        if (!isBlank(id)) {
-            path.add(id);
-            pushed = true;
-            if (id.equals(target)) out.add(new ArrayList<String>(path));
-        }
-        JSONArray kids = json.optJSONArray("locationID");
-        if (kids != null) {
-            for (int i = 0; i < kids.length(); i++) {
-                collectPaths(kids.opt(i), target, path, out);
-            }
-        }
-        if (pushed) path.remove(path.size() - 1);
     }
 
     /** Shiro path: does the request's user hold any role that covers locationID? */

--- a/src/main/java/org/ecocean/security/LocationRoleAccess.java
+++ b/src/main/java/org/ecocean/security/LocationRoleAccess.java
@@ -1,0 +1,165 @@
+package org.ecocean.security;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
+import org.ecocean.LocationID;
+import org.ecocean.User;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Location-based roles.
+ *
+ * A Role whose name equals an encounter's locationID, or the id of an ancestor of that node in
+ * the default locationID.json tree, grants view and edit access to the encounter. This is the
+ * one place that decides which role names count for a given location, so the live access checks
+ * (Encounter.canUserView/canUserEdit, Collaboration.canUserAccessEncounter,
+ * ServletUtilities.isUserAuthorizedForEncounter) and both OpenSearch viewUsers writers
+ * (Encounter.computeViewUsers and the background permissions pass) agree.
+ *
+ * Rules:
+ * - a role at a node covers that node and its whole subtree; a child-node role never grants the
+ *   parent;
+ * - lineage always comes from the DEFAULT tree (no per-user/org qualifier), so the decision is
+ *   the same for every viewer;
+ * - a locationID that is missing from the tree, or that appears under more than one parent
+ *   (ambiguous), gets exact-name matching only;
+ * - blank ids in the tree are skipped; a null or blank locationID grants nothing;
+ * - system role names never count as location roles, even when a location id collides with one.
+ */
+public final class LocationRoleAccess {
+    public static final Set<String> SYSTEM_ROLE_NAMES = Collections.unmodifiableSet(
+        new HashSet<String>(Arrays.asList("admin", "orgAdmin", "researcher", "rest",
+        "machinelearning")));
+
+    private LocationRoleAccess() {}
+
+    /** Role names that grant access to an encounter at locationID: itself plus its ancestors
+     *  in the default tree, minus system role names. Empty for a null/blank locationID. */
+    public static Set<String> roleNamesFor(String locationID) {
+        if (isBlank(locationID)) return Collections.emptySet();
+        JSONObject tree = null;
+        try {
+            tree = LocationID.getLocationIDStructure();
+        } catch (Exception ex) {
+            tree = null; // unreadable tree: exact match only
+        }
+        return roleNamesFor(locationID, tree);
+    }
+
+    static Set<String> roleNamesFor(String locationID, JSONObject tree) {
+        Set<String> names = new LinkedHashSet<String>(lineageFor(locationID, tree));
+        names.removeAll(SYSTEM_ROLE_NAMES);
+        return names;
+    }
+
+    /**
+     * Root-to-node lineage of ids for locationID in tree (the node itself is last). The root is
+     * part of the lineage when it carries an id. Returns just [locationID] when the tree is null,
+     * the id is absent, or the id appears more than once (ambiguous); empty for a blank id.
+     */
+    public static List<String> lineageFor(String locationID, JSONObject tree) {
+        if (isBlank(locationID)) return Collections.emptyList();
+        List<String> exactOnly = Collections.singletonList(locationID);
+        if (tree == null) return exactOnly;
+        List<List<String> > paths = new ArrayList<List<String> >();
+        try {
+            collectPaths(tree, locationID, new ArrayList<String>(), paths);
+        } catch (Exception ex) {
+            return exactOnly;
+        }
+        if (paths.size() != 1) return exactOnly;
+        return paths.get(0);
+    }
+
+    // depth-first walk recording every path that ends at a node whose id equals target
+    private static void collectPaths(Object node, String target, List<String> path,
+        List<List<String> > out) {
+        if (!(node instanceof JSONObject)) return; // malformed entry: ignore
+        JSONObject json = (JSONObject)node;
+        String id = json.optString("id", null);
+        boolean pushed = false;
+        if (!isBlank(id)) {
+            path.add(id);
+            pushed = true;
+            if (id.equals(target)) out.add(new ArrayList<String>(path));
+        }
+        JSONArray kids = json.optJSONArray("locationID");
+        if (kids != null) {
+            for (int i = 0; i < kids.length(); i++) {
+                collectPaths(kids.opt(i), target, path, out);
+            }
+        }
+        if (pushed) path.remove(path.size() - 1);
+    }
+
+    /** Shiro path: does the request's user hold any role that covers locationID? */
+    public static boolean requestHasLocationRole(HttpServletRequest request, String locationID) {
+        if (request == null) return false;
+        for (String name : roleNamesFor(locationID)) {
+            if (request.isUserInRole(name)) return true;
+        }
+        return false;
+    }
+
+    /** Database path, on the caller's Shepherd: does username hold any covering role in the
+     *  Shepherd's context? */
+    public static boolean userHasLocationRole(String username, String locationID,
+        Shepherd myShepherd) {
+        if ((username == null) || (myShepherd == null)) return false;
+        Set<String> names = roleNamesFor(locationID);
+        if (names.isEmpty()) return false;
+        return myShepherd.doesUserHaveAnyRole(username, names, myShepherd.getContext());
+    }
+
+    /** User UUIDs of everyone holding a covering role in the Shepherd's context (for the
+     *  OpenSearch viewUsers field). Users without a resolvable id are skipped. */
+    public static Set<String> userIdsWithLocationRole(String locationID, Shepherd myShepherd) {
+        Set<String> ids = new LinkedHashSet<String>();
+        if (myShepherd == null) return ids;
+        Set<String> names = roleNamesFor(locationID);
+        if (names.isEmpty()) return ids;
+        List<String> usernames = myShepherd.getUsernamesWithAnyRole(names, myShepherd.getContext());
+        if (usernames == null) return ids;
+        for (String username : usernames) {
+            if (username == null) continue;
+            User user = myShepherd.getUser(username);
+            if ((user != null) && (user.getId() != null)) ids.add(user.getId());
+        }
+        return ids;
+    }
+
+    /**
+     * Pure helper for the background permissions pass: the user ids granted by location roles
+     * for locationID, given a precomputed role-name -> user-ids map. lineageCache memoizes
+     * roleNamesFor per locationID so the tree is walked once per distinct location per pass.
+     */
+    public static Set<String> viewUserIdsForLocation(String locationID,
+        Map<String, Set<String> > roleNameToUserIds, Map<String, Set<String> > lineageCache) {
+        Set<String> ids = new LinkedHashSet<String>();
+        if (isBlank(locationID) || (roleNameToUserIds == null)) return ids;
+        Set<String> names = (lineageCache == null) ? null : lineageCache.get(locationID);
+        if (names == null) {
+            names = roleNamesFor(locationID);
+            if (lineageCache != null) lineageCache.put(locationID, names);
+        }
+        for (String name : names) {
+            Collection<String> users = roleNameToUserIds.get(name);
+            if (users != null) ids.addAll(users);
+        }
+        return ids;
+    }
+
+    private static boolean isBlank(String str) {
+        return (str == null) || str.trim().isEmpty();
+    }
+}

--- a/src/main/java/org/ecocean/servlet/EncounterSetLocationID.java
+++ b/src/main/java/org/ecocean/servlet/EncounterSetLocationID.java
@@ -65,6 +65,9 @@ public class EncounterSetLocationID extends HttpServlet {
            myShepherd.rollbackDBTransaction();
            }
          */
+        // release the transaction and the writer on every path, including an exception thrown by
+        // the authorization check (body deliberately not re-indented to keep the diff reviewable)
+        try {
         if ((request.getParameter("code") != null) && (request.getParameter("number") != null)) {
             String oldCode = "";
             myShepherd.beginDBTransaction();
@@ -78,8 +81,6 @@ public class EncounterSetLocationID extends HttpServlet {
                 response.setStatus(HttpServletResponse.SC_NOT_FOUND);
                 response.setContentType("application/json");
                 out.println("{\"success\":false,\"error\":\"encounter not found\"}");
-                out.close();
-                myShepherd.closeDBTransaction();
                 return;
             }
             User currentUser = myShepherd.getUser(request);
@@ -88,8 +89,6 @@ public class EncounterSetLocationID extends HttpServlet {
                 response.setStatus(HttpServletResponse.SC_FORBIDDEN);
                 response.setContentType("application/json");
                 out.println("{\"success\":false,\"error\":\"access denied\"}");
-                out.close();
-                myShepherd.closeDBTransaction();
                 return;
             }
             changeMe.setOpensearchProcessPermissions(true);
@@ -151,7 +150,16 @@ public class EncounterSetLocationID extends HttpServlet {
             // out.println("<p><a href=\"individualSearchResults.jsp\">View all individuals</a></font></p>");
             // out.println(ServletUtilities.getFooter(context));
         }
-        out.close();
-        myShepherd.closeDBTransaction();
+        } catch (Exception ex) {
+            // e.g. the role lookup threw: never leak the transaction, never report success
+            ex.printStackTrace();
+            myShepherd.rollbackDBTransaction();
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setContentType("application/json");
+            out.println("{\"success\":false,\"error\":\"internal error\"}");
+        } finally {
+            out.close();
+            myShepherd.closeDBTransaction();
+        }
     }
 }

--- a/src/main/java/org/ecocean/servlet/EncounterSetLocationID.java
+++ b/src/main/java/org/ecocean/servlet/EncounterSetLocationID.java
@@ -2,6 +2,7 @@ package org.ecocean.servlet;
 
 import org.ecocean.Encounter;
 import org.ecocean.LocationID;
+import org.ecocean.User;
 import org.ecocean.shepherd.core.Shepherd;
 
 import javax.servlet.http.HttpServlet;
@@ -64,11 +65,33 @@ public class EncounterSetLocationID extends HttpServlet {
            myShepherd.rollbackDBTransaction();
            }
          */
-        if (request.getParameter("code") != null) {
+        if ((request.getParameter("code") != null) && (request.getParameter("number") != null)) {
             String oldCode = "";
             myShepherd.beginDBTransaction();
             String encNum = request.getParameter("number").trim();
             Encounter changeMe = myShepherd.getEncounter(encNum);
+            // authorize against the encounter as persisted, before anything changes: the caller
+            // must already be allowed to edit it (owner, admin, edit collaboration, or a
+            // location-based role covering its CURRENT location)
+            if (changeMe == null) {
+                myShepherd.rollbackDBTransaction();
+                response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                response.setContentType("application/json");
+                out.println("{\"success\":false,\"error\":\"encounter not found\"}");
+                out.close();
+                myShepherd.closeDBTransaction();
+                return;
+            }
+            User currentUser = myShepherd.getUser(request);
+            if (!changeMe.canUserEdit(currentUser, myShepherd)) {
+                myShepherd.rollbackDBTransaction();
+                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                response.setContentType("application/json");
+                out.println("{\"success\":false,\"error\":\"access denied\"}");
+                out.close();
+                myShepherd.closeDBTransaction();
+                return;
+            }
             changeMe.setOpensearchProcessPermissions(true);
             setDateLastModified(changeMe);
             try {

--- a/src/main/java/org/ecocean/servlet/ServletUtilities.java
+++ b/src/main/java/org/ecocean/servlet/ServletUtilities.java
@@ -527,9 +527,10 @@ public class ServletUtilities {
                 // check other cases
                 // ----------------
                 // if the current user has a location ID-specific role matching the location ID
-                // of this Encounter, they are authorized
-                if (!isOwner && enc.getLocationCode() != null &&
-                    request.isUserInRole(enc.getLocationCode())) {
+                // of this Encounter (or an ancestor of it in the locationID tree), they are
+                // authorized -- same rule as the API/React checks, see LocationRoleAccess
+                if (!isOwner && org.ecocean.security.LocationRoleAccess.requestHasLocationRole(
+                    request, enc.getLocationCode())) {
                     isOwner = true;
                 }
                 // if the current user is in a collaboration with the Encounter owner

--- a/src/main/java/org/ecocean/servlet/UserConsolidate.java
+++ b/src/main/java/org/ecocean/servlet/UserConsolidate.java
@@ -7,7 +7,6 @@ package org.ecocean.servlet;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.*;
-import java.util.LinkedList;
 import java.util.Random;
 import javax.jdo.*;
 import javax.servlet.http.HttpServlet;
@@ -908,13 +907,8 @@ public class UserConsolidate extends HttpServlet {
         for (Role currentRole : bRoles) {
             bRoleNames.add(currentRole.getRolename());
         }
-        List<String> roleHierarchy = new LinkedList<String>(); // ArrayBlockingQueue because of enforce FIFO structure
-        roleHierarchy.add("admin"); // don't know how to make this anything but hard-coded, highest-in-hierarchy first
-        roleHierarchy.add("orgAdmin");
-        roleHierarchy.add("researcher");
-        roleHierarchy.add("rest");
-        roleHierarchy.add("machinelearning");
-        for (String currentRoleBeingChecked : roleHierarchy) {
+        // Role.SYSTEM_ROLES is ordered highest-in-hierarchy first
+        for (String currentRoleBeingChecked : Role.SYSTEM_ROLES) {
             if (aRoleNames.contains(currentRoleBeingChecked) &&
                 !bRoleNames.contains(currentRoleBeingChecked)) {
                 return true;

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -995,19 +995,72 @@ public class Shepherd {
         return roles;
     }
 
-    // skeletons: behavior driven by LocationRoleShepherdDbTest (location-based roles, #1549)
+    /**
+     * True when username holds at least one of rolenames in context (location-based roles, see
+     * LocationRoleAccess). Parameterized JDOQL, so names may contain quotes. A null or empty
+     * name set, username, or context never queries and is false. Matches on the stored context
+     * column, so a Role row with a NULL context does not satisfy any context (Shiro parity).
+     */
     public boolean doesUserHaveAnyRole(String username, java.util.Collection<String> rolenames,
         String context) {
-        throw new UnsupportedOperationException("not implemented yet");
+        if ((username == null) || (context == null) || (rolenames == null) ||
+            rolenames.isEmpty()) return false;
+        Query query = pm.newQuery(Role.class);
+        try {
+            query.setFilter(
+                "this.username == :u && this.context == :c && :names.contains(this.rolename)");
+            java.util.Map<String, Object> params = new java.util.HashMap<String, Object>();
+            params.put("u", username);
+            params.put("c", context);
+            params.put("names", new ArrayList<String>(new java.util.LinkedHashSet<String>(rolenames)));
+            Collection c = (Collection)query.executeWithMap(params);
+            return (c != null) && !c.isEmpty();
+        } finally {
+            query.closeAll();
+        }
     }
 
+    /** Distinct usernames holding at least one of rolenames in context. Empty for null/empty
+     *  inputs without querying. Results are copied before the query is closed. */
     public List<String> getUsernamesWithAnyRole(java.util.Collection<String> rolenames,
         String context) {
-        throw new UnsupportedOperationException("not implemented yet");
+        List<String> usernames = new ArrayList<String>();
+        if ((context == null) || (rolenames == null) || rolenames.isEmpty()) return usernames;
+        Query query = pm.newQuery(Role.class);
+        try {
+            query.setFilter("this.context == :c && :names.contains(this.rolename)");
+            query.setResult("distinct this.username");
+            java.util.Map<String, Object> params = new java.util.HashMap<String, Object>();
+            params.put("c", context);
+            params.put("names", new ArrayList<String>(new java.util.LinkedHashSet<String>(rolenames)));
+            Collection c = (Collection)query.executeWithMap(params);
+            if (c != null) {
+                for (Object o : c) {
+                    if (o != null) usernames.add(o.toString());
+                }
+            }
+        } finally {
+            query.closeAll();
+        }
+        return usernames;
     }
 
+    /** All Role rows stored with exactly this context. Unlike getAllRoles(), a datastore failure
+     *  propagates so callers can abort rather than treat the roles as absent. */
     public List<Role> getRolesInContext(String context) {
-        throw new UnsupportedOperationException("not implemented yet");
+        List<Role> roles = new ArrayList<Role>();
+        if (context == null) return roles;
+        Query query = pm.newQuery(Role.class);
+        try {
+            query.setFilter("this.context == :c");
+            java.util.Map<String, Object> params = new java.util.HashMap<String, Object>();
+            params.put("c", context);
+            Collection c = (Collection)query.executeWithMap(params);
+            if (c != null) roles.addAll(c);
+        } finally {
+            query.closeAll();
+        }
+        return roles;
     }
 
     public boolean doesUserHaveRole(String username, String rolename, String context) {

--- a/src/main/java/org/ecocean/shepherd/core/Shepherd.java
+++ b/src/main/java/org/ecocean/shepherd/core/Shepherd.java
@@ -995,6 +995,21 @@ public class Shepherd {
         return roles;
     }
 
+    // skeletons: behavior driven by LocationRoleShepherdDbTest (location-based roles, #1549)
+    public boolean doesUserHaveAnyRole(String username, java.util.Collection<String> rolenames,
+        String context) {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
+    public List<String> getUsernamesWithAnyRole(java.util.Collection<String> rolenames,
+        String context) {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
+    public List<Role> getRolesInContext(String context) {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
     public boolean doesUserHaveRole(String username, String rolename, String context) {
         if (username == null) return false;
         if (rolename == null) return false;

--- a/src/test/java/org/ecocean/LocationIDLineageTest.java
+++ b/src/test/java/org/ecocean/LocationIDLineageTest.java
@@ -1,0 +1,74 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * LocationID.lineageFor(): the root-to-node path through a locationID tree. Callers (currently
+ * LocationRoleAccess, for issue #1549) rely on it returning a single path or nothing useful --
+ * never a union of branches, which is how the older getIDForChildAndParents() behaves.
+ */
+class LocationIDLineageTest {
+    @Test void identifiedRootIsPartOfTheLineage() {
+        JSONObject tree = new JSONObject(
+            "{\"id\":\"World\",\"locationID\":[{\"id\":\"X\",\"locationID\":[]}]}");
+
+        assertEquals(Arrays.asList("World", "X"), LocationID.lineageFor("X", tree));
+        assertEquals(Arrays.asList("World"), LocationID.lineageFor("World", tree));
+    }
+
+    @Test void nestedLeafCarriesEveryAncestorInOrder() {
+        JSONObject tree = new JSONObject(
+            "{\"locationID\":[{\"id\":\"Indonesia\",\"locationID\":[{\"id\":\"Flores Sea\","
+            + "\"locationID\":[{\"id\":\"Komodo\"}]}]}]}");
+
+        assertEquals(Arrays.asList("Indonesia", "Flores Sea", "Komodo"),
+            LocationID.lineageFor("Komodo", tree), "root-to-node order, node last");
+    }
+
+    @Test void duplicatedIdFallsBackToExactOnly() {
+        JSONObject tree = new JSONObject(
+            "{\"locationID\":[{\"id\":\"A\",\"locationID\":[{\"id\":\"Twin\"}]},"
+            + "{\"id\":\"B\",\"locationID\":[{\"id\":\"Twin\"}]}]}");
+
+        assertEquals(Arrays.asList("Twin"), LocationID.lineageFor("Twin", tree),
+            "an id under two parents must not inherit the ancestors of either");
+    }
+
+    @Test void blankIntermediateIdIsSkipped() {
+        JSONObject tree = new JSONObject(
+            "{\"locationID\":[{\"id\":\"  \",\"locationID\":[{\"id\":\"Orphan\"}]}]}");
+
+        assertEquals(Arrays.asList("Orphan"), LocationID.lineageFor("Orphan", tree));
+    }
+
+    @Test void idNotInTreeIsExactOnly() {
+        JSONObject tree = new JSONObject("{\"locationID\":[{\"id\":\"X\"}]}");
+
+        assertEquals(Arrays.asList("Atlantis"), LocationID.lineageFor("Atlantis", tree));
+    }
+
+    @Test void nullTreeYieldsExactOnly() {
+        assertEquals(Arrays.asList("X"), LocationID.lineageFor("X", null));
+    }
+
+    @Test void malformedChildEntriesAreIgnored() {
+        JSONObject tree = new JSONObject(
+            "{\"locationID\":[\"not-an-object\", 7, {\"name\":\"no id here\",\"locationID\":["
+            + "{\"id\":\"Deep\",\"locationID\":\"not-an-array\"}]}]}");
+
+        assertEquals(Arrays.asList("Deep"), LocationID.lineageFor("Deep", tree));
+    }
+
+    @Test void blankLocationIdYieldsNothing() {
+        JSONObject tree = new JSONObject("{\"locationID\":[{\"id\":\"X\"}]}");
+
+        assertEquals(Collections.emptyList(), LocationID.lineageFor(null, tree));
+        assertEquals(Collections.emptyList(), LocationID.lineageFor("", tree));
+        assertEquals(Collections.emptyList(), LocationID.lineageFor("   ", tree));
+    }
+}

--- a/src/test/java/org/ecocean/RoleTest.java
+++ b/src/test/java/org/ecocean/RoleTest.java
@@ -1,0 +1,39 @@
+package org.ecocean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Role.SYSTEM_ROLES is shared by StartupWildbook (seeding), UserConsolidate (ranking two users)
+ * and LocationRoleAccess (names that must never be read as a locationID), so both its order and
+ * its immutability are load-bearing.
+ */
+class RoleTest {
+    @Test void systemRolesAreOrderedHighestPrivilegeFirst() {
+        assertEquals(Arrays.asList("admin", "orgAdmin", "researcher", "rest", "machinelearning"),
+            Role.SYSTEM_ROLES, "UserConsolidate walks this order to rank two users");
+    }
+
+    @Test void systemRoleNamesHoldsExactlyTheSameNames() {
+        assertEquals(new LinkedHashSet<String>(Role.SYSTEM_ROLES), Role.SYSTEM_ROLE_NAMES);
+        assertTrue(Role.SYSTEM_ROLE_NAMES.contains("orgAdmin"));
+        assertEquals(Role.SYSTEM_ROLES.size(), Role.SYSTEM_ROLE_NAMES.size(), "no duplicates");
+    }
+
+    @Test void systemRolesAreImmutable() {
+        assertThrows(UnsupportedOperationException.class, () -> Role.SYSTEM_ROLES.add("intruder"));
+        assertThrows(UnsupportedOperationException.class,
+            () -> Role.SYSTEM_ROLE_NAMES.add("intruder"));
+    }
+
+    @Test void nullContextReadsAsContext0() {
+        Role role = new Role("tomcat", "admin");
+
+        assertEquals("context0", role.getContext(), "ShepherdRealm relies on this default");
+    }
+}

--- a/src/test/java/org/ecocean/security/LocationRoleAccessTest.java
+++ b/src/test/java/org/ecocean/security/LocationRoleAccessTest.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
-import org.ecocean.LocationID;
 import org.ecocean.User;
 import org.ecocean.shepherd.core.Shepherd;
 import org.json.JSONObject;
@@ -35,44 +34,17 @@ import org.mockito.ArgumentCaptor;
 class LocationRoleAccessTest {
     private JSONObject previousDefaultTree;
 
-    // root (no id)
-    //   Pakistan
-    //     PAKISTAN - North
-    //     PAKISTAN - South
-    //   Indonesia
-    //     Flores Sea
-    //       Komodo
-    //   Dup  -> Twin        (Twin appears under two parents: ambiguous)
-    //   Other -> Twin
-    //   ""   -> Orphan      (blank-id intermediate node)
-    //   researcher -> Lab   (node named like a system role)
-    private static JSONObject fixtureTree() {
-        return new JSONObject("{\"description\":\"test\",\"locationID\":["
-            + "{\"name\":\"Pakistan\",\"id\":\"Pakistan\",\"locationID\":["
-            + "  {\"name\":\"PAKISTAN - North\",\"id\":\"PAKISTAN - North\",\"locationID\":[]},"
-            + "  {\"name\":\"PAKISTAN - South\",\"id\":\"PAKISTAN - South\",\"locationID\":[]}]},"
-            + "{\"name\":\"Indonesia\",\"id\":\"Indonesia\",\"locationID\":["
-            + "  {\"name\":\"Flores Sea\",\"id\":\"Flores Sea\",\"locationID\":["
-            + "    {\"name\":\"Komodo\",\"id\":\"Komodo\",\"locationID\":[]}]}]},"
-            + "{\"name\":\"Dup\",\"id\":\"Dup\",\"locationID\":[{\"name\":\"Twin\",\"id\":\"Twin\",\"locationID\":[]}]},"
-            + "{\"name\":\"Other\",\"id\":\"Other\",\"locationID\":[{\"name\":\"Twin\",\"id\":\"Twin\",\"locationID\":[]}]},"
-            + "{\"name\":\"blank\",\"id\":\"\",\"locationID\":[{\"name\":\"Orphan\",\"id\":\"Orphan\",\"locationID\":[]}]},"
-            + "{\"name\":\"researcher\",\"id\":\"researcher\",\"locationID\":[{\"name\":\"Lab\",\"id\":\"Lab\",\"locationID\":[]}]}"
-            + "]}");
-    }
-
     private static Set<String> set(String... names) {
         return new HashSet<String>(Arrays.asList(names));
     }
 
+    // fixture tree: see LocationRoleTestTree
     @BeforeEach void injectTree() {
-        previousDefaultTree = LocationID.getJSONMaps().get("default");
-        LocationID.getJSONMaps().put("default", fixtureTree());
+        previousDefaultTree = LocationRoleTestTree.inject();
     }
 
     @AfterEach void restoreTree() {
-        if (previousDefaultTree == null) LocationID.getJSONMaps().remove("default");
-        else LocationID.getJSONMaps().put("default", previousDefaultTree);
+        LocationRoleTestTree.restore(previousDefaultTree);
     }
 
     // ---- roleNamesFor: lineage against the default tree ----

--- a/src/test/java/org/ecocean/security/LocationRoleAccessTest.java
+++ b/src/test/java/org/ecocean/security/LocationRoleAccessTest.java
@@ -1,0 +1,244 @@
+package org.ecocean.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
+import org.ecocean.LocationID;
+import org.ecocean.User;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Location-based roles: a Role named after a locationID node grants access to encounters at
+ * that node and everything below it. These tests pin the lineage rules (issue #1549 / #1244).
+ */
+class LocationRoleAccessTest {
+    private JSONObject previousDefaultTree;
+
+    // root (no id)
+    //   Pakistan
+    //     PAKISTAN - North
+    //     PAKISTAN - South
+    //   Indonesia
+    //     Flores Sea
+    //       Komodo
+    //   Dup  -> Twin        (Twin appears under two parents: ambiguous)
+    //   Other -> Twin
+    //   ""   -> Orphan      (blank-id intermediate node)
+    //   researcher -> Lab   (node named like a system role)
+    private static JSONObject fixtureTree() {
+        return new JSONObject("{\"description\":\"test\",\"locationID\":["
+            + "{\"name\":\"Pakistan\",\"id\":\"Pakistan\",\"locationID\":["
+            + "  {\"name\":\"PAKISTAN - North\",\"id\":\"PAKISTAN - North\",\"locationID\":[]},"
+            + "  {\"name\":\"PAKISTAN - South\",\"id\":\"PAKISTAN - South\",\"locationID\":[]}]},"
+            + "{\"name\":\"Indonesia\",\"id\":\"Indonesia\",\"locationID\":["
+            + "  {\"name\":\"Flores Sea\",\"id\":\"Flores Sea\",\"locationID\":["
+            + "    {\"name\":\"Komodo\",\"id\":\"Komodo\",\"locationID\":[]}]}]},"
+            + "{\"name\":\"Dup\",\"id\":\"Dup\",\"locationID\":[{\"name\":\"Twin\",\"id\":\"Twin\",\"locationID\":[]}]},"
+            + "{\"name\":\"Other\",\"id\":\"Other\",\"locationID\":[{\"name\":\"Twin\",\"id\":\"Twin\",\"locationID\":[]}]},"
+            + "{\"name\":\"blank\",\"id\":\"\",\"locationID\":[{\"name\":\"Orphan\",\"id\":\"Orphan\",\"locationID\":[]}]},"
+            + "{\"name\":\"researcher\",\"id\":\"researcher\",\"locationID\":[{\"name\":\"Lab\",\"id\":\"Lab\",\"locationID\":[]}]}"
+            + "]}");
+    }
+
+    private static Set<String> set(String... names) {
+        return new HashSet<String>(Arrays.asList(names));
+    }
+
+    @BeforeEach void injectTree() {
+        previousDefaultTree = LocationID.getJSONMaps().get("default");
+        LocationID.getJSONMaps().put("default", fixtureTree());
+    }
+
+    @AfterEach void restoreTree() {
+        if (previousDefaultTree == null) LocationID.getJSONMaps().remove("default");
+        else LocationID.getJSONMaps().put("default", previousDefaultTree);
+    }
+
+    // ---- roleNamesFor: lineage against the default tree ----
+
+    @Test void leafIncludesItselfAndAncestors() {
+        assertEquals(set("Komodo", "Flores Sea", "Indonesia"),
+            LocationRoleAccess.roleNamesFor("Komodo"), "role at any ancestor covers the leaf");
+    }
+
+    @Test void childOfTopLevelNodeIncludesParent() {
+        assertEquals(set("PAKISTAN - North", "Pakistan"),
+            LocationRoleAccess.roleNamesFor("PAKISTAN - North"));
+    }
+
+    @Test void parentNodeIsNotCoveredByChildRoles() {
+        assertEquals(set("Pakistan"), LocationRoleAccess.roleNamesFor("Pakistan"),
+            "a child-node role must not grant the parent-node encounter");
+    }
+
+    @Test void siblingIsNotIncluded() {
+        assertFalse(LocationRoleAccess.roleNamesFor("PAKISTAN - North").contains("PAKISTAN - South"));
+    }
+
+    @Test void ambiguousDuplicateIdFallsBackToExactOnly() {
+        assertEquals(set("Twin"), LocationRoleAccess.roleNamesFor("Twin"),
+            "an id under two parents must not inherit either parent");
+    }
+
+    @Test void blankIntermediateIdIsSkipped() {
+        assertEquals(set("Orphan"), LocationRoleAccess.roleNamesFor("Orphan"));
+    }
+
+    @Test void idNotInTreeIsExactOnly() {
+        assertEquals(set("Atlantis"), LocationRoleAccess.roleNamesFor("Atlantis"));
+    }
+
+    @Test void nullOrBlankLocationYieldsNothing() {
+        assertTrue(LocationRoleAccess.roleNamesFor(null).isEmpty());
+        assertTrue(LocationRoleAccess.roleNamesFor("").isEmpty());
+        assertTrue(LocationRoleAccess.roleNamesFor("   ").isEmpty());
+    }
+
+    @Test void systemRoleNamesNeverCount() {
+        assertEquals(set("Lab"), LocationRoleAccess.roleNamesFor("Lab"),
+            "an ancestor named like a system role is dropped");
+        assertTrue(LocationRoleAccess.roleNamesFor("researcher").isEmpty(),
+            "a location named exactly like a system role grants nothing");
+        assertTrue(LocationRoleAccess.roleNamesFor("admin").isEmpty());
+        assertTrue(LocationRoleAccess.roleNamesFor("orgAdmin").isEmpty());
+    }
+
+    // ---- lineageFor: pure traversal edge cases ----
+
+    @Test void identifiedRootIsPartOfTheLineage() {
+        JSONObject tree = new JSONObject(
+            "{\"id\":\"World\",\"locationID\":[{\"id\":\"X\",\"locationID\":[]}]}");
+        assertEquals(Arrays.asList("World", "X"), LocationRoleAccess.lineageFor("X", tree));
+        assertEquals(Arrays.asList("World"), LocationRoleAccess.lineageFor("World", tree));
+    }
+
+    @Test void nullTreeYieldsExactOnly() {
+        assertEquals(Arrays.asList("X"), LocationRoleAccess.lineageFor("X", null));
+    }
+
+    @Test void malformedChildEntriesAreIgnored() {
+        JSONObject tree = new JSONObject(
+            "{\"locationID\":[\"not-an-object\", 7, {\"name\":\"no id here\",\"locationID\":["
+            + "{\"id\":\"Deep\",\"locationID\":\"not-an-array\"}]}]}");
+        assertEquals(Arrays.asList("Deep"), LocationRoleAccess.lineageFor("Deep", tree));
+    }
+
+    // ---- request path (Shiro) ----
+
+    @Test void requestGrantedWhenAnyLineageRoleHeld() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.isUserInRole(anyString())).thenReturn(false);
+        when(request.isUserInRole("Indonesia")).thenReturn(true);
+        assertTrue(LocationRoleAccess.requestHasLocationRole(request, "Komodo"));
+    }
+
+    @Test void requestDeniedWhenNoLineageRoleHeld() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.isUserInRole(anyString())).thenReturn(false);
+        when(request.isUserInRole("PAKISTAN - South")).thenReturn(true); // sibling
+        when(request.isUserInRole("Komodo")).thenReturn(true); // child of a different branch
+        assertFalse(LocationRoleAccess.requestHasLocationRole(request, "PAKISTAN - North"));
+    }
+
+    @Test void requestWithNullLocationNeverAsksShiro() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        assertFalse(LocationRoleAccess.requestHasLocationRole(request, null));
+        assertFalse(LocationRoleAccess.requestHasLocationRole(null, "Komodo"));
+        verify(request, never()).isUserInRole(anyString());
+    }
+
+    // ---- Shepherd path (DB) ----
+
+    @Test @SuppressWarnings("unchecked")
+    void userHasLocationRoleQueriesTheFullLineageInContext() {
+        Shepherd myShepherd = mock(Shepherd.class);
+        when(myShepherd.getContext()).thenReturn("context0");
+        when(myShepherd.doesUserHaveAnyRole(eq("bob"), any(Collection.class), eq("context0")))
+            .thenReturn(true);
+        assertTrue(LocationRoleAccess.userHasLocationRole("bob", "Komodo", myShepherd));
+        ArgumentCaptor<Collection<String>> names = ArgumentCaptor.forClass(Collection.class);
+        verify(myShepherd).doesUserHaveAnyRole(eq("bob"), names.capture(), eq("context0"));
+        assertEquals(set("Komodo", "Flores Sea", "Indonesia"), new HashSet<String>(names.getValue()));
+    }
+
+    @Test void userHasLocationRoleShortCircuitsWithoutNames() {
+        Shepherd myShepherd = mock(Shepherd.class);
+        assertFalse(LocationRoleAccess.userHasLocationRole("bob", null, myShepherd));
+        assertFalse(LocationRoleAccess.userHasLocationRole("bob", "researcher", myShepherd));
+        assertFalse(LocationRoleAccess.userHasLocationRole(null, "Komodo", myShepherd));
+        verifyNoInteractions(myShepherd);
+    }
+
+    @Test @SuppressWarnings("unchecked")
+    void userIdsWithLocationRoleResolvesUsernamesToIdsAndSkipsUnresolvable() {
+        Shepherd myShepherd = mock(Shepherd.class);
+        when(myShepherd.getContext()).thenReturn("context0");
+        when(myShepherd.getUsernamesWithAnyRole(any(Collection.class), eq("context0")))
+            .thenReturn(Arrays.asList("bob", "amy", "ghost"));
+        User bob = mock(User.class);
+        when(bob.getId()).thenReturn("u-bob");
+        User amy = mock(User.class);
+        when(amy.getId()).thenReturn(null); // no uuid -> cannot appear in viewUsers
+        when(myShepherd.getUser("bob")).thenReturn(bob);
+        when(myShepherd.getUser("amy")).thenReturn(amy);
+        when(myShepherd.getUser("ghost")).thenReturn(null);
+        assertEquals(set("u-bob"), LocationRoleAccess.userIdsWithLocationRole("Komodo", myShepherd));
+    }
+
+    @Test void userIdsWithLocationRoleIsEmptyWithoutNames() {
+        Shepherd myShepherd = mock(Shepherd.class);
+        assertTrue(LocationRoleAccess.userIdsWithLocationRole(null, myShepherd).isEmpty());
+        assertTrue(LocationRoleAccess.userIdsWithLocationRole("admin", myShepherd).isEmpty());
+        verifyNoInteractions(myShepherd);
+    }
+
+    // ---- permissions-pass helper (pure) ----
+
+    @Test void viewUserIdsForLocationUnionsLineageRolesAndCachesLineage() {
+        Map<String, Set<String>> roleNameToUserIds = new HashMap<String, Set<String>>();
+        roleNameToUserIds.put("Indonesia", set("u1"));
+        roleNameToUserIds.put("Komodo", set("u2", "u1"));
+        roleNameToUserIds.put("Pakistan", set("u3"));
+        Map<String, Set<String>> lineageCache = new HashMap<String, Set<String>>();
+
+        assertEquals(set("u1", "u2"),
+            LocationRoleAccess.viewUserIdsForLocation("Komodo", roleNameToUserIds, lineageCache));
+        assertTrue(lineageCache.containsKey("Komodo"), "lineage is cached per locationID");
+        assertEquals(set("u1"),
+            LocationRoleAccess.viewUserIdsForLocation("Flores Sea", roleNameToUserIds, lineageCache));
+        assertTrue(LocationRoleAccess.viewUserIdsForLocation("Atlantis", roleNameToUserIds,
+            lineageCache).isEmpty());
+        assertTrue(LocationRoleAccess.viewUserIdsForLocation(null, roleNameToUserIds,
+            lineageCache).isEmpty());
+    }
+
+    @Test void viewUserIdsForLocationUsesCachedLineageWhenPresent() {
+        Map<String, Set<String>> roleNameToUserIds = new HashMap<String, Set<String>>();
+        roleNameToUserIds.put("Elsewhere", set("u9"));
+        Map<String, Set<String>> lineageCache = new HashMap<String, Set<String>>();
+        lineageCache.put("Komodo", set("Elsewhere")); // pre-seeded: the tree is not consulted
+        assertEquals(set("u9"),
+            LocationRoleAccess.viewUserIdsForLocation("Komodo", roleNameToUserIds, lineageCache));
+    }
+}

--- a/src/test/java/org/ecocean/security/LocationRoleAccessTest.java
+++ b/src/test/java/org/ecocean/security/LocationRoleAccessTest.java
@@ -96,25 +96,7 @@ class LocationRoleAccessTest {
         assertTrue(LocationRoleAccess.roleNamesFor("orgAdmin").isEmpty());
     }
 
-    // ---- lineageFor: pure traversal edge cases ----
-
-    @Test void identifiedRootIsPartOfTheLineage() {
-        JSONObject tree = new JSONObject(
-            "{\"id\":\"World\",\"locationID\":[{\"id\":\"X\",\"locationID\":[]}]}");
-        assertEquals(Arrays.asList("World", "X"), LocationRoleAccess.lineageFor("X", tree));
-        assertEquals(Arrays.asList("World"), LocationRoleAccess.lineageFor("World", tree));
-    }
-
-    @Test void nullTreeYieldsExactOnly() {
-        assertEquals(Arrays.asList("X"), LocationRoleAccess.lineageFor("X", null));
-    }
-
-    @Test void malformedChildEntriesAreIgnored() {
-        JSONObject tree = new JSONObject(
-            "{\"locationID\":[\"not-an-object\", 7, {\"name\":\"no id here\",\"locationID\":["
-            + "{\"id\":\"Deep\",\"locationID\":\"not-an-array\"}]}]}");
-        assertEquals(Arrays.asList("Deep"), LocationRoleAccess.lineageFor("Deep", tree));
-    }
+    // pure traversal edge cases live with the traversal, in LocationIDLineageTest
 
     // ---- request path (Shiro) ----
 

--- a/src/test/java/org/ecocean/security/LocationRoleEncounterAccessTest.java
+++ b/src/test/java/org/ecocean/security/LocationRoleEncounterAccessTest.java
@@ -1,0 +1,229 @@
+package org.ecocean.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.Principal;
+import java.util.Collection;
+import javax.servlet.http.HttpServletRequest;
+import org.ecocean.Encounter;
+import org.ecocean.User;
+import org.ecocean.servlet.ServletUtilities;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+/**
+ * Location-based roles reach the live access checks the React app and the API use (issue
+ * #1549) and the request-based check individuals.jsp uses (issue #1244), with the legacy
+ * classic-page check switched to the same lineage rule.
+ */
+class LocationRoleEncounterAccessTest {
+    private JSONObject previousTree;
+    private Shepherd myShepherd;
+    private User bob;
+    private Encounter enc;
+
+    @BeforeEach void setUp() {
+        previousTree = LocationRoleTestTree.inject();
+        myShepherd = mock(Shepherd.class);
+        when(myShepherd.getContext()).thenReturn("context0");
+        bob = new User("bob", null, null); // real user: not admin (mock Shepherd returns no roles)
+        enc = new Encounter();
+        enc.setSubmitterID("owner");
+        enc.setLocationID("Komodo");
+    }
+
+    @AfterEach void tearDown() {
+        LocationRoleTestTree.restore(previousTree);
+    }
+
+    /** bob holds a role that is in the lineage set iff the set contains heldRole. */
+    @SuppressWarnings("unchecked")
+    private void bobHoldsRole(final String heldRole) {
+        when(myShepherd.doesUserHaveAnyRole(eq("bob"), any(Collection.class), eq("context0")))
+            .thenAnswer(inv -> ((Collection<String>)inv.getArgument(1)).contains(heldRole));
+    }
+
+    private static MockedStatic<Collaboration> noCollaborations() {
+        MockedStatic<Collaboration> mc = mockStatic(Collaboration.class, Answers.CALLS_REAL_METHODS);
+        mc.when(() -> Collaboration.collaborationBetweenUsers(anyString(), anyString(),
+            anyString())).thenReturn(null);
+        return mc;
+    }
+
+    // ---- Encounter.canUserView / canUserEdit (API + React paths) ----
+
+    @Test void canUserView_grantedByAncestorLocationRole() {
+        bobHoldsRole("Indonesia");
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            assertTrue(enc.canUserView(bob, myShepherd),
+                "a role at Indonesia covers an encounter at Komodo");
+        }
+    }
+
+    @Test void canUserView_deniedWhenOnlyAChildNodeRoleIsHeld() {
+        enc.setLocationID("Flores Sea");
+        bobHoldsRole("Komodo");
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            assertFalse(enc.canUserView(bob, myShepherd),
+                "a Komodo role must not grant the parent Flores Sea encounter");
+        }
+    }
+
+    @Test void canUserView_deniedWithoutAnyRoleOrCollaboration() {
+        bobHoldsRole("Pakistan");
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            assertFalse(enc.canUserView(bob, myShepherd));
+        }
+    }
+
+    @Test void canUserEdit_grantedByLocationRole() {
+        bobHoldsRole("Flores Sea");
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            assertTrue(enc.canUserEdit(bob, myShepherd), "location roles grant edit, not only view");
+        }
+    }
+
+    @Test void canUserEdit_deniedWithoutRoleOrEditCollaboration() {
+        bobHoldsRole("Pakistan");
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            assertFalse(enc.canUserEdit(bob, myShepherd));
+        }
+    }
+
+    @Test void canUserAccessWithShepherd_ownerNeverConsultsRoles() {
+        enc.setSubmitterID("bob");
+        assertTrue(enc.canUserAccess(bob, myShepherd));
+        verify(myShepherd, never()).doesUserHaveAnyRole(anyString(), any(Collection.class),
+            anyString());
+    }
+
+    @Test void canUserAccessWithShepherd_roleThenCollaboration() {
+        bobHoldsRole("Komodo");
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            assertTrue(enc.canUserAccess(bob, myShepherd));
+        }
+        bobHoldsRole("Pakistan");
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            assertFalse(enc.canUserAccess(bob, myShepherd));
+        }
+    }
+
+    // ---- Collaboration.canUserAccessEncounter (request path: individuals.jsp, #1244) ----
+
+    @Test void requestPath_grantedByLineageRole() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.isUserInRole(anyString())).thenReturn(false);
+        when(request.isUserInRole("Indonesia")).thenReturn(true);
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            mc.when(() -> Collaboration.canUserAccessOwnedObject(anyString(),
+                any(HttpServletRequest.class))).thenReturn(false);
+            assertTrue(Collaboration.canUserAccessEncounter(enc, request));
+        }
+    }
+
+    @Test void requestPath_deniedWithoutLineageRole() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.isUserInRole(anyString())).thenReturn(false);
+        when(request.isUserInRole("PAKISTAN - North")).thenReturn(true);
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            mc.when(() -> Collaboration.canUserAccessOwnedObject(anyString(),
+                any(HttpServletRequest.class))).thenReturn(false);
+            assertFalse(Collaboration.canUserAccessEncounter(enc, request));
+        }
+    }
+
+    // ---- Collaboration.canUserAccessEncounter (context + username path: exports, Task) ----
+
+    @Test @SuppressWarnings("unchecked")
+    void contextUsernamePath_grantedByRoleWithAShortLivedShepherdThatIsClosed() {
+        try (MockedStatic<Collaboration> mc = noCollaborations();
+            MockedConstruction<Shepherd> shepherds = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    when(mock.getContext()).thenReturn("context0");
+                    when(mock.doesUserHaveAnyRole(eq("bob"), any(Collection.class), eq("context0")))
+                        .thenReturn(true);
+                })) {
+            assertTrue(Collaboration.canUserAccessEncounter(enc, "context0", "bob"));
+            assertTrue(shepherds.constructed().size() >= 1, "a Shepherd is opened for the role check");
+            Shepherd roleShepherd = shepherds.constructed().get(0);
+            verify(roleShepherd).beginDBTransaction();
+            verify(roleShepherd).rollbackAndClose();
+        }
+    }
+
+    @Test @SuppressWarnings("unchecked")
+    void contextUsernamePath_closesTheRoleShepherdEvenWhenDenied() {
+        try (MockedStatic<Collaboration> mc = noCollaborations();
+            MockedConstruction<Shepherd> shepherds = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    when(mock.getContext()).thenReturn("context0");
+                    when(mock.doesUserHaveAnyRole(anyString(), any(Collection.class), anyString()))
+                        .thenReturn(false);
+                })) {
+            assertFalse(Collaboration.canUserAccessEncounter(enc, "context0", "bob"));
+            verify(shepherds.constructed().get(0)).rollbackAndClose();
+        }
+    }
+
+    // ---- ServletUtilities.isUserAuthorizedForEncounter (classic pages) ----
+
+    private HttpServletRequest classicRequestFor(String username) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        Principal principal = mock(Principal.class);
+        when(principal.getName()).thenReturn(username);
+        when(request.getUserPrincipal()).thenReturn(principal);
+        when(request.getRemoteUser()).thenReturn(username);
+        when(request.isUserInRole(anyString())).thenReturn(false);
+        return request;
+    }
+
+    @Test void classicCheck_grantedByAncestorRole() {
+        HttpServletRequest request = classicRequestFor("bob");
+        when(request.isUserInRole("Indonesia")).thenReturn(true);
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            mc.when(() -> Collaboration.canEditEncounter(any(Encounter.class),
+                any(HttpServletRequest.class))).thenReturn(false);
+            assertTrue(ServletUtilities.isUserAuthorizedForEncounter(enc, request, myShepherd),
+                "classic pages follow the same lineage rule");
+        }
+    }
+
+    @Test void classicCheck_deniedForChildRoleOnParentEncounter() {
+        enc.setLocationID("Flores Sea");
+        HttpServletRequest request = classicRequestFor("bob");
+        when(request.isUserInRole("Komodo")).thenReturn(true);
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            mc.when(() -> Collaboration.canEditEncounter(any(Encounter.class),
+                any(HttpServletRequest.class))).thenReturn(false);
+            assertFalse(ServletUtilities.isUserAuthorizedForEncounter(enc, request, myShepherd));
+        }
+    }
+
+    @Test void classicCheck_systemRoleNameCollisionGrantsNothing() {
+        enc.setLocationID("researcher");
+        HttpServletRequest request = classicRequestFor("bob");
+        when(request.isUserInRole("researcher")).thenReturn(true);
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            mc.when(() -> Collaboration.canEditEncounter(any(Encounter.class),
+                any(HttpServletRequest.class))).thenReturn(false);
+            assertFalse(ServletUtilities.isUserAuthorizedForEncounter(enc, request, myShepherd),
+                "holding the researcher role must not unlock an encounter located at 'researcher'");
+        }
+    }
+}

--- a/src/test/java/org/ecocean/security/LocationRoleEncounterAccessTest.java
+++ b/src/test/java/org/ecocean/security/LocationRoleEncounterAccessTest.java
@@ -1,5 +1,6 @@
 package org.ecocean.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -168,13 +169,46 @@ class LocationRoleEncounterAccessTest {
     }
 
     @Test @SuppressWarnings("unchecked")
-    void contextUsernamePath_closesTheRoleShepherdEvenWhenDenied() {
+    void contextUsernamePath_closesTheRoleShepherdBeforeTheCollaborationLookup() {
+        final java.util.concurrent.atomic.AtomicBoolean closedBeforeCollab =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
+        final java.util.List<Shepherd> opened = new java.util.ArrayList<Shepherd>();
+        // register the stub BEFORE the construction mock is active: with CALLS_REAL_METHODS the
+        // stubbing call itself runs the real collaborationBetweenUsers once, and that must not
+        // become one of the "constructed" Shepherds we assert on
+        try (MockedStatic<Collaboration> mc = mockStatic(Collaboration.class, Answers.CALLS_REAL_METHODS)) {
+            mc.when(() -> Collaboration.collaborationBetweenUsers(anyString(), anyString(),
+                anyString())).thenAnswer(inv -> {
+                    // the collaboration lookup runs only after the role Shepherd has been closed
+                    closedBeforeCollab.set(!opened.isEmpty() &&
+                        org.mockito.Mockito.mockingDetails(opened.get(0)).getInvocations().stream()
+                        .anyMatch(i -> "rollbackAndClose".equals(i.getMethod().getName())));
+                    return null;
+                });
+            try (MockedConstruction<Shepherd> shepherds = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    opened.add(mock);
+                    when(mock.getContext()).thenReturn("context0");
+                    when(mock.doesUserHaveAnyRole(anyString(), any(Collection.class), anyString()))
+                        .thenReturn(false);
+                })) {
+                assertFalse(Collaboration.canUserAccessEncounter(enc, "context0", "bob"));
+                assertEquals(1, opened.size(), "only the role check opens a Shepherd on this path");
+                verify(opened.get(0)).rollbackAndClose();
+                assertTrue(closedBeforeCollab.get(),
+                    "the role-check Shepherd must be closed before canCollaborate opens its own");
+            }
+        }
+    }
+
+    @Test @SuppressWarnings("unchecked")
+    void contextUsernamePath_aThrowingRoleQueryDeniesAndStillCloses() {
         try (MockedStatic<Collaboration> mc = noCollaborations();
             MockedConstruction<Shepherd> shepherds = mockConstruction(Shepherd.class,
                 (mock, ctx) -> {
                     when(mock.getContext()).thenReturn("context0");
                     when(mock.doesUserHaveAnyRole(anyString(), any(Collection.class), anyString()))
-                        .thenReturn(false);
+                        .thenThrow(new javax.jdo.JDOException("datastore down"));
                 })) {
             assertFalse(Collaboration.canUserAccessEncounter(enc, "context0", "bob"));
             verify(shepherds.constructed().get(0)).rollbackAndClose();
@@ -212,6 +246,27 @@ class LocationRoleEncounterAccessTest {
             mc.when(() -> Collaboration.canEditEncounter(any(Encounter.class),
                 any(HttpServletRequest.class))).thenReturn(false);
             assertFalse(ServletUtilities.isUserAuthorizedForEncounter(enc, request, myShepherd));
+        }
+    }
+
+    @Test void classicCheck_ownerAdminAndPublicStillAuthorized() {
+        try (MockedStatic<Collaboration> mc = noCollaborations()) {
+            mc.when(() -> Collaboration.canEditEncounter(any(Encounter.class),
+                any(HttpServletRequest.class))).thenReturn(false);
+            HttpServletRequest ownerReq = classicRequestFor("owner");
+            assertTrue(ServletUtilities.isUserAuthorizedForEncounter(enc, ownerReq, myShepherd),
+                "owner");
+            HttpServletRequest adminReq = classicRequestFor("root");
+            when(adminReq.isUserInRole("admin")).thenReturn(true);
+            assertTrue(ServletUtilities.isUserAuthorizedForEncounter(enc, adminReq, myShepherd),
+                "admin");
+            Encounter publicEnc = new Encounter();
+            publicEnc.setSubmitterID("public");
+            publicEnc.setLocationID("Komodo");
+            assertTrue(ServletUtilities.isUserAuthorizedForEncounter(publicEnc,
+                classicRequestFor("bob"), myShepherd), "public encounter");
+            assertFalse(ServletUtilities.isUserAuthorizedForEncounter(enc,
+                classicRequestFor("bob"), myShepherd), "unrelated user without any role");
         }
     }
 

--- a/src/test/java/org/ecocean/security/LocationRolePermissionsPassTest.java
+++ b/src/test/java/org/ecocean/security/LocationRolePermissionsPassTest.java
@@ -1,0 +1,190 @@
+package org.ecocean.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.jdo.PersistenceManager;
+import javax.jdo.Query;
+import org.ecocean.Encounter;
+import org.ecocean.OpenSearch;
+import org.ecocean.Role;
+import org.ecocean.User;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+/**
+ * Encounter.opensearchIndexPermissions() is the viewUsers writer that runs after Role changes.
+ * It must agree with computeViewUsers about location-based roles, and a failed role read must
+ * abort the pass (leaving permissionsNeeded set) rather than silently revoke every location
+ * grant in the index.
+ */
+class LocationRolePermissionsPassTest {
+    private JSONObject previousTree;
+    private List<User> users;
+    private List<Role> roles;
+    private List<Object[]> rows;
+    private RuntimeException roleLoadFailure;
+
+    @BeforeEach void setUp() {
+        previousTree = LocationRoleTestTree.inject();
+        users = new ArrayList<User>();
+        roles = new ArrayList<Role>();
+        rows = new ArrayList<Object[]>();
+        roleLoadFailure = null;
+    }
+
+    @AfterEach void tearDown() {
+        LocationRoleTestTree.restore(previousTree);
+    }
+
+    private void user(String username, String id) {
+        User u = mock(User.class);
+        when(u.getUsername()).thenReturn(username);
+        when(u.getId()).thenReturn(id);
+        users.add(u);
+    }
+
+    private void role(String username, String rolename) {
+        Role r = new Role(username, rolename);
+        r.setContext("context0");
+        roles.add(r);
+    }
+
+    private void encounterRow(String id, String submitter, String locationID) {
+        rows.add(new Object[] { id, submitter, locationID });
+    }
+
+    /** Runs the pass with the fixture; returns viewUsers written per encounter id. */
+    private Map<String, Set<String> > runPass() {
+        final Map<String, Set<String> > written = new HashMap<String, Set<String> >();
+        try (MockedStatic<Collaboration> mc = mockStatic(Collaboration.class, Answers.CALLS_REAL_METHODS);
+            MockedConstruction<Shepherd> shepherds = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    when(mock.getContext()).thenReturn("context0");
+                    when(mock.getUsersWithUsername()).thenReturn(users);
+                    if (roleLoadFailure != null) {
+                        when(mock.getRolesInContext("context0")).thenThrow(roleLoadFailure);
+                    } else {
+                        when(mock.getRolesInContext("context0")).thenReturn(roles);
+                    }
+                    PersistenceManager pm = mock(PersistenceManager.class);
+                    Query query = mock(Query.class);
+                    when(query.execute()).thenReturn(rows);
+                    when(pm.newQuery(eq("javax.jdo.query.SQL"), anyString())).thenReturn(query);
+                    when(mock.getPM()).thenReturn(pm);
+                    when(mock.getEncounter(anyString())).thenReturn(null);
+                });
+            MockedConstruction<OpenSearch> searches = mockConstruction(OpenSearch.class,
+                (mock, ctx) -> {
+                    when(mock.getIndexedViewUsers(anyString(), anyString())).thenReturn(null);
+                })) {
+            mc.when(() -> Collaboration.securityEnabled(anyString())).thenReturn(true);
+            mc.when(() -> Collaboration.collaborationsForUser(any(Shepherd.class), anyString()))
+                .thenReturn(new ArrayList<Collaboration>());
+
+            boolean completed = Encounter.opensearchIndexPermissions();
+            written.put("__completed", new HashSet<String>(Arrays.asList(String.valueOf(completed))));
+
+            for (OpenSearch os : searches.constructed()) {
+                ArgumentCaptor<String> ids = ArgumentCaptor.forClass(String.class);
+                ArgumentCaptor<JSONObject> docs = ArgumentCaptor.forClass(JSONObject.class);
+                verify(os, org.mockito.Mockito.atLeast(0)).indexUpdate(eq("encounter"),
+                    ids.capture(), docs.capture());
+                for (int i = 0; i < ids.getAllValues().size(); i++) {
+                    JSONArray vu = docs.getAllValues().get(i).optJSONArray("viewUsers");
+                    Set<String> set = new HashSet<String>();
+                    if (vu != null) for (int j = 0; j < vu.length(); j++) set.add(vu.getString(j));
+                    written.put(ids.getAllValues().get(i), set);
+                }
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+        return written;
+    }
+
+    @Test void locationRoleHoldersLandInViewUsers() {
+        user("owner", "uuid-O");
+        user("bob", "uuid-B");
+        user("amy", "uuid-A");
+        role("bob", "Indonesia"); // ancestor of Komodo
+        role("amy", "Pakistan"); // unrelated branch
+        encounterRow("enc-1", "owner", "Komodo");
+
+        Map<String, Set<String> > written = runPass();
+        assertEquals(new HashSet<String>(Arrays.asList("uuid-B")), written.get("enc-1"),
+            "bob via the Indonesia ancestor role; amy's Pakistan role does not cover Komodo");
+    }
+
+    @Test void ownerIsNeverListedInItsOwnViewUsers() {
+        user("owner", "uuid-O");
+        role("owner", "Komodo");
+        encounterRow("enc-1", "owner", "Komodo");
+
+        Map<String, Set<String> > written = runPass();
+        assertTrue(written.containsKey("enc-1"), "viewUsers is always written, even when empty");
+        assertTrue(written.get("enc-1").isEmpty());
+    }
+
+    @Test void systemRoleNamesAndUnknownUsersAreIgnored() {
+        user("owner", "uuid-O");
+        user("bob", "uuid-B");
+        role("bob", "researcher");
+        role("nobody", "Indonesia"); // no matching user row -> no id to grant
+        encounterRow("enc-1", "owner", "researcher");
+        encounterRow("enc-2", "owner", "Komodo");
+
+        Map<String, Set<String> > written = runPass();
+        assertTrue(written.get("enc-1").isEmpty(), "researcher is a system role, not a location");
+        assertTrue(written.get("enc-2").isEmpty());
+    }
+
+    @Test void encounterWithoutLocationGetsNoLocationGrants() {
+        user("owner", "uuid-O");
+        user("bob", "uuid-B");
+        role("bob", "Indonesia");
+        encounterRow("enc-1", "owner", null);
+
+        Map<String, Set<String> > written = runPass();
+        assertTrue(written.get("enc-1").isEmpty());
+    }
+
+    @Test void roleLoadFailureAbortsBeforeAnyIndexWrite() {
+        user("owner", "uuid-O");
+        user("bob", "uuid-B");
+        role("bob", "Indonesia");
+        encounterRow("enc-1", "owner", "Komodo");
+        roleLoadFailure = new javax.jdo.JDOException("datastore down");
+
+        Map<String, Set<String> > written = runPass();
+        assertEquals(new HashSet<String>(Arrays.asList("false")), written.get("__completed"),
+            "the pass must report failure so permissionsNeeded stays set for a retry");
+        assertFalse(written.containsKey("enc-1"),
+            "no viewUsers write may happen when the roles could not be read");
+    }
+}

--- a/src/test/java/org/ecocean/security/LocationRolePermissionsPassTest.java
+++ b/src/test/java/org/ecocean/security/LocationRolePermissionsPassTest.java
@@ -23,6 +23,8 @@ import java.util.Set;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import org.ecocean.Encounter;
+import org.ecocean.IndexingManager;
+import org.ecocean.IndexingManagerFactory;
 import org.ecocean.OpenSearch;
 import org.ecocean.Role;
 import org.ecocean.User;
@@ -33,7 +35,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
-import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 
@@ -49,6 +50,8 @@ class LocationRolePermissionsPassTest {
     private List<Role> roles;
     private List<Object[]> rows;
     private RuntimeException roleLoadFailure;
+    private IndexingManager indexingManager;
+    private Encounter staleEncounter; // returned by getEncounter(...) for the invalid-owner row
 
     @BeforeEach void setUp() {
         previousTree = LocationRoleTestTree.inject();
@@ -56,6 +59,8 @@ class LocationRolePermissionsPassTest {
         roles = new ArrayList<Role>();
         rows = new ArrayList<Object[]>();
         roleLoadFailure = null;
+        indexingManager = mock(IndexingManager.class);
+        staleEncounter = null;
     }
 
     @AfterEach void tearDown() {
@@ -98,30 +103,31 @@ class LocationRolePermissionsPassTest {
                     when(pm.newQuery(eq("javax.jdo.query.SQL"), anyString())).thenReturn(query);
                     when(mock.getPM()).thenReturn(pm);
                     when(mock.getEncounter(anyString())).thenReturn(null);
+                    if (staleEncounter != null)
+                        when(mock.getEncounter(staleEncounter.getCatalogNumber())).thenReturn(staleEncounter);
                 });
             MockedConstruction<OpenSearch> searches = mockConstruction(OpenSearch.class,
                 (mock, ctx) -> {
                     when(mock.getIndexedViewUsers(anyString(), anyString())).thenReturn(null);
-                })) {
+                    // the pass reuses ONE updateData object across rows, so snapshot each
+                    // document at call time instead of capturing the (mutated) reference
+                    org.mockito.Mockito.doAnswer(inv -> {
+                        JSONObject doc = inv.getArgument(2);
+                        JSONArray vu = doc.optJSONArray("viewUsers");
+                        Set<String> set = new HashSet<String>();
+                        if (vu != null) for (int j = 0; j < vu.length(); j++) set.add(vu.getString(j));
+                        written.put(inv.getArgument(1), set);
+                        return null;
+                    }).when(mock).indexUpdate(eq("encounter"), anyString(), any(JSONObject.class));
+                });
+            MockedStatic<IndexingManagerFactory> factory = mockStatic(IndexingManagerFactory.class)) {
+            factory.when(IndexingManagerFactory::getIndexingManager).thenReturn(indexingManager);
             mc.when(() -> Collaboration.securityEnabled(anyString())).thenReturn(true);
             mc.when(() -> Collaboration.collaborationsForUser(any(Shepherd.class), anyString()))
                 .thenReturn(new ArrayList<Collaboration>());
 
             boolean completed = Encounter.opensearchIndexPermissions();
             written.put("__completed", new HashSet<String>(Arrays.asList(String.valueOf(completed))));
-
-            for (OpenSearch os : searches.constructed()) {
-                ArgumentCaptor<String> ids = ArgumentCaptor.forClass(String.class);
-                ArgumentCaptor<JSONObject> docs = ArgumentCaptor.forClass(JSONObject.class);
-                verify(os, org.mockito.Mockito.atLeast(0)).indexUpdate(eq("encounter"),
-                    ids.capture(), docs.capture());
-                for (int i = 0; i < ids.getAllValues().size(); i++) {
-                    JSONArray vu = docs.getAllValues().get(i).optJSONArray("viewUsers");
-                    Set<String> set = new HashSet<String>();
-                    if (vu != null) for (int j = 0; j < vu.length(); j++) set.add(vu.getString(j));
-                    written.put(ids.getAllValues().get(i), set);
-                }
-            }
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
@@ -186,5 +192,36 @@ class LocationRolePermissionsPassTest {
             "the pass must report failure so permissionsNeeded stays set for a retry");
         assertFalse(written.containsKey("enc-1"),
             "no viewUsers write may happen when the roles could not be read");
+    }
+
+    @Test void differentEncountersGetTheirOwnViewerSets() {
+        user("owner", "uuid-O");
+        user("bob", "uuid-B");
+        user("amy", "uuid-A");
+        role("bob", "Indonesia");
+        role("amy", "Pakistan");
+        encounterRow("enc-komodo", "owner", "Komodo");
+        encounterRow("enc-pak", "owner", "PAKISTAN - North");
+        encounterRow("enc-none", "owner", "Atlantis");
+
+        Map<String, Set<String> > written = runPass();
+        assertEquals(new HashSet<String>(Arrays.asList("uuid-B")), written.get("enc-komodo"));
+        assertEquals(new HashSet<String>(Arrays.asList("uuid-A")), written.get("enc-pak"));
+        assertTrue(written.get("enc-none").isEmpty());
+    }
+
+    @Test void invalidOwnerRowIsHandedToTheFullReindexNotWrittenInline() {
+        user("bob", "uuid-B");
+        role("bob", "Indonesia");
+        encounterRow("enc-ghost", "ghost-user", "Komodo"); // owner has no user row
+        staleEncounter = new Encounter();
+        staleEncounter.setCatalogNumber("enc-ghost");
+
+        Map<String, Set<String> > written = runPass();
+        assertFalse(written.containsKey("enc-ghost"),
+            "the pass does not write viewUsers inline for an unresolvable owner");
+        // the full reindex it enqueues serializes viewUsers via computeViewUsers, which grants
+        // location roles independently of the owner (see LocationRoleViewUsersTest)
+        verify(indexingManager).addIndexingQueueEntry(eq(staleEncounter), eq(false));
     }
 }

--- a/src/test/java/org/ecocean/security/LocationRoleShepherdDbTest.java
+++ b/src/test/java/org/ecocean/security/LocationRoleShepherdDbTest.java
@@ -142,11 +142,13 @@ class LocationRoleShepherdDbTest {
     @Test void getUsernamesWithAnyRole_distinctUsernamesInContextOnly() {
         Shepherd sh = open();
         try {
-            List<String> names = sh.getUsernamesWithAnyRole(
-                Arrays.asList("Indonesia", "Flores Sea", "Indonesia", "Komodo"), "context0");
+            // bob matches TWO stored rows (Indonesia and O'Brien Bay); the projection must
+            // still return him once
+            List<String> names = sh.getUsernamesWithAnyRole(Arrays.asList("Indonesia",
+                "O'Brien Bay", "Flores Sea", "Indonesia", "Komodo"), "context0");
             assertEquals(new HashSet<String>(Arrays.asList("bob", "amy")),
                 new HashSet<String>(names), "bob via Indonesia, amy via Flores Sea; nullctx and otherctx excluded");
-            assertEquals(2, names.size(), "distinct: duplicate names must not duplicate users");
+            assertEquals(2, names.size(), "distinct: a user holding two matching roles appears once");
         } finally {
             sh.rollbackAndClose();
         }

--- a/src/test/java/org/ecocean/security/LocationRoleShepherdDbTest.java
+++ b/src/test/java/org/ecocean/security/LocationRoleShepherdDbTest.java
@@ -1,0 +1,181 @@
+package org.ecocean.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import org.ecocean.CommonConfiguration;
+import org.ecocean.Role;
+import org.ecocean.shepherd.core.Shepherd;
+import org.ecocean.shepherd.core.TestPMFUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * The location-role lookups run parameterized JDOQL (":names.contains(this.rolename)") through
+ * real DataNucleus 5.2.7 against real Postgres. Mocks cannot prove the binding, the distinct
+ * projection, apostrophe handling, or that a Role stored with a NULL context never matches a
+ * context query (the same rule ShepherdRealm applies for Shiro).
+ */
+@Testcontainers
+class LocationRoleShepherdDbTest {
+    @Container
+    static PostgreSQLContainer<?> postgres =
+        new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("wildbook_test")
+            .withUsername("wildbook")
+            .withPassword("wildbook");
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        CommonConfiguration.initialize("context0", new Properties());
+
+        Properties props = new Properties();
+        props.setProperty("datanucleus.ConnectionUserName", postgres.getUsername());
+        props.setProperty("datanucleus.ConnectionPassword", postgres.getPassword());
+        props.setProperty("datanucleus.ConnectionDriverName", postgres.getDriverClassName());
+        props.setProperty("datanucleus.ConnectionURL", postgres.getJdbcUrl());
+        props.setProperty("datanucleus.schema.autoCreateTables", "true");
+        TestPMFUtil.closePMF("context0");
+
+        Shepherd sh = new Shepherd("context0", props);
+        try {
+            sh.beginDBTransaction();
+            role(sh, "bob", "Indonesia", "context0");
+            role(sh, "bob", "O'Brien Bay", "context0"); // apostrophe must bind, not break
+            role(sh, "bob", "Komodo", "otherctx"); // right name, wrong context
+            role(sh, "amy", "Flores Sea", "context0");
+            role(sh, "nullctx", "Indonesia", null); // stored NULL context never matches
+            role(sh, "sys", "admin", "context0");
+            sh.commitDBTransaction();
+        } catch (Exception e) {
+            sh.rollbackDBTransaction();
+            throw e;
+        } finally {
+            sh.closeDBTransaction();
+        }
+    }
+
+    @AfterAll
+    static void tearDown() {
+        TestPMFUtil.closePMF("context0");
+    }
+
+    private static void role(Shepherd sh, String username, String rolename, String context) {
+        Role r = new Role(username, rolename);
+        r.setContext(context);
+        sh.getPM().makePersistent(r);
+    }
+
+    private static Shepherd open() {
+        Shepherd sh = new Shepherd("context0");
+        sh.setAction("LocationRoleShepherdDbTest");
+        sh.beginDBTransaction();
+        return sh;
+    }
+
+    @Test void doesUserHaveAnyRole_matchesOneOfSeveralNamesInContext() {
+        Shepherd sh = open();
+        try {
+            assertTrue(sh.doesUserHaveAnyRole("bob",
+                Arrays.asList("Komodo", "Flores Sea", "Indonesia"), "context0"),
+                "bob holds Indonesia in context0");
+            assertTrue(sh.doesUserHaveAnyRole("amy", Arrays.asList("Flores Sea"), "context0"));
+        } finally {
+            sh.rollbackAndClose();
+        }
+    }
+
+    @Test void doesUserHaveAnyRole_ignoresRolesFromAnotherContext() {
+        Shepherd sh = open();
+        try {
+            assertFalse(sh.doesUserHaveAnyRole("bob", Arrays.asList("Komodo"), "context0"),
+                "bob's Komodo role lives in otherctx");
+            assertTrue(sh.doesUserHaveAnyRole("bob", Arrays.asList("Komodo"), "otherctx"));
+        } finally {
+            sh.rollbackAndClose();
+        }
+    }
+
+    @Test void doesUserHaveAnyRole_bindsApostrophes() {
+        Shepherd sh = open();
+        try {
+            assertTrue(sh.doesUserHaveAnyRole("bob", Arrays.asList("O'Brien Bay"), "context0"));
+            assertFalse(sh.doesUserHaveAnyRole("amy", Arrays.asList("O'Brien Bay"), "context0"));
+        } finally {
+            sh.rollbackAndClose();
+        }
+    }
+
+    @Test void doesUserHaveAnyRole_storedNullContextNeverMatches() {
+        Shepherd sh = open();
+        try {
+            assertFalse(sh.doesUserHaveAnyRole("nullctx", Arrays.asList("Indonesia"), "context0"),
+                "a Role row with NULL context must not satisfy a context0 query (Shiro parity)");
+        } finally {
+            sh.rollbackAndClose();
+        }
+    }
+
+    @Test void doesUserHaveAnyRole_emptyOrNullInputsAreFalseWithoutQuerying() {
+        Shepherd sh = open();
+        try {
+            assertFalse(sh.doesUserHaveAnyRole("bob", Collections.<String>emptyList(), "context0"));
+            assertFalse(sh.doesUserHaveAnyRole("bob", null, "context0"));
+            assertFalse(sh.doesUserHaveAnyRole(null, Arrays.asList("Indonesia"), "context0"));
+            assertFalse(sh.doesUserHaveAnyRole("bob", Arrays.asList("Indonesia"), null));
+        } finally {
+            sh.rollbackAndClose();
+        }
+    }
+
+    @Test void getUsernamesWithAnyRole_distinctUsernamesInContextOnly() {
+        Shepherd sh = open();
+        try {
+            List<String> names = sh.getUsernamesWithAnyRole(
+                Arrays.asList("Indonesia", "Flores Sea", "Indonesia", "Komodo"), "context0");
+            assertEquals(new HashSet<String>(Arrays.asList("bob", "amy")),
+                new HashSet<String>(names), "bob via Indonesia, amy via Flores Sea; nullctx and otherctx excluded");
+            assertEquals(2, names.size(), "distinct: duplicate names must not duplicate users");
+        } finally {
+            sh.rollbackAndClose();
+        }
+    }
+
+    @Test void getUsernamesWithAnyRole_emptyInputsYieldEmpty() {
+        Shepherd sh = open();
+        try {
+            assertTrue(sh.getUsernamesWithAnyRole(Collections.<String>emptyList(), "context0").isEmpty());
+            assertTrue(sh.getUsernamesWithAnyRole(null, "context0").isEmpty());
+            assertTrue(sh.getUsernamesWithAnyRole(Arrays.asList("Indonesia"), null).isEmpty());
+        } finally {
+            sh.rollbackAndClose();
+        }
+    }
+
+    @Test void getRolesInContext_returnsOnlyThatContextsRows() {
+        Shepherd sh = open();
+        try {
+            List<Role> roles = sh.getRolesInContext("context0");
+            Set<String> pairs = new HashSet<String>();
+            for (Role r : roles) pairs.add(r.getUsername() + "/" + r.getRolename());
+            assertEquals(new HashSet<String>(Arrays.asList("bob/Indonesia", "bob/O'Brien Bay",
+                "amy/Flores Sea", "sys/admin")), pairs,
+                "otherctx and NULL-context rows are excluded");
+            assertTrue(sh.getRolesInContext("nowhere").isEmpty());
+            assertTrue(sh.getRolesInContext(null).isEmpty());
+        } finally {
+            sh.rollbackAndClose();
+        }
+    }
+}

--- a/src/test/java/org/ecocean/security/LocationRoleTestTree.java
+++ b/src/test/java/org/ecocean/security/LocationRoleTestTree.java
@@ -1,0 +1,51 @@
+package org.ecocean.security;
+
+import org.ecocean.LocationID;
+import org.json.JSONObject;
+
+/**
+ * Test fixture: a small locationID tree injected as the DEFAULT tree so location-role tests do
+ * not depend on the bundled locationID.json. Always restore the previous entry afterwards.
+ *
+ * root (no id)
+ *   Pakistan
+ *     PAKISTAN - North
+ *     PAKISTAN - South
+ *   Indonesia
+ *     Flores Sea
+ *       Komodo
+ *   Dup  -> Twin        (Twin appears under two parents: ambiguous)
+ *   Other -> Twin
+ *   ""   -> Orphan      (blank-id intermediate node)
+ *   researcher -> Lab   (node named like a system role)
+ */
+final class LocationRoleTestTree {
+    private LocationRoleTestTree() {}
+
+    static JSONObject fixture() {
+        return new JSONObject("{\"description\":\"test\",\"locationID\":["
+            + "{\"name\":\"Pakistan\",\"id\":\"Pakistan\",\"locationID\":["
+            + "  {\"name\":\"PAKISTAN - North\",\"id\":\"PAKISTAN - North\",\"locationID\":[]},"
+            + "  {\"name\":\"PAKISTAN - South\",\"id\":\"PAKISTAN - South\",\"locationID\":[]}]},"
+            + "{\"name\":\"Indonesia\",\"id\":\"Indonesia\",\"locationID\":["
+            + "  {\"name\":\"Flores Sea\",\"id\":\"Flores Sea\",\"locationID\":["
+            + "    {\"name\":\"Komodo\",\"id\":\"Komodo\",\"locationID\":[]}]}]},"
+            + "{\"name\":\"Dup\",\"id\":\"Dup\",\"locationID\":[{\"name\":\"Twin\",\"id\":\"Twin\",\"locationID\":[]}]},"
+            + "{\"name\":\"Other\",\"id\":\"Other\",\"locationID\":[{\"name\":\"Twin\",\"id\":\"Twin\",\"locationID\":[]}]},"
+            + "{\"name\":\"blank\",\"id\":\"\",\"locationID\":[{\"name\":\"Orphan\",\"id\":\"Orphan\",\"locationID\":[]}]},"
+            + "{\"name\":\"researcher\",\"id\":\"researcher\",\"locationID\":[{\"name\":\"Lab\",\"id\":\"Lab\",\"locationID\":[]}]}"
+            + "]}");
+    }
+
+    /** Installs the fixture as the default tree; returns the previous default (may be null). */
+    static JSONObject inject() {
+        JSONObject previous = LocationID.getJSONMaps().get("default");
+        LocationID.getJSONMaps().put("default", fixture());
+        return previous;
+    }
+
+    static void restore(JSONObject previous) {
+        if (previous == null) LocationID.getJSONMaps().remove("default");
+        else LocationID.getJSONMaps().put("default", previous);
+    }
+}

--- a/src/test/java/org/ecocean/security/LocationRoleViewUsersTest.java
+++ b/src/test/java/org/ecocean/security/LocationRoleViewUsersTest.java
@@ -1,0 +1,153 @@
+package org.ecocean.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import org.ecocean.Encounter;
+import org.ecocean.User;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.MockedStatic;
+
+/**
+ * Encounter.computeViewUsers (the OpenSearch viewUsers writer behind the encounter, annotation
+ * and individual serializers) must list everyone holding a covering location role, so search
+ * results stop showing "access: none" to users the live checks admit (#1549).
+ */
+class LocationRoleViewUsersTest {
+    private JSONObject previousTree;
+    private Shepherd myShepherd;
+    private Encounter enc;
+    private User owner;
+
+    private static User user(String username, String id) {
+        User u = mock(User.class);
+        when(u.getUsername()).thenReturn(username);
+        when(u.getId()).thenReturn(id);
+        return u;
+    }
+
+    @BeforeEach void setUp() {
+        previousTree = LocationRoleTestTree.inject();
+        myShepherd = mock(Shepherd.class);
+        when(myShepherd.getContext()).thenReturn("context0");
+        // build the mocks first: stubbing a fresh mock inside thenReturn(...) is unfinished stubbing
+        owner = user("owner", "owner-uuid");
+        User bob = user("bob", "uuid-B");
+        User amy = user("amy", "uuid-A");
+        when(myShepherd.getUser("owner")).thenReturn(owner);
+        when(myShepherd.getUser("bob")).thenReturn(bob);
+        when(myShepherd.getUser("amy")).thenReturn(amy);
+        enc = new Encounter();
+        enc.setSubmitterID("owner");
+        enc.setLocationID("Komodo");
+    }
+
+    @AfterEach void tearDown() {
+        LocationRoleTestTree.restore(previousTree);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void roleHolders(String... usernames) {
+        when(myShepherd.getUsernamesWithAnyRole(any(Collection.class), eq("context0")))
+            .thenReturn(Arrays.asList(usernames));
+    }
+
+    private static MockedStatic<Collaboration> securityOnNoCollabs(Shepherd sh) {
+        MockedStatic<Collaboration> mc = mockStatic(Collaboration.class, Answers.CALLS_REAL_METHODS);
+        mc.when(() -> Collaboration.securityEnabled(anyString())).thenReturn(true);
+        mc.when(() -> Collaboration.persistedCollaborationsForUser(eq(sh), anyString()))
+            .thenReturn(new ArrayList<Collaboration>());
+        return mc;
+    }
+
+    @Test void locationRoleHoldersAreViewers() {
+        roleHolders("bob");
+        try (MockedStatic<Collaboration> mc = securityOnNoCollabs(myShepherd)) {
+            List<String> ids = enc.computeViewUsers(myShepherd);
+            assertEquals(Arrays.asList("uuid-B"), ids);
+        }
+    }
+
+    @Test @SuppressWarnings("unchecked")
+    void lineageNamesAreQueried() {
+        roleHolders();
+        try (MockedStatic<Collaboration> mc = securityOnNoCollabs(myShepherd)) {
+            enc.computeViewUsers(myShepherd);
+        }
+        org.mockito.ArgumentCaptor<Collection<String>> names =
+            org.mockito.ArgumentCaptor.forClass(Collection.class);
+        verify(myShepherd).getUsernamesWithAnyRole(names.capture(), eq("context0"));
+        assertEquals(new HashSet<String>(Arrays.asList("Komodo", "Flores Sea", "Indonesia")),
+            new HashSet<String>(names.getValue()));
+    }
+
+    @Test void ownerHoldingTheRoleIsNotListedAsAViewer() {
+        roleHolders("owner", "bob");
+        try (MockedStatic<Collaboration> mc = securityOnNoCollabs(myShepherd)) {
+            List<String> ids = enc.computeViewUsers(myShepherd);
+            assertEquals(Arrays.asList("uuid-B"), ids,
+                "the owner is granted via submitterUserId, never listed in viewUsers");
+        }
+    }
+
+    @Test void roleGrantSurvivesAnUnresolvableOwner() {
+        enc.setSubmitterID("ghost-user");
+        when(myShepherd.getUser("ghost-user")).thenReturn(null);
+        roleHolders("bob");
+        try (MockedStatic<Collaboration> mc = securityOnNoCollabs(myShepherd)) {
+            List<String> ids = enc.computeViewUsers(myShepherd);
+            assertEquals(Arrays.asList("uuid-B"), ids,
+                "location roles do not depend on the owner; only collaboration grants fail closed");
+        }
+    }
+
+    @Test void roleHolderWhoIsAlsoACollaboratorIsListedOnce() {
+        roleHolders("bob");
+        Collaboration approved = new Collaboration("owner", "bob");
+        approved.setState(Collaboration.STATE_APPROVED);
+        try (MockedStatic<Collaboration> mc = securityOnNoCollabs(myShepherd)) {
+            mc.when(() -> Collaboration.persistedCollaborationsForUser(eq(myShepherd), eq("owner")))
+                .thenReturn(Arrays.asList(approved));
+            List<String> ids = enc.computeViewUsers(myShepherd);
+            assertEquals(Arrays.asList("uuid-B"), ids);
+        }
+    }
+
+    @Test @SuppressWarnings("unchecked")
+    void noLocationIdNeverQueriesRoles() {
+        enc.setLocationID(null);
+        try (MockedStatic<Collaboration> mc = securityOnNoCollabs(myShepherd)) {
+            assertTrue(enc.computeViewUsers(myShepherd).isEmpty());
+        }
+        verify(myShepherd, never()).getUsernamesWithAnyRole(any(Collection.class), anyString());
+    }
+
+    @Test @SuppressWarnings("unchecked")
+    void publicEncounterStaysEmptyWithoutQueryingRoles() {
+        enc.setSubmitterID("public");
+        try (MockedStatic<Collaboration> mc = securityOnNoCollabs(myShepherd)) {
+            assertTrue(enc.computeViewUsers(myShepherd).isEmpty());
+        }
+        verify(myShepherd, never()).getUsernamesWithAnyRole(any(Collection.class), anyString());
+        assertFalse(enc.computeViewUsers(myShepherd).contains("uuid-B"));
+    }
+}

--- a/src/test/java/org/ecocean/servlet/EncounterSetLocationIDTest.java
+++ b/src/test/java/org/ecocean/servlet/EncounterSetLocationIDTest.java
@@ -138,6 +138,27 @@ class EncounterSetLocationIDTest {
         assertEquals("Komodo", enc.getLocationID());
     }
 
+    @Test @SuppressWarnings("unchecked")
+    void aThrowingAuthorizationCheckStillReleasesTheShepherd() throws Exception {
+        when(request.getParameter("code")).thenReturn("Komodo");
+        try (MockedStatic<Collaboration> mc = noCollaborations();
+            MockedConstruction<Shepherd> shepherds = mockConstruction(Shepherd.class,
+                (mock, ctx) -> {
+                    when(mock.getContext()).thenReturn("context0");
+                    when(mock.getEncounter("enc-1")).thenReturn(enc);
+                    when(mock.getUser(any(HttpServletRequest.class))).thenReturn(bob);
+                    when(mock.doesUserHaveAnyRole(anyString(), any(Collection.class), anyString()))
+                        .thenThrow(new javax.jdo.JDOException("datastore down"));
+                })) {
+            new EncounterSetLocationID().doPost(request, response);
+            Shepherd sh = shepherds.constructed().get(0);
+            verify(sh).closeDBTransaction();
+            verify(sh, never()).commitDBTransaction();
+            verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+        assertEquals("Pakistan", enc.getLocationID());
+    }
+
     @Test void unknownEncounterIsNotFound() throws Exception {
         when(request.getParameter("number")).thenReturn("missing");
         when(request.getParameter("code")).thenReturn("Komodo");

--- a/src/test/java/org/ecocean/servlet/EncounterSetLocationIDTest.java
+++ b/src/test/java/org/ecocean/servlet/EncounterSetLocationIDTest.java
@@ -1,0 +1,151 @@
+package org.ecocean.servlet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collection;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.ecocean.Encounter;
+import org.ecocean.LocationID;
+import org.ecocean.User;
+import org.ecocean.security.Collaboration;
+import org.ecocean.shepherd.core.Shepherd;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+/**
+ * /EncounterSetLocationID must authorize against the encounter as persisted, before anything is
+ * changed. In particular a caller must not be able to move an encounter into a location their
+ * own location-based role covers in order to gain access to it.
+ */
+class EncounterSetLocationIDTest {
+    private JSONObject previousTree;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private StringWriter body;
+    private Encounter enc;
+    private User bob;
+
+    // Pakistan -> PAKISTAN - North ; Indonesia -> Flores Sea -> Komodo
+    private static JSONObject tree() {
+        return new JSONObject("{\"locationID\":["
+            + "{\"name\":\"Pakistan\",\"id\":\"Pakistan\",\"locationID\":["
+            + "  {\"name\":\"PAKISTAN - North\",\"id\":\"PAKISTAN - North\",\"locationID\":[]}]},"
+            + "{\"name\":\"Indonesia\",\"id\":\"Indonesia\",\"locationID\":["
+            + "  {\"name\":\"Flores Sea\",\"id\":\"Flores Sea\",\"locationID\":["
+            + "    {\"name\":\"Komodo\",\"id\":\"Komodo\",\"locationID\":[]}]}]}]}");
+    }
+
+    @BeforeEach void setUp() throws Exception {
+        previousTree = LocationID.getJSONMaps().get("default");
+        LocationID.getJSONMaps().put("default", tree());
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        body = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(body));
+        when(request.getServletContext()).thenReturn(null);
+        when(request.getContextPath()).thenReturn("");
+        when(request.getRemoteUser()).thenReturn("bob");
+        when(request.getParameter("number")).thenReturn("enc-1");
+        enc = new Encounter();
+        enc.setCatalogNumber("enc-1");
+        enc.setSubmitterID("owner");
+        enc.setLocationID("Pakistan");
+        bob = new User("bob", null, null);
+    }
+
+    @AfterEach void tearDown() {
+        if (previousTree == null) LocationID.getJSONMaps().remove("default");
+        else LocationID.getJSONMaps().put("default", previousTree);
+    }
+
+    /** bob's only location role is heldRole; no collaborations exist. */
+    @SuppressWarnings("unchecked")
+    private MockedConstruction<Shepherd> shepherdWhereBobHolds(final String heldRole) {
+        return mockConstruction(Shepherd.class, (mock, ctx) -> {
+            when(mock.getContext()).thenReturn("context0");
+            when(mock.getEncounter("enc-1")).thenReturn(enc);
+            when(mock.getUser(any(HttpServletRequest.class))).thenReturn(bob);
+            when(mock.doesUserHaveAnyRole(eq("bob"), any(Collection.class), eq("context0")))
+                .thenAnswer(inv -> ((Collection<String>)inv.getArgument(1)).contains(heldRole));
+        });
+    }
+
+    private static MockedStatic<Collaboration> noCollaborations() {
+        MockedStatic<Collaboration> mc = mockStatic(Collaboration.class, Answers.CALLS_REAL_METHODS);
+        mc.when(() -> Collaboration.collaborationBetweenUsers(anyString(), anyString(),
+            anyString())).thenReturn(null);
+        return mc;
+    }
+
+    @Test void callerCannotMoveAnEncounterIntoTheirOwnLocationRole() throws Exception {
+        when(request.getParameter("code")).thenReturn("Indonesia"); // covered by bob's role
+        try (MockedStatic<Collaboration> mc = noCollaborations();
+            MockedConstruction<Shepherd> shepherds = shepherdWhereBobHolds("Indonesia")) {
+            new EncounterSetLocationID().doPost(request, response);
+            verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+            verify(shepherds.constructed().get(0), never()).commitDBTransaction();
+        }
+        assertEquals("Pakistan", enc.getLocationID(), "the persisted location must be untouched");
+    }
+
+    @Test void nonOwnerWithoutRoleOrCollaborationIsForbidden() throws Exception {
+        when(request.getParameter("code")).thenReturn("Komodo");
+        try (MockedStatic<Collaboration> mc = noCollaborations();
+            MockedConstruction<Shepherd> shepherds = shepherdWhereBobHolds("nothing")) {
+            new EncounterSetLocationID().doPost(request, response);
+            verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+            verify(shepherds.constructed().get(0), never()).commitDBTransaction();
+        }
+        assertEquals("Pakistan", enc.getLocationID());
+    }
+
+    @Test void roleCoveringTheCurrentLocationMayChangeIt() throws Exception {
+        when(request.getParameter("code")).thenReturn("Komodo");
+        try (MockedStatic<Collaboration> mc = noCollaborations();
+            MockedConstruction<Shepherd> shepherds = shepherdWhereBobHolds("Pakistan")) {
+            new EncounterSetLocationID().doPost(request, response);
+            verify(response).setStatus(HttpServletResponse.SC_OK);
+            verify(shepherds.constructed().get(0)).commitDBTransaction();
+        }
+        assertEquals("Komodo", enc.getLocationID());
+    }
+
+    @Test void ownerMayChangeIt() throws Exception {
+        enc.setSubmitterID("bob");
+        when(request.getParameter("code")).thenReturn("Komodo");
+        try (MockedStatic<Collaboration> mc = noCollaborations();
+            MockedConstruction<Shepherd> shepherds = shepherdWhereBobHolds("nothing")) {
+            new EncounterSetLocationID().doPost(request, response);
+            verify(response).setStatus(HttpServletResponse.SC_OK);
+        }
+        assertEquals("Komodo", enc.getLocationID());
+    }
+
+    @Test void unknownEncounterIsNotFound() throws Exception {
+        when(request.getParameter("number")).thenReturn("missing");
+        when(request.getParameter("code")).thenReturn("Komodo");
+        try (MockedStatic<Collaboration> mc = noCollaborations();
+            MockedConstruction<Shepherd> shepherds = shepherdWhereBobHolds("nothing")) {
+            new EncounterSetLocationID().doPost(request, response);
+            verify(response).setStatus(HttpServletResponse.SC_NOT_FOUND);
+            verify(shepherds.constructed().get(0), never()).commitDBTransaction();
+        }
+    }
+}


### PR DESCRIPTION
Closes #1549. Closes #1244.

## The bug

A "location-based role" is a `Role` row whose name equals an encounter's location ID (IoT uses roles such as `Indonesia`, `Flores Sea`, `ORP-Pakistan`). Only the legacy classic-page check, `ServletUtilities.isUserAuthorizedForEncounter`, knew about it. Everything the React app and the search index rely on did not:

- `Encounter.canUserView` / `canUserEdit` (the `/api/v3/encounters/{id}` GET and PATCH gates) only accepted owner, admin, public or collaboration, so the React encounter page returned the blocked stub and showed the "start a collaboration" prompt (#1549). `canUserEdit` even carried a TODO asking whether location roles were real.
- `Encounter.computeViewUsers` and the background permissions pass, the two writers of the OpenSearch `viewUsers` ACL, only listed collaborators and orgAdmins, so search results showed those encounters as `access: none`.
- `Collaboration.canUserAccessEncounter` had no role check either, so `individuals.jsp` denied the individual (#1244).

## What changed

**One rule, one place.** `org.ecocean.security.LocationRoleAccess` (new) decides which role names cover a location: the location ID itself plus every ancestor of it in the default `locationID.json` tree, minus the system role names (`admin`, `orgAdmin`, `researcher`, `rest`, `machinelearning`). A role at a node therefore covers that node and its whole subtree; a child-node role never grants the parent. An ID that is missing from the tree, or that appears under more than one parent, gets exact-name matching only. Blank IDs are skipped; a null or blank location grants nothing.

**Every access path consults it.**
- `EncounterSetLocationID` (legacy servlet, `roles[researcher]` in web.xml) had its authorization block commented out, so any researcher could re-locate any encounter. It now requires `canUserEdit` on the encounter as persisted before anything changes (404 unknown, 403 denied), and releases its Shepherd on every path. With location roles honored everywhere this mattered more: a caller must not be able to move an encounter into a location their own role covers.
- `Encounter.canUserView` and `canUserEdit` grant view and edit to a covering-role holder (parity with the classic check, which always granted edit). A new `Encounter.canUserAccess(User, Shepherd)` reuses the caller's Shepherd for the lookup.
- `Collaboration.canUserAccessEncounter`: the request overload asks Shiro `isUserInRole` over the lineage; the context-only overload (still used by `AccessControl` export, `OBISSeamap`, `canUserAccessOccurrence`, `canUserAccessImportTask`, `Task`) runs the lookup on a short-lived Shepherd that is closed before any collaboration lookup opens its own; a new Shepherd-bearing overload backs `canUserAccess(User, Shepherd)`.
- `ServletUtilities.isUserAuthorizedForEncounter` switches from exact match to the same lineage rule, so classic and React agree. This also stops a system role such as `researcher` from unlocking an encounter whose location ID happens to collide with it.

**Both `viewUsers` writers agree.** `computeViewUsers` adds covering-role holders before it resolves the owner (the location grant does not depend on the owner; collaboration/orgAdmin grants still fail closed) and never lists the owner. The permissions pass loads roles once per pass through the new `Shepherd.getRolesInContext`, selects `LOCATIONID` with each encounter row, unions the lineage grants into the same set, and excludes the owner. `getRolesInContext` propagates a datastore failure so a bad role read aborts the pass (leaving `permissionsNeeded` set for a retry) instead of silently revoking every location grant in the index.

**Shepherd helpers** `doesUserHaveAnyRole` and `getUsernamesWithAnyRole` bind the name set and context as JDOQL parameters (names may carry quotes) and match on the stored context column, so a `Role` row stored with a NULL context never satisfies a context query, the same rule `ShepherdRealm` applies for Shiro.

## Propagation after deploy

- **The install's location names must be listed in the indexed `roleN` property** (`commonConfiguration.properties`): that is the list `appadmin/users.jsp` renders as the role-assignment options, so it is how an admin grants `Indonesia` in the first place. The shipped default already mixes both kinds (`role0..role4` are the system roles, `role5..role15` are Finnish lake names), which is exactly what a location role is meant to look like. Nothing in the access checks reads this property -- it only governs what an admin can click.

- Role create/delete already sets `permissionsNeeded`; the background pass then rewrites `viewUsers` and its change detection enqueues the annotation/individual refresh.
- A location ID edit already reindexes the encounter through the serializer.
- No migration or config change. Existing documents pick up the new grants on the next permissions pass (at the latest the forced run, `backgroundPermissionsMaxForceMinutes`, default 45).
- `locationID.json` edits need a restart (the tree is cached), then the forced pass catches up.

## Known limitation (pre-existing, not changed here)

The permissions pass only enqueues the child (annotation/individual) ACL refresh when the encounter's `viewUsers` changed and the previously indexed value was readable; a failed enqueue is not retried on later passes. Location roles add one more revocation vector to that existing gap. Follow-up.

## Tests

- `LocationRoleAccessTest` (21): lineage rules, ambiguity, blank/id-less nodes, system-name exclusion, request/Shepherd paths, pass helper.
- `LocationRoleShepherdDbTest` (8, Testcontainers, real DataNucleus 5.2.7 + Postgres): parameter binding, apostrophes, distinct projection, wrong and NULL context, empty inputs.
- `LocationRoleEncounterAccessTest` (16): `canUserView`/`canUserEdit`/`canUserAccess`, both `Collaboration` overloads (the short-lived Shepherd is closed before the collaboration lookup runs, and on a throwing role query), the classic check including owner/admin/public preservation and the system-name collision.
- `LocationRoleViewUsersTest` (7) and `LocationRolePermissionsPassTest` (7): both writers, owner exclusion, unresolvable owner (serializer grants; the pass hands the row to the full reindex), per-encounter viewer sets, dedupe with collaborators, role-load failure aborts before any index write.
- `EncounterSetLocationIDTest` (6): the servlet authorizes against the persisted encounter (a caller cannot move an encounter into their own role's location), 404/403 paths, owner and covering-role success, and that a throwing authorization check still releases the Shepherd.
- Existing ACL suites unchanged and green (`ComputeViewUsersTest`, `CanUserAccessTest`, `PermissionsTest`, `EncounterAclFieldsTest`).
- Full backend suite on the final commit: 962 run, 0 failures, 0 errors, 7 skipped (`mvn -o test`, BUILD SUCCESS). One earlier run hit `JwtServiceTest.tamperedToken_rejected`, a pre-existing random-key flake unrelated to this branch (it passes on re-run).

## Manual QA (IoT)

1. Give a researcher a role named after a top-level location (e.g. `Pakistan`) and no collaboration with the owner of a `PAKISTAN - North` encounter.
2. `/react/encounter?number=...` opens with edit controls instead of the collaboration prompt.
3. `/react/encounter-search` filtered to that location lists the encounter with full fields (ID column populated), within one permissions pass of the deploy.
4. `individuals.jsp` for the encounter's individual opens.
5. A role named after a sibling or child location does not grant any of the above.

## Review response

`40b0603` answers @naknomum's review, pure refactor with no access-control outcome change:

- The lineage walk moved to `LocationID.lineageFor()` (tree geometry, no role concept). The older `getIDForChildAndParents()`/`findPath()` is left in place -- it flattens several matching branches into one list for a duplicated id and returns empty when the root is the target, which is why the access path does not use it -- and the new javadoc says so.
- The system role names moved to `Role.SYSTEM_ROLES` (ordered; `UserConsolidate` ranks two users by that order) with `Role.SYSTEM_ROLE_NAMES` for membership tests. Two copies already existed before this branch -- `UserConsolidate.roleHierarchy` and `StartupWildbook`'s seeding -- and all three now share the one constant.
- Traversal tests moved with the code into `LocationIDLineageTest` (+5 cases); `RoleTest` pins the hierarchy order, list/set agreement and immutability.

## Credits

Written by **Claude Fable 5.1** (Claude Code). **Codex** (`codex-cli`, `gpt-6-astra`, reasoning effort high) reviewed the design before any code was written and then the diff. Its design review found five load-bearing problems: `LocationID.findPath` accumulates ancestors from several branches for a duplicated ID (hence the ambiguity fallback and the authorization-specific traversal); `Role.getContext()` maps a stored NULL to `context0` while every JDOQL path filters on the stored column (hence the context-parity rule and `getRolesInContext`); the serializer's fail-closed owner check would have suppressed the location grant that the live checks admit; `Shepherd.getAllRoles()` swallows `JDOException` and would have let the pass erase every location grant on a bad read; and the redundant second Shepherd on the `canUserView` path. Its diff review (round 1: 1 Major, 3 Minor) found the unauthenticated `EncounterSetLocationID` write path and three test weaknesses (a captor that reused the pass's mutable `updateData`, a closure assertion that did not prove ordering, a `distinct` projection that was never exercised); all four are fixed. Round 2 returned **"CONVERGED: no Major findings"** with one Minor, the servlet's transaction release on an exception from the authorization check, fixed in the last commit and covered by a test; that last fix was not sent back for a third round.

