### PR TITLE
fix(individuals): show researcher comments to anyone who can view the individual

### DIFF
--- a/src/main/webapp/individuals.jsp
+++ b/src/main/webapp/individuals.jsp
@@ -2520,9 +2520,9 @@ if (sharky.getNames() != null) {
       <br>
       <%-- Comments --%>
       <div class="col-sm-6">
-        <%
-        if(isOwner){
-          %>
+          <%-- The board follows view access, which the whole page body is already gated on: these
+               record merges and similar shared history, so anyone who can see the individual can
+               see what has been done to it. Adding a comment still takes edit rights, below. --%>
           <p><img align="absmiddle" src="images/Crystal_Clear_app_kaddressbook.gif"> <strong><%=researcherComments %></strong>: </p>
           <div id='commentBoard' style="text-align:left;border:1px solid lightgray;width:100%;height:250px;overflow-y:scroll;overflow-x:scroll;border-radius:5px;">
             <p><%=sharky.getComments().replaceAll("\n", "<br>")%></p>
@@ -2543,7 +2543,6 @@ if (sharky.getNames() != null) {
               <%
             } //if isEditable
 
-          }
           %>
 
         </td>


### PR DESCRIPTION
Fixes #1138.

Implements what @naknomum specified in https://github.com/WildMeOrg/Wildbook/issues/1138#issuecomment-5589337398 — the board follows `visible`, and the add-comment form stays on `isCatalogEditable() && isOwner`.

## Cause

The Researcher Comments board was gated on `isOwner` (`individuals.jsp:2524`), which is edit permission rather than view permission (`:503`):

```java
boolean isOwner = Collaboration.canUserPartiallyEditMarkedIndividual(sharky, request);
```

`canUserPartiallyEditMarkedIndividual` returns true for an admin, and otherwise only if the user can edit **at least one** of the individual's encounters. That accounts for both halves of the report: an admin always saw the full history, while a researcher or OrgAdmin saw the board only on individuals they happened to have an encounter on — which in practice are the ones they worked on themselves. The reported symptom, "I can only see my own actions", is really "the board is hidden entirely on every individual I have no encounter on", which is why an OrgAdmin could not see that someone in their org had merged an individual.

## Fix

Removing the gate is sufficient — no new predicate needed. The entire page body is already behind view access at `:497`:

```java
if (myShepherd.isMarkedIndividual(id) && visible) {   // visible = canUserAccessMarkedIndividual, :237
```

so the board simply becomes part of the normal view-access content.

The add-comment form is nested inside the removed block but carries its own independent `isCatalogEditable(context) && isOwner` check at `:2531`, so it stays gated exactly as before — reading the history and writing to it remain separate permissions. Net diff is three lines.

## One visible side effect

`MarkedIndividual.getComments()` returns the string `"None"` when there are no comments, so an individual with no history will now show "Researcher Comments: None" to any viewer, where a non-owner previously saw no section at all. That is already what admins see, so I left it rather than adding an emptiness check — happy to suppress the block when empty if you'd rather.

## Verification

Exercised end to end against a local Wildbook (Tomcat 9 / JRE17, Postgres, OpenSearch 3.1.0) built from this branch.

Fixture, created through the app rather than by hand: an encounter (`KB`, *Giraffa tippelskirchi*), an individual `TEST-1138` assigned via `PATCH /api/v3/encounters/{id}` on `individualId`, and a real comment written through `IndividualAddComment`. Then a second account with **only** the `researcher` role and no encounter of its own, plus an `approved` collaboration with the submitter — `Collaboration.canCollaborate` grants view on `approved` while edit requires state `edit`, so that account lands in exactly the "can see the individual, cannot edit it" case this issue is about.

Swapping only `individuals.jsp` between `main` and this branch on the running instance:

| scenario | comment board | comment text | add-comment form |
|---|---|---|---|
| `main`, researcher (view-only) | ✗ | ✗ | ✗ |
| this branch, researcher (view-only) | ✓ | ✓ | ✗ |
| this branch, admin/owner | ✓ | ✓ | ✓ |
| this branch, individual with no comments | ✓ (shows "None") | — | ✗ |

Row 1 is the bug: the page renders the individual fine (93KB, the name appears five times) and still shows no Researcher Comments at all. Row 2 is the fix, with the add-comment form correctly still withheld. Row 3 confirms owners are unaffected. Row 4 confirms the "None" note above.

No Jasper exception on any request, so the JSP compiles.

One caveat on scope: this was checked by inspecting the served HTML for the comment board, the comment text and the form markup, not by driving a browser. Layout and styling of the newly-visible block have not been eyeballed on a real page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnYvkvJGprMb41dZe38H6R
