### PR TITLE
Require an authenticated researcher for comment and behavior servlets

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -346,6 +346,9 @@
 				/MediaAssetsForUser = authc
 				/MediaAssetAttach = authc, roles[researcher]
 				/MediaAssetModify = authc, roles[researcher]
+				/EncounterSetBehavior = authc, roles[researcher]
+				/OccurrenceAddComment = authc, roles[researcher]
+				/EncounterAddComment = authc, roles[researcher]
 
 				# ===== Workspace Management =====
 				/WorkspaceServer = authc, roles[researcher]

--- a/src/test/java/org/ecocean/security/AuthorizationRoutesTest.java
+++ b/src/test/java/org/ecocean/security/AuthorizationRoutesTest.java
@@ -1,0 +1,46 @@
+package org.ecocean.security;
+
+import java.nio.file.Path;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.apache.shiro.config.Ini;
+import org.apache.shiro.util.AntPathMatcher;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuthorizationRoutesTest {
+    private Ini.Section routes() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        NodeList filters = factory.newDocumentBuilder()
+            .parse(Path.of("src/main/webapp/WEB-INF/web.xml").toFile()).getElementsByTagName("filter");
+        for (int i = 0; i < filters.getLength(); i++) {
+            Element filter = (Element)filters.item(i);
+            if ("ShiroFilter".equals(filter.getElementsByTagName("filter-name").item(0).getTextContent())) {
+                Ini ini = new Ini();
+                ini.load(filter.getElementsByTagName("param-value").item(0).getTextContent());
+                return ini.getSection("urls");
+            }
+        }
+        throw new AssertionError("Shiro configuration missing");
+    }
+
+    private String firstRule(Ini.Section routes, String path) {
+        AntPathMatcher matcher = new AntPathMatcher();
+        for (Map.Entry<String, String> rule : routes.entrySet()) {
+            if (matcher.matches(rule.getKey(), path)) return rule.getValue();
+        }
+        return null;
+    }
+
+    @Test void sensitiveWriteRoutesRequireAuthenticationBeforeHandlerChecks() throws Exception {
+        Ini.Section routes = routes();
+        for (String path : new String[] {"/EncounterSetBehavior", "/OccurrenceAddComment", "/EncounterAddComment", "/MediaAssetModify"}) {
+            assertEquals("authc, roles[researcher]", firstRule(routes, path), path);
+        }
+        assertEquals("authc", firstRule(routes, "/ProjectDelete"));
+        assertEquals("authc, roles[admin]", firstRule(routes, "/UserDelete"));
+    }
+}


### PR DESCRIPTION
Found by a Codex (gpt-6-astra) authorization sweep. The handler-level checks for these servlets ship separately.

[Plain-text summary description of the solution. Include any class updates, new or edited functions, significant changes to UX, etc]

PR fixes #[REPLACE WITH ISSUE NUMBER]

**Before you Submit!**
* Is all the text internationalized?
* If you made a change to the header, did you update the react, jsp, and html?
* Are all depedencies at a locked version?
* Did you adhere to [best practices](https://wildbook.docs.wildme.org/contribute/code-guide.html)?
* Is there a quick [unit test](https://wildbook.docs.wildme.org/contribute/tests.html) you can add?
