### PR TITLE
fix(ia): commit the inline vector match started from the project page

### DIFF
--- a/src/main/java/org/ecocean/servlet/ProjectIA.java
+++ b/src/main/java/org/ecocean/servlet/ProjectIA.java
@@ -56,54 +56,22 @@ public class ProjectIA extends HttpServlet {
         myShepherd.beginDBTransaction();
 
         JSONObject res = new JSONObject();
-        JSONObject j = ServletUtilities.jsonFromHttpServletRequest(request);
+        res.put("success", false);
         String projectIdPrefix = null;
         String queryEncounterId = null;
 
         try {
-            res.put("success", "false");
-
+            // parsed inside the try: the Shepherd is already open, so a malformed body must not
+            // throw past the finally that releases the PersistenceManager
+            JSONObject j = ServletUtilities.jsonFromHttpServletRequest(request);
             projectIdPrefix = j.optString("projectIdPrefix", null);
             queryEncounterId = j.optString("queryEncounterId", null);
-            if (Util.stringExists(queryEncounterId) && Util.stringExists(projectIdPrefix)) {
-                Project project = myShepherd.getProjectByProjectIdPrefix(projectIdPrefix);
-                Encounter queryEnc = myShepherd.getEncounter(queryEncounterId);
-                if (project != null && queryEnc != null) {
-                    List<Encounter> targetEncs = project.getEncounters();
-                    List<Annotation> targetAnns = new ArrayList<>();
-                    JSONArray initiatedJobs = new JSONArray();
-                    for (Annotation queryAnn : queryEnc.getAnnotations()) {
-                        if (IBEISIA.validForIdentification(queryAnn)) {
-                            if (targetAnns.isEmpty()) {
-                                targetAnns = getAnnotationList(targetEncs);
-                            }
-                            List<Annotation> anns = new ArrayList<>();
-                            anns.add(0, queryAnn);
-                            Task parentTask = new Task();
-                            JSONObject tp = new JSONObject();
-                            JSONObject mf = new JSONObject();
-                            mf.put("projectId", project.getId());
-                            tp.put("matchingSetFilter", mf);
-                            parentTask.setParameters(tp);
-                            myShepherd.storeNewTask(parentTask);
-
-                            Task childTask = IA.intakeAnnotations(myShepherd, anns, parentTask,
-                                true);
-                            JSONObject jobJSON = new JSONObject();
-                            jobJSON.put("topTaskId", parentTask.getId());
-                            jobJSON.put("childTaskId", childTask.getId());
-                            jobJSON.put("queryAnnId", queryAnn.getId());
-                            initiatedJobs.put(jobJSON);
-                        }
-                    }
-                    res.put("success", "true");
-                    res.put("initiatedJobs", initiatedJobs);
-                    response.setStatus(HttpServletResponse.SC_OK);
-                    // JSONObject rtnIA = IBEISIA.sendIdentify(qanns, tanns, queryConfigDict, userConfidence, baseUrl, context);
-                }
+            res = initiateProjectMatch(myShepherd, projectIdPrefix, queryEncounterId);
+            // a well-formed outcome stays 200 even when nothing matched: project.jsp drives its
+            // UI off `success`, and its ajax error handler leaves the "starting" spinner up
+            if (res.optBoolean("success", false)) {
+                response.setStatus(HttpServletResponse.SC_OK);
             }
-            out.println(res);
-            out.close();
         } catch (NullPointerException npe) {
             npe.printStackTrace();
             addErrorMessage(res, "NullPointerException npe");
@@ -117,13 +85,78 @@ public class ProjectIA extends HttpServlet {
             addErrorMessage(res, "Exception e");
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         } finally {
-            myShepherd.rollbackDBTransaction();
-            myShepherd.closeDBTransaction();
+            // initiateProjectMatch() owns the commit, so this only unwinds a run that failed
+            // before it (rollback of an inactive transaction is a no-op).
+            myShepherd.rollbackAndClose();
             out.println(res);
+            out.close();
         }
     }
 
-    private ArrayList<Annotation> getAnnotationList(List<Encounter> encs) {
+    static JSONObject initiateProjectMatch(Shepherd myShepherd, String projectIdPrefix,
+        String queryEncounterId) {
+        JSONObject res = new JSONObject();
+
+        res.put("success", false);
+        if (!Util.stringExists(queryEncounterId) || !Util.stringExists(projectIdPrefix)) return res;
+        Project project = myShepherd.getProjectByProjectIdPrefix(projectIdPrefix);
+        Encounter queryEnc = myShepherd.getEncounter(queryEncounterId);
+        if ((project == null) || (queryEnc == null)) return res;
+        List<Encounter> targetEncs = project.getEncounters();
+        List<Annotation> targetAnns = new ArrayList<>();
+        JSONArray initiatedJobs = new JSONArray();
+        JSONArray failedAnnotations = new JSONArray();
+        for (Annotation queryAnn : queryEnc.getAnnotations()) {
+            if (!IBEISIA.validForIdentification(queryAnn)) continue;
+            if (targetAnns.isEmpty()) {
+                targetAnns = getAnnotationList(targetEncs);
+            }
+            try {
+                List<Annotation> anns = new ArrayList<>();
+                anns.add(0, queryAnn);
+                Task parentTask = new Task();
+                JSONObject tp = new JSONObject();
+                JSONObject mf = new JSONObject();
+                mf.put("projectId", project.getId());
+                tp.put("matchingSetFilter", mf);
+                parentTask.setParameters(tp);
+                myShepherd.storeNewTask(parentTask);
+
+                Task childTask = IA.intakeAnnotations(myShepherd, anns, parentTask, true);
+                // IA.intakeAnnotations() runs a vector (MiewID) match INLINE on this Shepherd:
+                // the per-annotation subtasks, the MatchResult and the terminal task status are
+                // only makePersistent()ed, and it is the caller that has to commit them. Without
+                // this commit the servlet's rollback discarded all of it and left a childless
+                // task with a null status, which Task.getStatus() reports forever as the
+                // non-terminal "waiting to queue" -- the match-results page then polls and spins
+                // indefinitely (issue #1761). commitDBTransaction() would not do: it swallows
+                // failures, so an unpersisted match could still be reported as started.
+                // Committing per annotation keeps one annotation's failure from discarding the
+                // matches that already ran for its siblings.
+                if (!myShepherd.commitDBTransactionWithStatus()) {
+                    failedAnnotations.put(queryAnn.getId());
+                    continue;
+                }
+                JSONObject jobJSON = new JSONObject();
+                jobJSON.put("topTaskId", parentTask.getId());
+                jobJSON.put("childTaskId", childTask.getId());
+                jobJSON.put("queryAnnId", queryAnn.getId());
+                initiatedJobs.put(jobJSON);
+            } catch (Exception ex) {
+                // a failure here can leave the transaction aborted, which would poison every
+                // later annotation; unwind it so the remaining ones start clean
+                ex.printStackTrace();
+                myShepherd.rollbackDBTransaction();
+                failedAnnotations.put(queryAnn.getId());
+            }
+        }
+        res.put("success", failedAnnotations.length() == 0);
+        res.put("initiatedJobs", initiatedJobs);
+        if (failedAnnotations.length() > 0) res.put("failedAnnotations", failedAnnotations);
+        return res;
+    }
+
+    private static ArrayList<Annotation> getAnnotationList(List<Encounter> encs) {
         ArrayList<Annotation> anns = new ArrayList<>();
         Set<Annotation> annHash = new HashSet<>();
 

--- a/src/test/java/org/ecocean/servlet/ProjectIATransactionTest.java
+++ b/src/test/java/org/ecocean/servlet/ProjectIATransactionTest.java
@@ -1,0 +1,183 @@
+package org.ecocean.servlet;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.ecocean.Annotation;
+import org.ecocean.Encounter;
+import org.ecocean.Project;
+import org.ecocean.ia.IA;
+import org.ecocean.ia.Task;
+import org.ecocean.identity.IBEISIA;
+import org.ecocean.shepherd.core.Shepherd;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Transaction-ownership tests for {@link ProjectIA#initiateProjectMatch} (issue #1761).
+ *
+ * <p>{@code IA.intakeAnnotations()} performs the vector (MiewID) match INLINE on the caller's
+ * Shepherd -- it creates the per-annotation subtasks, the MatchResult and the terminal task status
+ * with {@code makePersistent()} only, and relies on the caller to commit. ProjectIA used to roll
+ * back unconditionally, which discarded all of that and left a childless task with a null status;
+ * {@code Task.getStatus()} then reports the non-terminal "waiting to queue" forever, so the React
+ * match-results page spins indefinitely.</p>
+ */
+class ProjectIATransactionTest {
+    private static final String PREFIX = "MES-#####";
+    private static final String ENC_ID = "d316cd66-f0b1-49a4-859e-b1c4cec177ae";
+    private static final String PROJECT_ID = "6ea1c0a2-1a7e-4a0e-9b2c-0d3f5a7e9b11";
+
+    // A query encounter carrying exactly one identifiable annotation, in a project of its own.
+    private static Shepherd shepherdWithOneMatchableAnnotation() {
+        return shepherdWithMatchableAnnotations("ann-1");
+    }
+
+    private static Shepherd shepherdWithMatchableAnnotations(String... annIds) {
+        ArrayList<Annotation> encAnns = new ArrayList<>();
+
+        for (String annId : annIds) {
+            Annotation queryAnn = mock(Annotation.class);
+            when(queryAnn.getId()).thenReturn(annId);
+            encAnns.add(queryAnn);
+        }
+        Encounter queryEnc = mock(Encounter.class);
+        when(queryEnc.getAnnotations()).thenReturn(encAnns);
+        Project project = mock(Project.class);
+        when(project.getId()).thenReturn(PROJECT_ID);
+        when(project.getEncounters()).thenReturn(new ArrayList<Encounter>());
+        Shepherd myShepherd = mock(Shepherd.class);
+        when(myShepherd.getProjectByProjectIdPrefix(PREFIX)).thenReturn(project);
+        when(myShepherd.getEncounter(ENC_ID)).thenReturn(queryEnc);
+        return myShepherd;
+    }
+
+    // Committing before the inline match would persist nothing useful, so order is part of
+    // the contract, not an implementation detail. (doPost() still calls rollbackAndClose()
+    // afterwards to release the PersistenceManager; that is a no-op on a committed transaction.)
+    @Test void helperCommitsAfterTheInlineMatchWorkAndDoesNotRollBackOnSuccess() {
+        Shepherd myShepherd = shepherdWithOneMatchableAnnotation();
+        List<String> callOrder = new ArrayList<>();
+
+        when(myShepherd.commitDBTransactionWithStatus()).thenAnswer(invocation -> {
+            callOrder.add("commit");
+            return true;
+        });
+        try (MockedStatic<IBEISIA> ibeis = mockStatic(IBEISIA.class);
+            MockedStatic<IA> ia = mockStatic(IA.class)) {
+            ibeis.when(() -> IBEISIA.validForIdentification(any(Annotation.class))).thenReturn(
+                true);
+            ia.when(() -> IA.intakeAnnotations(any(Shepherd.class), any(List.class),
+                any(Task.class), anyBoolean())).thenAnswer(invocation -> {
+                callOrder.add("intakeAnnotations");
+                return new Task();
+            });
+            ProjectIA.initiateProjectMatch(myShepherd, PREFIX, ENC_ID);
+        }
+        assertEquals(Arrays.asList("intakeAnnotations", "commit"), callOrder,
+            "the inline match work must be committed, and committed after it is done");
+        verify(myShepherd, never()).rollbackDBTransaction();
+    }
+
+    @Test void reportsSuccessWithInitiatedJobsWhenTheCommitLands() {
+        Shepherd myShepherd = shepherdWithOneMatchableAnnotation();
+
+        when(myShepherd.commitDBTransactionWithStatus()).thenReturn(true);
+        JSONObject res;
+        try (MockedStatic<IBEISIA> ibeis = mockStatic(IBEISIA.class);
+            MockedStatic<IA> ia = mockStatic(IA.class)) {
+            ibeis.when(() -> IBEISIA.validForIdentification(any(Annotation.class))).thenReturn(
+                true);
+            ia.when(() -> IA.intakeAnnotations(any(Shepherd.class), any(List.class),
+                any(Task.class), anyBoolean())).thenReturn(new Task());
+            res = ProjectIA.initiateProjectMatch(myShepherd, PREFIX, ENC_ID);
+        }
+        assertTrue(res.optBoolean("success", false),
+            "success must be reported after a good commit");
+        assertEquals(1, res.getJSONArray("initiatedJobs").length(),
+            "the one identifiable annotation should have initiated one job");
+    }
+
+    // commitDBTransaction() swallows commit failures, which is why the production code uses
+    // commitDBTransactionWithStatus(): a match whose results were not persisted must not be
+    // advertised to the user as started.
+    @Test void reportsFailureWhenTheCommitDoesNotLand() {
+        Shepherd myShepherd = shepherdWithOneMatchableAnnotation();
+
+        when(myShepherd.commitDBTransactionWithStatus()).thenReturn(false);
+        JSONObject res;
+        try (MockedStatic<IBEISIA> ibeis = mockStatic(IBEISIA.class);
+            MockedStatic<IA> ia = mockStatic(IA.class)) {
+            ibeis.when(() -> IBEISIA.validForIdentification(any(Annotation.class))).thenReturn(
+                true);
+            ia.when(() -> IA.intakeAnnotations(any(Shepherd.class), any(List.class),
+                any(Task.class), anyBoolean())).thenReturn(new Task());
+            res = ProjectIA.initiateProjectMatch(myShepherd, PREFIX, ENC_ID);
+        }
+        assertFalse(res.optBoolean("success", false),
+            "a failed commit must not be reported as a started match");
+        assertEquals(0, res.getJSONArray("initiatedJobs").length(),
+            "no jobs should be advertised when the work was not persisted");
+    }
+
+    // Each annotation's match is committed on its own, so a blow-up part way through the
+    // encounter cannot throw away the matches that already ran (issue #1761).
+    @Test void aFailingAnnotationDoesNotDiscardTheMatchAlreadyCommittedForAnother() {
+        Shepherd myShepherd = shepherdWithMatchableAnnotations("ann-1", "ann-2");
+        List<String> callOrder = new ArrayList<>();
+
+        when(myShepherd.commitDBTransactionWithStatus()).thenAnswer(invocation -> {
+            callOrder.add("commit");
+            return true;
+        });
+        JSONObject res;
+        try (MockedStatic<IBEISIA> ibeis = mockStatic(IBEISIA.class);
+            MockedStatic<IA> ia = mockStatic(IA.class)) {
+            ibeis.when(() -> IBEISIA.validForIdentification(any(Annotation.class))).thenReturn(
+                true);
+            ia.when(() -> IA.intakeAnnotations(any(Shepherd.class), any(List.class),
+                any(Task.class), anyBoolean())).thenAnswer(invocation -> {
+                callOrder.add("intakeAnnotations");
+                // blow up on the second annotation only
+                if (callOrder.contains("commit")) throw new RuntimeException("intake exploded");
+                return new Task();
+            });
+            res = ProjectIA.initiateProjectMatch(myShepherd, PREFIX, ENC_ID);
+        }
+        assertEquals(Arrays.asList("intakeAnnotations", "commit", "intakeAnnotations"), callOrder,
+            "the first annotation must already be committed before the second one runs");
+        assertEquals(1, res.getJSONArray("initiatedJobs").length(),
+            "the annotation that succeeded keeps its job");
+        assertEquals("ann-2", res.getJSONArray("failedAnnotations").getString(0),
+            "the annotation that blew up must be reported");
+        assertFalse(res.optBoolean("success", false),
+            "a partially failed run must not claim overall success");
+        // the poisoned transaction has to be unwound so later annotations start clean
+        verify(myShepherd).rollbackDBTransaction();
+    }
+
+    @Test void reportsFailureAndCommitsNothingWhenTheProjectIsUnknown() {
+        Shepherd myShepherd = mock(Shepherd.class);
+
+        when(myShepherd.getProjectByProjectIdPrefix(anyString())).thenReturn(null);
+        when(myShepherd.getEncounter(anyString())).thenReturn(null);
+        JSONObject res = ProjectIA.initiateProjectMatch(myShepherd, PREFIX, ENC_ID);
+        assertFalse(res.optBoolean("success", false), "unknown project must not report success");
+        verify(myShepherd, never()).commitDBTransactionWithStatus();
+    }
+}


### PR DESCRIPTION
Fixes #1761.

## What users see

"Start Match" on a project page (`/projects/project.jsp`) starts a match, but the MiewID section of the match-results page shows *"Match results are still being processed."* and spins forever. Starting the same match from the encounter page works. Reported on amphibian-reptile; it affects any install whose `IA.json` uses a vector/MiewID config.

## Root cause

`ProjectIA` called `IA.intakeAnnotations()` and then unconditionally rolled its `Shepherd` back in a `finally`. That rollback has been there since 2020 (`44a2832c45`) and was harmless: back then `intakeAnnotations()` only *enqueued* a WBIA job, the queue write happens outside the DB transaction, and the async worker committed its own `Shepherd`.

`ba050552e2` (2026-01-22, first released in **10.10.0**) added inline vector matching:

```java
// if this is a vector-based matching option, this will just do the job and be done
if (Embedding.findMatchProspects(opts.get(i), tasks.get(i), myShepherd)) continue;
```

`Embedding.findMatchProspects()` runs the kNN match synchronously on the **caller's** `Shepherd` and only `makePersistent()`s the per-annotation subtasks, the `MatchResult` and the terminal task status — committing is the caller's job. ProjectIA's rollback discarded all of it.

What survived is the bare `Task` row `Shepherd.storeNewTask()` had already committed (it commits via `updateDBTransaction()`): no children, no `MatchResult`, and a **null status**. `Task.getStatus()` reports that as the non-terminal `"waiting to queue"`, and its timeout→`error` branch is guarded on `status != null`, so the task can never age out either. The React page polls it every 5s indefinitely.

The encounter page is unaffected because it POSTs to `/ia`; the queue worker's `IA.handleRest()` commits after `intakeAnnotations()`, as does the bulk-import path in `IBEISIA`.

## The change

The match-initiation work moves into `ProjectIA.initiateProjectMatch()`, which owns the transaction:

- **Commits** with `commitDBTransactionWithStatus()`. `commitDBTransaction()` swallows commit failures, so a match whose results never landed could still be advertised as started.
- **Commits per annotation**, so a failure part way through an encounter no longer discards the matches that already ran for its siblings. A failing annotation unwinds its own (possibly PG-aborted) transaction so later annotations start clean, and is reported in `failedAnnotations` instead of taking down the request.
- The request body is **parsed inside the `try`**. It was read after the `Shepherd` was opened but before the `try`, so a malformed body threw past the `finally` that releases the PersistenceManager.
- The response is written **exactly once**. It was printed before the rollback and again afterwards onto an already-closed writer.
- `success` is a **real JSON boolean**. It was the string `"false"`, which `project.jsp`'s `if (d.success)` read as truthy — so the failure branch there never fired. `project.jsp` is the only consumer of `/ProjectIA`.
- A well-formed outcome stays HTTP 200 even when nothing matched: `project.jsp`'s ajax `error:` handler only logs and never hides `#match-start-adding-div_`, so a non-2xx would leave the page's "starting" spinner up forever.

## Tests

`ProjectIATransactionTest` — 5 tests. Three of them fail on `main`:

- the commit lands, and lands *after* `intakeAnnotations()` (fails as `expected: <[intakeAnnotations, commit]> but was: <[intakeAnnotations]>`)
- a failed commit is not reported as a started match
- a failing annotation does not discard a sibling's already-committed match

Full `mvn clean install`: **923 tests, 0 failures.**

## Deploying

Tasks already stuck on a deployed install do **not** self-heal — they have no `MatchResult` and a null status, so they cannot even age out to `error`. Those matches need re-running after the WAR.

## Known residual, not fixed here

If `IA.intakeAnnotations()` throws *after* its internal `storeNewTask()` commits, the task it created is durable with a null status and still spins. ProjectIA cannot mark it terminal because `intakeAnnotations()` does not hand back the task it built. The remedy belongs in `IA.intakeAnnotations()` or in `Task.getStatus()`'s `status != null` timeout guard — both fleet-wide in blast radius, so they are left for a separate PR.

Separately, three non-causal defects in this servlet are left alone to keep the diff to the transaction fix: the `parentTask` that is persisted but never linked as the parent of the task `intakeAnnotations()` builds, the dead `targetAnns` computation (it loads every annotation in the project on each Start Match), and `goToIAResults`'s unused `projectIdPrefix` local in `project.jsp`.

## Credit

Codex (`gpt-6-astra`) reviewed both the diagnosis and the fix. It confirmed the transaction reasoning against `NontransactionalWrite`/flush semantics, established that `Task.getStatus()`'s null guard makes the stuck state permanent rather than merely slow, caught that `commitDBTransaction()` swallows failures, found the malformed-body PersistenceManager leak, and pinned down the multi-annotation partial-failure path. My first cut committed once at the end of the loop and returned 500 on commit failure; both came out of that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
