### PR TITLE
test(frontend): repair the 14 jest suites that have been failing on main

### DIFF
--- a/frontend/src/__tests__/components/UnauthenticatedSwitch.test.js
+++ b/frontend/src/__tests__/components/UnauthenticatedSwitch.test.js
@@ -23,12 +23,6 @@ jest.mock("../../pages/Login", () => {
   return LoginMock;
 });
 
-jest.mock("../../pages/Citation", () => {
-  const CitationMock = () => <div>Citation Page</div>;
-  CitationMock.displayName = "Citation";
-  return CitationMock;
-});
-
 jest.mock("../../pages/errorPages/Unauthorized", () => {
   const UnauthorizedMock = ({ setHeader }) => {
     setHeader(false);
@@ -67,12 +61,6 @@ describe("UnAuthenticatedSwitch", () => {
   test("renders the login page by default", async () => {
     renderComponent({ showAlert: false, setShowAlert: jest.fn() });
     expect(await screen.getByText("Login Page")).toBeInTheDocument();
-  });
-
-  test("renders the citation page when navigating to /citation", async () => {
-    window.history.pushState({}, "", "/citation");
-    renderComponent({ showAlert: false, setShowAlert: jest.fn() });
-    expect(await screen.findByText("Citation Page")).toBeInTheDocument();
   });
 
   test("navigates to login with redirect query when visiting an unknown page", async () => {

--- a/frontend/src/__tests__/pages/Encounter/Encounter.test.js
+++ b/frontend/src/__tests__/pages/Encounter/Encounter.test.js
@@ -430,6 +430,16 @@ describe("Encounter page – polling behavior", () => {
 
   test("polling is scheduled when an asset has a non-terminal detectionStatus", async () => {
     setUrl("E-POLL-3");
+    // The polling effect arms off store.encounterData (see the awaitingAssetSignature dep
+    // added in 868e438afb). This suite stubs mobx's observer, so mutating the store double
+    // never re-renders and the effect would never see the fetched data -- preset the store
+    // so the awaiting asset is visible on the first render.
+    global.__MOCK_STORE_PRESET__ = {
+      encounterData: {
+        id: "E-POLL-3",
+        mediaAssets: [{ id: "m1", detectionStatus: "running" }],
+      },
+    };
     axios.get
       .mockResolvedValueOnce({
         data: { id: "E-POLL-3", mediaAssets: [{ detectionStatus: "running" }] },
@@ -505,6 +515,16 @@ describe("Encounter page – polling behavior", () => {
 
   test("polling stops once all assets reach a terminal status", async () => {
     setUrl("E-POLL-4");
+    // The polling effect arms off store.encounterData (see the awaitingAssetSignature dep
+    // added in 868e438afb). This suite stubs mobx's observer, so mutating the store double
+    // never re-renders and the effect would never see the fetched data -- preset the store
+    // so the awaiting asset is visible on the first render.
+    global.__MOCK_STORE_PRESET__ = {
+      encounterData: {
+        id: "E-POLL-4",
+        mediaAssets: [{ id: "m1", detectionStatus: "running" }],
+      },
+    };
     axios.get
       .mockResolvedValueOnce({
         data: { id: "E-POLL-4", mediaAssets: [{ detectionStatus: "running" }] },
@@ -533,6 +553,16 @@ describe("Encounter page – polling behavior", () => {
 
   test("initial fetch calls setEncounterData, poll tick calls setMediaAssets", async () => {
     setUrl("E-POLL-6");
+    // The polling effect arms off store.encounterData (see the awaitingAssetSignature dep
+    // added in 868e438afb). This suite stubs mobx's observer, so mutating the store double
+    // never re-renders and the effect would never see the fetched data -- preset the store
+    // so the awaiting asset is visible on the first render.
+    global.__MOCK_STORE_PRESET__ = {
+      encounterData: {
+        id: "E-POLL-6",
+        mediaAssets: [{ id: "m1", detectionStatus: "running" }],
+      },
+    };
     const secondMediaAssets = [{ detectionStatus: "complete" }];
     axios.get
       .mockResolvedValueOnce({

--- a/frontend/src/__tests__/pages/Encounter/EncounterStore.test.js
+++ b/frontend/src/__tests__/pages/Encounter/EncounterStore.test.js
@@ -190,7 +190,7 @@ describe("EncounterStore", () => {
       expect(axios.post).toHaveBeenCalledWith(
         "/api/v3/search/individual?size=20&from=0",
         expect.objectContaining({
-          sort: [{ names: { order: "desc", unmapped_type: "keyword" } }],
+          sort: [{ names: { order: "desc", mode: "min", unmapped_type: "keyword" } }],
         }),
       );
     });
@@ -745,9 +745,9 @@ describe("EncounterStore", () => {
           mediaAssets: [
             {
               annotations: [
-                { id: "ann-1", encounterId: "enc-123" },
-                { id: "ann-2", encounterId: "enc-456" },
-                { id: "ann-3", encounterId: "enc-123" },
+                { id: "ann-1", encounterId: "enc-123", boundingBox: [0, 0, 10, 10] },
+                { id: "ann-2", encounterId: "enc-456", boundingBox: [0, 0, 10, 10] },
+                { id: "ann-3", encounterId: "enc-123", boundingBox: [0, 0, 10, 10] },
               ],
             },
           ],
@@ -759,6 +759,25 @@ describe("EncounterStore", () => {
           "ann-1",
           "ann-3",
         ]);
+      });
+
+      it("excludes trivial and zero-area annotations", () => {
+        store.setEncounterData({
+          id: "enc-123",
+          mediaAssets: [
+            {
+              annotations: [
+                { id: "keep", encounterId: "enc-123", boundingBox: [0, 0, 10, 10] },
+                { id: "trivial", encounterId: "enc-123", isTrivial: true, boundingBox: [0, 0, 10, 10] },
+                { id: "no-bbox", encounterId: "enc-123" },
+                { id: "zero-area", encounterId: "enc-123", boundingBox: [0, 0, 0, 0] },
+              ],
+            },
+          ],
+        });
+        store.setSelectedImageIndex(0);
+
+        expect(store.encounterAnnotations.map((a) => a.id)).toEqual(["keep"]);
       });
 
       it("hasMatchableAnnotations is true for a matchAgainst+acmId unity annotation (isTrivial, full-image bbox)", () => {
@@ -829,6 +848,7 @@ describe("EncounterStore", () => {
                 {
                   id: "ann-1",
                   encounterId: "enc-123",
+                  boundingBox: [0, 0, 10, 10],
                   iaTaskId: "task-123",
                   iaTaskParameters: { skipIdent: false },
                   identificationStatus: "complete",

--- a/frontend/src/__tests__/pages/Encounter/IdentifySectionReview.test.js
+++ b/frontend/src/__tests__/pages/Encounter/IdentifySectionReview.test.js
@@ -7,6 +7,9 @@ jest.mock("mobx-react-lite", () => ({
 
 jest.mock("react-intl", () => ({
   FormattedMessage: ({ id }) => <span>{id}</span>,
+  useIntl: () => ({
+    formatMessage: ({ defaultMessage, id }) => defaultMessage ?? id,
+  }),
 }));
 
 jest.mock("../../../components/AttributesAndValueComponent", () => {
@@ -33,6 +36,7 @@ describe("IdentifySectionReview", () => {
     const store = makeStore({
       identify: {
         individualDisplayName: "Flipper",
+        individualId: "indiv-7",
         identificationRemarks: "auto",
         otherCatalogNumbers: "ALT-123",
         occurrenceId: "occ-999",
@@ -41,12 +45,15 @@ describe("IdentifySectionReview", () => {
 
     render(<IdentifySectionReview store={store} />);
 
-    expect(screen.getByTestId("attr-IDENTIFIED_AS")).toBeInTheDocument();
+    expect(screen.getByText("IDENTIFIED_AS")).toBeInTheDocument();
     expect(screen.getByTestId("attr-MATCHED_BY")).toBeInTheDocument();
     expect(screen.getByTestId("attr-ALTERNATE_ID")).toBeInTheDocument();
 
-    expect(screen.getByTestId("val-IDENTIFIED_AS")).toHaveTextContent(
-      "Flipper",
+    // the identified-as value is rendered as a link to the individual
+    const individualLink = screen.getByRole("link", { name: "Flipper" });
+    expect(individualLink).toHaveAttribute(
+      "href",
+      "/individuals.jsp?id=indiv-7",
     );
     expect(screen.getByTestId("val-MATCHED_BY")).toHaveTextContent("auto");
     expect(screen.getByTestId("val-ALTERNATE_ID")).toHaveTextContent("ALT-123");
@@ -79,7 +86,9 @@ describe("IdentifySectionReview", () => {
 
     render(<IdentifySectionReview store={store} />);
 
-    expect(screen.getByTestId("val-IDENTIFIED_AS")).toHaveTextContent("");
+    // with no individual on the store the heading still renders but the link does not
+    expect(screen.getByText("IDENTIFIED_AS")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Flipper" })).toBeNull();
     expect(screen.getByTestId("val-MATCHED_BY")).toHaveTextContent("");
     expect(screen.getByTestId("val-ALTERNATE_ID")).toHaveTextContent("");
   });

--- a/frontend/src/__tests__/pages/Encounter/ImageCard.test.js
+++ b/frontend/src/__tests__/pages/Encounter/ImageCard.test.js
@@ -72,6 +72,17 @@ const ThemeWrapper = ({ children }) => (
   </ThemeColorContext.Provider>
 );
 
+// jsdom never fires an <img> load event, and reports a zero layout, so ImageCard's load
+// handler returns before it can set imageReady -- which gates both click-to-open and the
+// annotation rects. Give the element a size, then fire the load.
+const simulateImageLoad = () => {
+  const img = screen.getByAltText("encounter image");
+  Object.defineProperty(img, "clientWidth", { value: 500, configurable: true });
+  Object.defineProperty(img, "clientHeight", { value: 250, configurable: true });
+  fireEvent.load(img);
+  return img;
+};
+
 const baseEncounterData = {
   id: "E-1",
   mediaAssets: [
@@ -181,6 +192,8 @@ describe("ImageCard", () => {
     const user = userEvent.setup();
     const store = makeStore();
     renderCard(store);
+
+    simulateImageLoad();
 
     const imageBox = screen.getByAltText("encounter image").parentElement;
     await user.click(imageBox);
@@ -367,6 +380,8 @@ describe("ImageCard", () => {
 
     renderCard(store);
 
+    simulateImageLoad();
+
     const rectDiv = document.querySelector('[id^="rect-"]');
     expect(rectDiv).toBeTruthy();
 
@@ -430,44 +445,59 @@ describe("ImageCard", () => {
 
     test("no images: banner is not shown", () => {
       renderWithAssets([]);
-      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      expect(screen.queryByText("DETECTION_IN_PROGRESS")).not.toBeInTheDocument();
     });
 
-    test("image with null detectionStatus: banner is shown (needs polling)", () => {
+    // A null/undefined detectionStatus is TERMINAL on its own (isTerminalDetectionStatus
+    // treats a missing status as done). It only means "still detecting" for a bulk-import
+    // asset, which the API reports as null status plus a trivial placeholder annotation.
+    test("image with null detectionStatus: banner is not shown", () => {
       renderWithAssets([makeAsset(null)]);
-      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.queryByText("DETECTION_IN_PROGRESS")).not.toBeInTheDocument();
     });
 
-    test("image with undefined detectionStatus: banner is shown (needs polling)", () => {
+    test("image with undefined detectionStatus: banner is not shown", () => {
       renderWithAssets([makeAsset(undefined)]);
-      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(
+        screen.queryByText("DETECTION_IN_PROGRESS"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("bulk-import asset awaiting detection: banner is shown", () => {
+      renderWithAssets(
+        [{ ...makeAsset(null), annotations: [{ id: "a1", isTrivial: true }] }],
+        { encounterData: { id: "E-1", importTaskId: "imp-1", mediaAssets: [
+          { ...makeAsset(null), annotations: [{ id: "a1", isTrivial: true }] },
+        ] } },
+      );
+      expect(screen.getByText("DETECTION_IN_PROGRESS")).toBeInTheDocument();
     });
 
     test("non-terminal detectionStatus 'running': banner is shown", () => {
       renderWithAssets([makeAsset("running")]);
-      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByText("DETECTION_IN_PROGRESS")).toBeInTheDocument();
     });
 
     test("detectionStatus 'complete': banner is not shown", () => {
       renderWithAssets([makeAsset("complete")]);
-      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      expect(screen.queryByText("DETECTION_IN_PROGRESS")).not.toBeInTheDocument();
     });
 
     test("detectionStatus 'error': banner is not shown", () => {
       renderWithAssets([makeAsset("error")]);
-      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      expect(screen.queryByText("DETECTION_IN_PROGRESS")).not.toBeInTheDocument();
     });
 
     test("detectionStatus 'pending': banner is not shown", () => {
       renderWithAssets([makeAsset("pending")]);
-      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      expect(screen.queryByText("DETECTION_IN_PROGRESS")).not.toBeInTheDocument();
     });
 
     test("banner reflects selectedImageIndex: index 0 complete hides banner even when index 1 is running", () => {
       renderWithAssets([makeAsset("complete"), makeAsset("running")], {
         selectedImageIndex: 0,
       });
-      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      expect(screen.queryByText("DETECTION_IN_PROGRESS")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/__tests__/pages/Encounter/ImageModal.test.js
+++ b/frontend/src/__tests__/pages/Encounter/ImageModal.test.js
@@ -208,6 +208,13 @@ describe("ImageModal", () => {
     const store = makeImageStore();
     renderModal({ imageStore: store });
 
+    // jsdom never fires an <img> load event and reports a zero layout, so ImageModal's load
+    // handler returns before setting imageReady -- which gates the annotation rects.
+    const img = document.getElementById("image-modal-main-image");
+    Object.defineProperty(img, "clientWidth", { value: 500, configurable: true });
+    Object.defineProperty(img, "clientHeight", { value: 250, configurable: true });
+    fireEvent.load(img);
+
     const rect = document.getElementById("annotation-rect-0");
     expect(rect).toBeTruthy();
 

--- a/frontend/src/__tests__/pages/Encounter/MoreDetails.test.js
+++ b/frontend/src/__tests__/pages/Encounter/MoreDetails.test.js
@@ -8,6 +8,9 @@ jest.mock("mobx-react-lite", () => ({
 
 jest.mock("react-intl", () => ({
   FormattedMessage: ({ id }) => <span>{id}</span>,
+  useIntl: () => ({
+    formatMessage: ({ defaultMessage, id }) => defaultMessage ?? id,
+  }),
 }));
 
 jest.mock("../../../pages/Encounter/TrackingReview", () => ({
@@ -91,6 +94,7 @@ const makeStore = (overrides = {}) => ({
   setMeasurementsAndTrackingSection: jest.fn(),
   setBiologicalSamplesSection: jest.fn(),
   setProjectsSection: jest.fn(),
+  setSpotMappingSection: jest.fn(),
 
   measurementValues: [1],
   errors: {

--- a/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/GalleryView.test.js
+++ b/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/GalleryView.test.js
@@ -68,6 +68,21 @@ function makeStore(overrides = {}) {
     pageSize: 2,
     previousPageItems: {},
 
+    start: 0,
+    assetOffset: 0,
+    galleryExhausted: false,
+    setStart: jest.fn(function (n) {
+      this.start = n;
+    }),
+    setAssetOffset: jest.fn(function (n) {
+      this.assetOffset = n;
+    }),
+    setGalleryExhausted: jest.fn(function (v) {
+      this.galleryExhausted = v;
+    }),
+    setGalleryLoading: jest.fn(),
+    setLoadingAll: jest.fn(),
+
     currentPageItems: [],
     setCurrentPageItems: jest.fn(function (items) {
       this.currentPageItems = items;
@@ -77,8 +92,19 @@ function makeStore(overrides = {}) {
       this.currentPage = n;
     }),
 
-    setPreviousPageItems: jest.fn(function (page, items) {
-      this.previousPageItems[page] = items;
+    setPreviousPageItems: jest.fn(function (
+      page,
+      items,
+      start,
+      assetOffset,
+      galleryExhausted,
+    ) {
+      this.previousPageItems[page] = {
+        items,
+        start,
+        assetOffset,
+        galleryExhausted,
+      };
     }),
 
     resetGallery: jest.fn(),
@@ -208,7 +234,7 @@ describe("GalleryView", () => {
         { __k: "a2", url: "#", annotations: [] },
       ],
     });
-    const pg = jest.fn();
+    const pg = jest.fn().mockResolvedValue(true);
 
     renderWithProviders(<GalleryView store={store} pg={pg} />);
     pg.mockClear();
@@ -220,11 +246,35 @@ describe("GalleryView", () => {
     expect(store.setPreviousPageItems).toHaveBeenCalledWith(
       0,
       store.currentPageItems.slice(),
+      store.start,
+      store.assetOffset,
+      store.galleryExhausted,
     );
 
     expect(pg).toHaveBeenCalledTimes(1);
 
     expect(store.setCurrentPage).toHaveBeenCalledWith(1);
+  });
+
+  test("clicking next does not advance the page when pg reports no more results", async () => {
+    const store = makeStore({
+      currentPage: 0,
+      pageSize: 2,
+      currentPageItems: [
+        { __k: "a1", url: "#", annotations: [] },
+        { __k: "a2", url: "#", annotations: [] },
+      ],
+    });
+    const pg = jest.fn().mockResolvedValue(false);
+
+    renderWithProviders(<GalleryView store={store} pg={pg} />);
+    pg.mockClear();
+    await act(async () => {
+      fireEvent.click(screen.getAllByTestId("main-btn")[1]);
+    });
+
+    expect(pg).toHaveBeenCalledTimes(1);
+    expect(store.setCurrentPage).not.toHaveBeenCalled();
   });
 
   test("clicking previous uses cached items when available", () => {
@@ -236,10 +286,15 @@ describe("GalleryView", () => {
         { __k: "b2", url: "#", annotations: [] },
       ],
       previousPageItems: {
-        0: [
-          { __k: "a1", url: "#", annotations: [] },
-          { __k: "a2", url: "#", annotations: [] },
-        ],
+        0: {
+          items: [
+            { __k: "a1", url: "#", annotations: [] },
+            { __k: "a2", url: "#", annotations: [] },
+          ],
+          start: 0,
+          assetOffset: 0,
+          galleryExhausted: false,
+        },
       },
     });
 
@@ -249,7 +304,7 @@ describe("GalleryView", () => {
     fireEvent.click(prev);
 
     expect(store.setCurrentPageItems).toHaveBeenCalledWith(
-      store.previousPageItems[0].slice(),
+      store.previousPageItems[0].items.slice(),
     );
     expect(store.setCurrentPage).toHaveBeenCalledWith(0);
   });

--- a/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/ImageGalleryModal.test.js
+++ b/frontend/src/__tests__/pages/EncounterSearchPageAndFilters/ImageGalleryModal.test.js
@@ -6,6 +6,9 @@ jest.mock("react-intl", () => ({
   FormattedMessage: ({ defaultMessage, id }) => (
     <span>{defaultMessage ?? id}</span>
   ),
+  useIntl: () => ({
+    formatMessage: ({ defaultMessage, id }) => defaultMessage ?? id,
+  }),
 }));
 jest.mock("mobx-react-lite", () => ({ observer: (c) => c }));
 

--- a/frontend/src/__tests__/pages/PoliciesAndData.test.js
+++ b/frontend/src/__tests__/pages/PoliciesAndData.test.js
@@ -4,13 +4,13 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { IntlProvider } from "react-intl";
-import PoliciesAndData from "../../../pages/PoliciesAndData/PoliciesAndData";
-import LocaleContext from "../../../IntlProvider";
-import ThemeColorContext from "../../../ThemeColorProvider";
-import AuthContext from "../../../AuthProvider";
-import messages from "../../../locale/en.json";
+import PoliciesAndData from "../../pages/PoliciesAndData/PoliciesAndData";
+import LocaleContext from "../../IntlProvider";
+import ThemeColorContext from "../../ThemeColorProvider";
+import AuthContext from "../../AuthProvider";
+import messages from "../../locale/en.json";
 
-jest.mock("../../../pages/Citation", () => {
+jest.mock("../../pages/Citation", () => {
   const React = require("react");
   const MockCitingWildbook = () =>
     React.createElement(
@@ -76,9 +76,10 @@ describe("PoliciesAndData Component", () => {
       expect(screen.getByText("MENU_LEARN_CITINGWILDBOOK")).toBeInTheDocument();
     });
 
-    test("renders default section (Citing Wildbook) when no section param provided", () => {
+    test("renders default section (Privacy Policy) when no section param provided", () => {
       renderComponent();
-      expect(screen.getByTestId("citing-wildbook")).toBeInTheDocument();
+      expect(screen.queryByTestId("citing-wildbook")).not.toBeInTheDocument();
+      expect(fetch).toHaveBeenCalled();
     });
 
     test("renders chevron icons for all sections", () => {
@@ -129,11 +130,12 @@ describe("PoliciesAndData Component", () => {
       });
     });
 
-    test("defaults to Citing Wildbook for invalid section param", () => {
+    test("defaults to Privacy Policy for invalid section param", () => {
       renderComponent({
         initialPath: "/policies?section=invalid",
       });
-      expect(screen.getByTestId("citing-wildbook")).toBeInTheDocument();
+      expect(screen.queryByTestId("citing-wildbook")).not.toBeInTheDocument();
+      expect(fetch).toHaveBeenCalled();
     });
   });
 
@@ -220,7 +222,7 @@ describe("PoliciesAndData Component", () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText(/PDF not found for/)).toBeInTheDocument();
+        expect(screen.getByText(/PDF not available for locale/)).toBeInTheDocument();
       });
     });
 
@@ -291,8 +293,10 @@ describe("PoliciesAndData Component", () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText(/PDF not found for/)).toBeInTheDocument();
-        expect(screen.getByText("fr")).toBeInTheDocument();
+        // the locale is interpolated into the sentence, not its own text node
+        expect(
+          screen.getByText(/PDF not available for locale fr/),
+        ).toBeInTheDocument();
       });
     });
 
@@ -404,7 +408,7 @@ describe("PoliciesAndData Component", () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText(/PDF not found for/)).toBeInTheDocument();
+        expect(screen.getByText(/PDF not available for locale/)).toBeInTheDocument();
       });
     });
 
@@ -417,7 +421,9 @@ describe("PoliciesAndData Component", () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText("de")).toBeInTheDocument();
+        expect(
+          screen.getByText(/PDF not available for locale de/),
+        ).toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/__tests__/pages/ReportAnEncounterPage/ReportAnEncounter.test.js
+++ b/frontend/src/__tests__/pages/ReportAnEncounterPage/ReportAnEncounter.test.js
@@ -107,6 +107,9 @@ describe("ReportEncounter Component", () => {
 
     renderComponent();
 
+    // anonymous submitters must accept the terms before Submit is enabled
+    fireEvent.click(screen.getByRole("checkbox"));
+
     const submitButton = screen.getByRole("button", {
       name: /SUBMIT_ENCOUNTER/i,
     });
@@ -134,6 +137,9 @@ describe("ReportEncounter Component", () => {
 
     renderComponent();
 
+    // anonymous submitters must accept the terms before Submit is enabled
+    fireEvent.click(screen.getByRole("checkbox"));
+
     const submitButton = screen.getByRole("button", {
       name: /SUBMIT_ENCOUNTER/i,
     });
@@ -159,6 +165,9 @@ describe("ReportEncounter Component", () => {
     }));
 
     renderComponent();
+
+    // anonymous submitters must accept the terms before Submit is enabled
+    fireEvent.click(screen.getByRole("checkbox"));
 
     const submitButton = screen.getByRole("button", {
       name: /SUBMIT_ENCOUNTER/i,

--- a/frontend/src/__tests__/pages/login/LoginPageAuthenticate.test.js
+++ b/frontend/src/__tests__/pages/login/LoginPageAuthenticate.test.js
@@ -34,6 +34,9 @@ test("calls authenticate function on submit", () => {
     target: { value: "password123" },
   });
 
+  // Sign In stays disabled until the terms checkbox is ticked
+  fireEvent.click(screen.getByRole("checkbox"));
+
   fireEvent.click(screen.getByRole("button", { name: /Sign In/i }));
 
   expect(mockAuthenticate).toHaveBeenCalledWith("testuser", "password123");

--- a/frontend/src/__tests__/pages/login/LoginPageError.test.js
+++ b/frontend/src/__tests__/pages/login/LoginPageError.test.js
@@ -31,15 +31,18 @@ describe("LoginPage Tests", () => {
   let mockAuthenticate;
   let mockSetError;
 
-  test("should show error message when submitting empty username and password", async () => {
+  test("cannot submit an empty username and password", async () => {
     renderWithProviders(<LoginPage />);
+
+    // the page used to call authenticate("", "") here; it now refuses the submit outright
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeDisabled();
 
     await act(async () => {
       screen.getByRole("button", { name: /sign in/i }).click();
     });
 
-    expect(mockSetError).toHaveBeenCalledWith(null);
-    expect(mockAuthenticate).toHaveBeenCalledWith("", "");
+    expect(mockAuthenticate).not.toHaveBeenCalled();
   });
 
   test("should show error when entering incorrect credentials", async () => {
@@ -54,6 +57,8 @@ describe("LoginPage Tests", () => {
     });
 
     await act(async () => {
+      // Sign In stays disabled until the terms checkbox is ticked
+      fireEvent.click(screen.getByRole("checkbox"));
       screen.getByRole("button", { name: /sign in/i }).click();
     });
 

--- a/frontend/src/__tests__/pages/login/LoginPageSubmit.test.js
+++ b/frontend/src/__tests__/pages/login/LoginPageSubmit.test.js
@@ -7,7 +7,7 @@ import {
   fireInput,
   clickButton,
 } from "../../../utils/utils";
-import { waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { useSiteSettings } from "../../../SiteSettingsContext";
 
 jest.mock("../../../models/auth/useLogin");
@@ -37,6 +37,8 @@ describe("LoginPage - Form Submission", () => {
     renderWithProviders(<LoginPage />);
     fireInput("Username", "testuser");
     fireInput("Password", "password123");
+    // Sign In stays disabled until the terms checkbox is ticked
+    fireEvent.click(screen.getByRole("checkbox"));
     clickButton("Sign In");
 
     await waitFor(() =>

--- a/frontend/src/__tests__/setupTests.js
+++ b/frontend/src/__tests__/setupTests.js
@@ -12,7 +12,16 @@ jest.mock("react-intl", () => {
     useIntl: () => {
       const messages = require("../locale/en.json");
       return {
-        formatMessage: ({ id }) => messages[id] || id,
+        // Substitute simple {placeholder} arguments. Dropping `values` made any message
+        // with an argument render its raw ICU pattern, so tests could not assert the copy
+        // a user actually sees (e.g. "PDF not available for locale de.").
+        formatMessage: ({ id, defaultMessage }, values) => {
+          const message = messages[id] ?? defaultMessage ?? id;
+          if (!values) return message;
+          return String(message).replace(/\{(\w+)\}/g, (match, key) =>
+            key in values ? String(values[key]) : match,
+          );
+        },
       };
     },
     FormattedMessage: jest.fn().mockImplementation(({ id }) => id),


### PR DESCRIPTION
The frontend jest suite has been failing **14 suites / 34 cases** on `main`. CI runs jest with `continue-on-error`, so nothing ever surfaced it — only `mvn clean install` gates a PR — and the rot accumulated unnoticed.

**None of it was a product bug.** The tests had drifted behind the code they cover. This repairs them rather than deleting them. **No production source is touched** — 15 files, all test scaffolding.

| | Before (`main`) | After |
|---|---|---|
| Suites | 14 failing / 144 | **144 passing** |
| Cases | 34 failing, 1338 passing | **1406 passing** |

## Four recurring causes

- **A terms-agreement checkbox now gates submission.** `submitDisabled` includes `!agree`, so clicks in the three login suites and in `ReportAnEncounter` landed on a disabled button and the handler never ran. The tests now tick it.
- **Test doubles fell behind their real stores.** `MoreDetails` lacked `setSpotMappingSection` (every tab click threw); `GalleryView` still modelled the page cache as `page -> items[]` when it is now `page -> {items, start, assetOffset, galleryExhausted}` with a five-argument setter; `EncounterStore` predated both the `mode: "min"` names sort and the bounding-box filter on `encounterAnnotations`.
- **jsdom never fires an `<img>` load event and reports a zero layout**, so `ImageCard`'s and `ImageModal`'s load handlers returned before setting `imageReady` — which gates click-to-open and the annotation rects. Both now give the element a size and fire load.
- **Components were restructured.** `IDENTIFIED_AS` is a link rather than an attribute row; `PoliciesAndData`'s default section became Privacy Policy, with new not-available copy.

## Three findings worth more than the repairs

1. **`PoliciesAndData.test.js` had never executed, once.** Every import used `../../../` from a directory that needs `../../`, so the suite failed to load and its 32 tests silently counted for nothing. That is why the totals jump from 1372 to 1406.

2. **Two `ImageCard` tests were green for the wrong reason.** They located the detection banner via `role="status"`, which also matches a Bootstrap loading spinner. Queried precisely they fail — and the behaviour they asserted is wrong: a null `detectionStatus` is *terminal* unless the asset is a bulk import awaiting detection. Rewritten to the real contract, with the bulk-import case added.

3. **The global `react-intl` mock dropped `formatMessage`'s `values` argument**, so any message with a placeholder rendered its raw ICU pattern and no test could assert the copy a user actually sees. It now interpolates. I chased this as a possible product bug first — it is not; users see the correct text.

## One deletion

`UnauthenticatedSwitch › renders the citation page when navigating to /citation`. That public route was deliberately removed in `b83c75c488` ("add policies and data page, remove citing page"); an unauthenticated visit now falls through to Login, which the neighbouring unknown-page test already covers. Deleted with its now-unused mock.

## Four additions

Where the repair exposed a gap: the trivial/zero-area annotation exclusion, the bulk-import detection banner, and `GalleryView`'s advance-only-if-`pg()`-resolves-truthy contract in both directions.

## Known limitation, commented in place

The three `Encounter` polling tests only arm because the store is preset. The component re-arms polling through mobx reactivity (`awaitingAssetSignature`, `868e438afb`) and that suite stubs `observer` to identity, so the re-arm-on-mutation path cannot be exercised there without an observable store double.

## Worth considering separately

Now that the suite is green, dropping `continue-on-error` from the jest step would stop this recurring. I have not changed the workflow here — that is a policy call, and it should land only after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
